### PR TITLE
Added access token resource (#1)

### DIFF
--- a/docs/resources/artifactory_access_token.md
+++ b/docs/resources/artifactory_access_token.md
@@ -1,0 +1,36 @@
+# Artifactory Access Token Resource
+
+Provides an Artifactory access token resource. This can be used to create and revoke access tokens
+
+~> **Note:** Access and refresh tokens will be stored in the raw state as plain-text. [Read more about sensitive data in
+state](https://www.terraform.io/docs/state/sensitive-data.html).
+
+## Example Usage
+
+```hcl
+# Create a new Artifactory access token as the configured user
+resource "artifactory_access_token" "my_token" {
+  username = "my-token"
+  scope    = "api:*"
+}
+
+output "my_access_token" {
+  value = artifactory_access_token.my_token.access_token
+}
+
+output "my_refresh_token" {
+  value = artifactory_access_token.my_token.refresh_token
+}
+```
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `username` - (Required) The user name for which this token is created
+* `scope` - (Required) The scope to assign to the token provided as a space-separated list of scope tokens
+* `expires_in` - (Optional) The time in seconds for which the token will be valid
+* `refreshable` - (Optional) If true, this token is refreshable and the refresh token can be used to replace it with a new token once it expires
+* `audience` - (Optional) A space-separate list of the other Artifactory instances or services that should accept this token identified by their Artifactory [Service IDs](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-GetServiceID) as obtained from the Get Service ID endpoint
+
+See the Artifactory REST API [documentation](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateToken) for more details

--- a/pkg/artifactory/provider.go
+++ b/pkg/artifactory/provider.go
@@ -74,6 +74,7 @@ func Provider() terraform.ResourceProvider {
 			"artifactory_single_replication_config": resourceArtifactorySingleReplicationConfig(),
 			"artifactory_certificate":               resourceArtifactoryCertificate(),
 			"artifactory_api_key":                   resourceArtifactoryApiKey(),
+			"artifactory_access_token":              resourceArtifactoryAcessToken(),
 			// Deprecated. Remove in V3
 			"artifactory_permission_targets": resourceArtifactoryPermissionTargets(),
 		},

--- a/pkg/artifactory/resource_artifactory_access_token.go
+++ b/pkg/artifactory/resource_artifactory_access_token.go
@@ -1,0 +1,114 @@
+package artifactory
+
+import (
+	"context"
+	"net/http"
+	"strconv"
+
+	"github.com/atlassian/go-artifactory/v2/artifactory"
+	v1 "github.com/atlassian/go-artifactory/v2/artifactory/v1"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArtifactoryAcessToken() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAccessTokenCreate,
+		Read:   resourceAccessTokenRead,
+		Delete: resourceAccessTokenDelete,
+
+		Schema: map[string]*schema.Schema{
+			"username": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"scope": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"expires_in": {
+				Type:     schema.TypeInt,
+				Optional: true,
+				Default:  3600,
+				ForceNew: true,
+			},
+			"refreshable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+			"audience": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"access_token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+			"refresh_token": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
+		},
+	}
+}
+
+func unmarshalToken(s *schema.ResourceData) *v1.AccessTokenOptions {
+	d := &ResourceData{s}
+
+	accessTokenOption := new(v1.AccessTokenOptions)
+
+	accessTokenOption.Username = d.getStringRef("username", false)
+	accessTokenOption.Scope = d.getStringRef("scope", false)
+	accessTokenOption.ExpiresIn = d.getIntRef("expires_in", false)
+	refreshable := d.getBoolRef("refreshable", false)
+	accessTokenOption.Refreshable = artifactory.String(strconv.FormatBool(*refreshable))
+	accessTokenOption.Audience = d.getStringRef("audience", false)
+
+	return accessTokenOption
+}
+
+func resourceAccessTokenCreate(d *schema.ResourceData, m interface{}) error {
+	c := m.(*ArtClient).ArtOld
+
+	accessTokenOption := unmarshalToken(d)
+
+	token, _, err := c.V1.Security.CreateToken(context.Background(), accessTokenOption)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(*token.AccessToken)
+	d.Set("access_token", *token.AccessToken)
+	d.Set("refresh_token", *token.RefreshToken)
+
+	return nil
+}
+
+func resourceAccessTokenRead(d *schema.ResourceData, m interface{}) error {
+	return nil
+}
+
+func resourceAccessTokenDelete(d *schema.ResourceData, m interface{}) error {
+	c := m.(*ArtClient).ArtOld
+
+	_, resp, err := c.V1.Security.RevokeToken(context.Background(), v1.AccessTokenRevokeOptions{
+		Token: d.Id(),
+	})
+	if err != nil {
+		return err
+	}	
+
+	if resp.StatusCode == http.StatusNotFound {
+		return nil
+	}
+
+	if resp.StatusCode == http.StatusInternalServerError {
+		return nil
+	}
+
+	return err
+}

--- a/pkg/artifactory/resource_artifactory_access_token_test.go
+++ b/pkg/artifactory/resource_artifactory_access_token_test.go
@@ -1,0 +1,38 @@
+package artifactory
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+)
+
+const accessToken = `
+resource "artifactory_access_token" "test_access_token" {
+	username = "test"
+	scope    = "api:*"
+  }
+`
+
+func TestAccAccessToken(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAccessTokenDestroy("artifactory_access_token.test_access_token"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: accessToken,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("artifactory_access_token.test_access_token", "access_token"),
+					resource.TestCheckResourceAttrSet("artifactory_access_token.test_access_token", "refresh_token"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAccessTokenDestroy(id string) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		return nil
+	}
+}


### PR DESCRIPTION
Adds [Access Token](https://www.jfrog.com/confluence/display/JFROG/Access+Tokens) support to the provider.
Currently only the ability to create (and recreate in case of updates) and revoke (delete) a token is supported.

There is no datasource/read support currently because of current limitations of the [Artifactory REST API](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API). 
When [creating](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateToken) a new token, the response would look like this:

```json
{
   "access_token":   "<the access token>",
   "expires_in":    "<Validity period in seconds>",
   "scope":         "<access scope>",
   "token_type":    "Bearer",
   "refresh_token": "<the refresh token if access_token is refreshable>"
}
```

and the only available REST resource available to read tokens is to get a [list of tokens](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-GetTokens), which returns a response like this:

```jsonc
{
  "tokens" : [ {
    "issuer" : "jfrt@01ejth5fa032aa1x9197451qk3",
    "subject" : "jfrt@01ejth5fa032aa1x9197451qk3/users/xxx",
    "expiry" : 1605794711,
    "refreshable" : false,
    "token_id" : "d61a6655-9169-4236-84c6-6e836b0bac01",
    "issued_at" : 1603375511
  }, {
...
}
```

Unfortunately, there is no obvious way to correlate a token from the list of tokens returned from `GET /api/security/token` to the token that was just created with `POST /api/security/token`. I.e. There are no uniquely identifiable fields that match in either reponse.