### PR TITLE
Feat: access token

### DIFF
--- a/docs/resources/artifactory_access_token.md
+++ b/docs/resources/artifactory_access_token.md
@@ -8,6 +8,7 @@ state](https://www.terraform.io/docs/state/sensitive-data.html).
 
 ## Example Usages
 ### Create a new Artifactory Access Token for an existing user
+
 ```hcl
 resource "artifactory_access_token" "exising_user" {
   username          = "existing-user"
@@ -15,14 +16,34 @@ resource "artifactory_access_token" "exising_user" {
 }
 ```
 
-### Creates a new token for groups
+Note: This assumes that the user `existing-user` has already been created in Artifactory by different means, i.e. manually or in a separate terraform apply.
+
+### Create a new Artifactory User and Access token
 ```hcl
+resource "artifactory_user" "new_user" {
+  name   = "new_user"
+  email  = "new_user@somewhere.com"
+
+  groups = [
+    "readers",
+  ]
+}
+
 resource "artifactory_access_token" "new_user" {
-  username          = "new-user"
+  username          = artifactory_user.new_user.name
+  end_date_relative = "5m"
+}
+```
+
+### Creates a new token for groups
+This creates a transient user called `temporary-user`.
+```hcl
+resource "artifactory_access_token" "temporary_user" {
+  username          = "temporary-user"
   end_date_relative = "1h"
 
   groups = [
-      "readers",
+    "readers",
   ]
 }
 ```
@@ -44,7 +65,7 @@ resource "artifactory_access_token" "refreshable" {
   refreshable = true
 
   groups = [
-      "readers",
+    "readers",
   ]
 }
 ```
@@ -79,7 +100,7 @@ resource "artifactory_access_token" "fixeddate" {
   end_date = "2018-01-01T01:02:03Z"
 
   groups = [
-      "readers",
+    "readers",
   ]
 }
 ```
@@ -102,7 +123,7 @@ resource "artifactory_access_token" "rotating" {
   end_date = time_rotating.now_plus_1_hour.rotation_rfc3339
 
   groups = [
-      "readers",
+    "readers",
   ]
 }
 ```
@@ -128,7 +149,7 @@ resource "artifactory_access_token" "rotating" {
   end_date = time_rotating.now_plus_1_hour.rotation_rfc3339
 
   groups = [
-      "readers",
+    "readers",
   ]
 }
 ```

--- a/docs/resources/artifactory_access_token.md
+++ b/docs/resources/artifactory_access_token.md
@@ -1,0 +1,136 @@
+# Artifactory Access Token Resource
+
+Provides an Artifactory Access Token resource. This can be used to create and manage Artifactory Access Tokens.
+
+~> **Note:** Access Tokens will be stored in the raw state as plain-text. [Read more about sensitive data in
+state](https://www.terraform.io/docs/state/sensitive-data.html).
+
+
+## Example Usages
+### Create a new Artifactory Access Token for an existing user
+```hcl
+resource "artifactory_access_token" "exising_user" {
+  username          = "existing-user"
+  end_date_relative = "5m"
+}
+```
+
+### Creates a new token for groups
+```hcl
+resource "artifactory_access_token" "new_user" {
+  username          = "new-user"
+  end_date_relative = "1h"
+
+  groups = [
+      "readers",
+  ]
+}
+```
+
+### Create token with no expiry
+```hcl
+resource "artifactory_access_token" "no_expiry" {
+  username          = "existing-user"
+  end_date_relative = "0s"
+}
+```
+
+### Creates a refreshable token
+```hcl
+resource "artifactory_access_token" "refreshable" {
+  username          = "refreshable"
+  end_date_relative = "1m"
+
+  refreshable = true
+
+  groups = [
+      "readers",
+  ]
+}
+```
+
+### Creates an administrator token
+```hcl
+resource "artifactory_access_token" "admin" {
+  username          = "admin"
+  end_date_relative = "1m"
+
+  admin_token {
+    instance_id = "<instance id>"
+  }
+}
+```
+
+### Creates a token with an audience
+```hcl
+resource "artifactory_access_token" "audience" {
+  username          = "admin"
+  end_date_relative = "1m"
+
+  audience = "jfrt@*"
+  refreshable = true
+}
+```
+
+### Creates a token with an audience
+```hcl
+resource "artifactory_access_token" "audience" {
+  username          = "admin"
+  end_date_relative = "1m"
+
+  audience    = "jfrt@*"
+  refreshable = true
+}
+```
+
+### Creates a token with a fixed end date
+```hcl
+resource "artifactory_access_token" "audience" {
+  username = "admin"
+  end_date = "2018-01-01T01:02:03Z"
+
+  audience    = "jfrt@*"
+  refreshable = true
+}
+```
+
+## Attribute Reference
+
+The following attributes are exported:
+
+* `username` - (Required) The username or subject for the token. A non-admin can only specify their own username. Admins can specify any existing username, or a new name for a temporary token. Temporary tokens require `groups` to be set.
+
+* One of `end_date` or `end_date_relative` must be set.
+
+    * `end_date` - (Optional) The end date which the token is valid until, formatted as a RFC3339 date string (e.g. `2018-01-01T01:02:03Z`).
+
+    * `end_date_relative` - (Optional) A relative duration for which the token is valid until, for example `240h` (10 days) or `2400h30m`. Valid time units are "s", "m", "h".
+
+
+* `groups` - (Optional) List of groups. The token is granted access based on the permissions of the groups. Specify `["*"]` for all groups that the user belongs to. `groups` cannot be specified with `admin_token`.
+* `admin_token` - (Optional) Specify the `instance_id` in this block to grant this token admin privileges. This can only be created when the authenticated user is an admin. `admin_token` cannot be specified with `groups`.
+* `refreshable` - (Optional) Is this token refreshable? Defaults to `false`
+* `audience` - (Optional) A space-separate list of the other Artifactory instances or services that should accept this token identified by their Artifactory Service IDs. You may set `"jfrt@*"` so the token to be accepted by all Artifactory instances.
+
+  Refreshable must be `true` to set the `audience`. 
+    
+    For instructions to retrieve the Artifactory Service ID see this [documentation](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-GetServiceID).
+    
+
+**Note:** Changing **any** field forces a new resource to be created.
+
+
+
+### Additional Outputs
+
+* `access_token` - Returns the access token to authenciate to Artifactory
+* `refresh_token` - Returns the refresh token when `refreshable` is true, or an empty string when `refreshable` is false
+
+## References
+
+- https://www.jfrog.com/confluence/display/ACC1X/Access+Tokens
+- https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateToken
+
+## Import
+
+Artifactory **does not** retain access tokens and cannot be imported into state.

--- a/pkg/artifactory/provider.go
+++ b/pkg/artifactory/provider.go
@@ -74,6 +74,7 @@ func Provider() terraform.ResourceProvider {
 			"artifactory_single_replication_config": resourceArtifactorySingleReplicationConfig(),
 			"artifactory_certificate":               resourceArtifactoryCertificate(),
 			"artifactory_api_key":                   resourceArtifactoryApiKey(),
+			"artifactory_access_token":              resourceArtifactoryAccessToken(),
 			// Deprecated. Remove in V3
 			"artifactory_permission_targets": resourceArtifactoryPermissionTargets(),
 		},

--- a/pkg/artifactory/resource_artifactory_access_token.go
+++ b/pkg/artifactory/resource_artifactory_access_token.go
@@ -1,0 +1,325 @@
+package artifactory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/atlassian/go-artifactory/v2/artifactory"
+	artifactoryold "github.com/atlassian/go-artifactory/v2/artifactory"
+	v1 "github.com/atlassian/go-artifactory/v2/artifactory/v1"
+	"github.com/hashicorp/terraform/helper/hashcode"
+	"github.com/hashicorp/terraform/helper/schema"
+)
+
+func resourceArtifactoryAccessToken() *schema.Resource {
+	return &schema.Resource{
+		Create: resourceAccessTokenCreate,
+		Read:   resourceAccessTokenRead,
+		Delete: resourceAccessTokenDelete,
+
+		Importer: &schema.ResourceImporter{
+			State: schema.ImportStatePassthrough,
+		},
+
+		Schema: map[string]*schema.Schema{
+			"username": {
+				Type:     schema.TypeString,
+				Required: true,
+				ForceNew: true,
+			},
+			"audience": {
+				Type:     schema.TypeString,
+				Optional: true,
+				ForceNew: true,
+			},
+			"groups": {
+				Type:     schema.TypeList,
+				Optional: true,
+				ForceNew: true,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
+			"end_date_relative": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"end_date"},
+				ValidateFunc: func(i interface{}, k string) ([]string, []error) {
+					v, ok := i.(string)
+					if !ok {
+						return nil, []error{fmt.Errorf("expected type of %q to be string", k)}
+					}
+
+					if strings.TrimSpace(v) == "" {
+						return nil, []error{fmt.Errorf("%q must not be empty", k)}
+					}
+
+					return nil, nil
+				},
+			},
+			"end_date": {
+				Type:          schema.TypeString,
+				Optional:      true,
+				Computed:      true,
+				ForceNew:      true,
+				ConflictsWith: []string{"end_date_relative"},
+				ValidateFunc: func(i interface{}, k string) (warnings []string, errors []error) {
+					v, ok := i.(string)
+					if !ok {
+						errors = append(errors, fmt.Errorf("expected type of %q to be string", k))
+						return warnings, errors
+					}
+
+					if _, err := time.Parse(time.RFC3339, v); err != nil {
+						errors = append(errors, fmt.Errorf("expected %q to be a valid RFC3339 date, got %q: %+v", k, i, err))
+					}
+
+					return warnings, errors
+				},
+			},
+			"refreshable": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				ForceNew: true,
+			},
+			"admin_token": {
+				Type:          schema.TypeSet,
+				ConflictsWith: []string{"groups"},
+				Optional:      true,
+				MaxItems:      1,
+				MinItems:      1,
+				ForceNew:      true,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"instance_id": {
+							Type:     schema.TypeString,
+							Required: true,
+							ForceNew: true,
+						},
+					},
+				},
+			},
+			"access_token": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+			"refresh_token": {
+				Type:      schema.TypeString,
+				Computed:  true,
+				Sensitive: true,
+			},
+		},
+	}
+}
+
+func resourceAccessTokenCreate(d *schema.ResourceData, m interface{}) error {
+	client := m.(*ArtClient).ArtOld
+	grantType := "client_credentials" // client_credentials is the only supported type
+
+	tokenOptions := v1.AccessTokenOptions{}
+	resourceData := &ResourceData{d}
+
+	date, expiresIn, err := getDate(d)
+	if err != nil {
+		return err
+	}
+
+	tokenOptions.ExpiresIn = expiresIn
+	d.Set("end_date", date.Format(time.RFC3339))
+
+	refreshable := resourceData.Get("refreshable").(bool)
+	audience := d.Get("audience").(string)
+
+	tokenOptions.Audience = artifactory.String(audience)
+	tokenOptions.GrantType = &grantType
+	tokenOptions.Refreshable = artifactory.String(strconv.FormatBool(refreshable))
+	tokenOptions.Username = resourceData.getStringRef("username", false)
+
+	username := resourceData.Get("username").(string)
+	userExists, err := checkUserExists(client, username)
+
+	if !userExists && len(resourceData.Get("groups").([]interface{})) == 0 {
+		return fmt.Errorf("you must specify at least 1 group when creating a token for a non-existant user - %s, or correct the username", username)
+	}
+
+	err = unpackGroups(d, client, &tokenOptions)
+	if err != nil {
+		return err
+	}
+
+	err = unpackAdminToken(d, client, &tokenOptions)
+	if err != nil {
+		return err
+	}
+
+	AccessToken, _, err := client.V1.Security.CreateToken(context.Background(), &tokenOptions)
+	if err != nil {
+		return err
+	}
+
+	d.SetId(strconv.Itoa(hashcode.String(*AccessToken.AccessToken)))
+	d.Set("access_token", *AccessToken.AccessToken)
+	if refreshable {
+		d.Set("refresh_token", *AccessToken.RefreshToken)
+	} else {
+		d.Set("refresh_token", "")
+	}
+
+	return nil
+}
+
+func resourceAccessTokenRead(d *schema.ResourceData, m interface{}) error {
+	return nil
+}
+
+func resourceAccessTokenDelete(d *schema.ResourceData, m interface{}) error {
+	c := m.(*ArtClient).ArtOld
+
+	// convert end date relative to duration in seconds
+	endDateRelative := d.Get("end_date_relative").(string)
+	if endDateRelative == "" {
+		log.Printf("[DEBUG] Token is not revoked. It will expire at " + d.Get("end_date").(string))
+		return nil
+	}
+
+	duration, err := time.ParseDuration(endDateRelative)
+	if err != nil {
+		return fmt.Errorf("unable to parse `end_date_relative` (%s) as a duration", endDateRelative)
+	}
+
+	// Artifactory only allows you to revoke a token if the there is no expiry.
+	// Otherwise, Artifactory will ensure the token is revoked at the expiry time.
+	// https://www.jfrog.com/confluence/display/JFROG/Access+Tokens#AccessTokens-ViewingandRevokingTokens
+	// https://www.jfrog.com/jira/browse/RTFACT-15293
+
+	if duration.Seconds() == 0 {
+		log.Printf("[DEBUG] Revoking token")
+		revokeOptions := v1.AccessTokenRevokeOptions{}
+		revokeOptions.Token = d.Get("access_token").(string)
+
+		_, resp, err := c.V1.Security.RevokeToken(context.Background(), revokeOptions)
+
+		if resp.StatusCode == http.StatusNotFound {
+			log.Printf("[DEBUG] Token Revoked")
+			return nil
+		}
+		return err
+	}
+
+	log.Printf("[DEBUG] Token is not revoked. It will expire at " + d.Get("end_date").(string))
+
+	return nil
+}
+
+func unpackGroups(d *schema.ResourceData, client *artifactoryold.Artifactory, tokenOptions *v1.AccessTokenOptions) error {
+	if srcGroups, ok := d.GetOk("groups"); ok {
+		groups := make([]string, len(srcGroups.([]interface{})))
+		for i, group := range srcGroups.([]interface{}) {
+			groups[i] = group.(string)
+
+			if exist, err := checkGroupExists(client, groups[i]); !exist {
+				return err
+			}
+		}
+
+		scopedGroupString := strings.Join(groups[:], ",")
+		scope := "member-of-groups:\"" + scopedGroupString + "\""
+		tokenOptions.Scope = &scope
+	}
+
+	return nil
+}
+
+func unpackAdminToken(d *schema.ResourceData, client *artifactoryold.Artifactory, tokenOptions *v1.AccessTokenOptions) error {
+	if adminToken, ok := d.GetOk("admin_token"); ok {
+		set := adminToken.(*schema.Set)
+		val := set.List()[0].(map[string]interface{})
+
+		instanceID := val["instance_id"].(string)
+
+		scope := "jfrt@" + instanceID + ":admin"
+		tokenOptions.Scope = &scope
+	}
+
+	return nil
+}
+
+func checkUserExists(client *artifactoryold.Artifactory, name string) (bool, error) {
+	_, resp, err := client.V1.Security.GetUser(context.Background(), name)
+
+	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return false, errors.New("User must exist in artifactory")
+		}
+		// If we cannot search for Users, the current user is not an admin
+		// So, we'll let this through and let the CreateToken function error if there is a misconfiguration.
+		if resp.StatusCode == http.StatusForbidden {
+			return true, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+func checkGroupExists(client *artifactoryold.Artifactory, name string) (bool, error) {
+	_, resp, err := client.V1.Security.GetGroup(context.Background(), name)
+
+	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return false, errors.New("Group must exist in artifactory")
+		}
+		// If we cannot search for groups, the current user is not an admin
+		// So, we'll let this through and let the CreateToken function error if there is a misconfiguration.
+		if resp.StatusCode == http.StatusForbidden {
+			return true, nil
+		}
+		return false, err
+	}
+
+	return true, nil
+}
+
+// inspired by azure ad implementation
+func getDate(d *schema.ResourceData) (*time.Time, *int, error) {
+	var endDate time.Time
+	now := time.Now()
+
+	if v := d.Get("end_date").(string); v != "" {
+		var err error
+		endDate, err = time.Parse(time.RFC3339, v)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to parse the provided end date %q: %+v", v, err)
+		}
+	} else if v := d.Get("end_date_relative").(string); v != "" {
+		d, err := time.ParseDuration(v)
+		if err != nil {
+			return nil, nil, fmt.Errorf("unable to parse `end_date_relative` %s as a duration", v)
+		}
+		// Artifactory's minimum duration is in seconds.
+		// The consumer should either specify 0 for a non-expiring token, or >= 1 seconds
+		// If the consumer passes in configuration that is between 0 and 1 seconds, they have used a smaller time unit that seconds.
+		if d.Nanoseconds() > 0 && d.Seconds() < 1 {
+			return nil, nil, fmt.Errorf("minimum duration is 1 second, but `end_date_relative` is %s", v)
+		}
+		endDate = time.Now().Add(d)
+	} else {
+		return nil, nil, fmt.Errorf("one of `end_date` or `end_date_relative` must be specified")
+	}
+
+	differenceInSeconds := int(endDate.Sub(now).Seconds())
+
+	if differenceInSeconds < 0 {
+		return nil, nil, fmt.Errorf("end date must be in the future, but is %s", endDate.String())
+	}
+	return &endDate, &differenceInSeconds, nil
+}

--- a/pkg/artifactory/resource_artifactory_access_token_test.go
+++ b/pkg/artifactory/resource_artifactory_access_token_test.go
@@ -16,9 +16,6 @@ import (
 	"github.com/jfrog/jfrog-client-go/artifactory/auth"
 )
 
-// We need to create users to test Access Tokens
-// Administrators have different behaviours to non-administratros
-
 const audienceBad = `
 resource "artifactory_user" "existinguser" {
 	name  = "existinguser"
@@ -424,7 +421,7 @@ func testAccCheckAccessTokenDestroy(id string) func(*terraform.State) error {
 		if err != nil {
 			return err
 		} else if _, resp, err := rtold.V1.System.Ping(context.Background()); err != nil {
-			if resp.StatusCode == 401 {
+			if resp.StatusCode == http.StatusUnauthorized {
 				return nil
 			}
 			return fmt.Errorf("failed to ping server. Got %s", err)

--- a/pkg/artifactory/resource_artifactory_access_token_test.go
+++ b/pkg/artifactory/resource_artifactory_access_token_test.go
@@ -340,7 +340,7 @@ func TestAccAccessTokenMissingGroup(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      missingGroup,
-				ExpectError: regexp.MustCompile("Group must exist in artifactory"),
+				ExpectError: regexp.MustCompile("group must exist in artifactory"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource_artifactory_access_token_test.go
+++ b/pkg/artifactory/resource_artifactory_access_token_test.go
@@ -1,0 +1,447 @@
+package artifactory
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"regexp"
+	"testing"
+	"time"
+
+	artifactoryold "github.com/atlassian/go-artifactory/v2/artifactory"
+	"github.com/atlassian/go-artifactory/v2/artifactory/transport"
+	"github.com/hashicorp/terraform/helper/resource"
+	"github.com/hashicorp/terraform/terraform"
+	"github.com/jfrog/jfrog-client-go/artifactory/auth"
+)
+
+// We need to create users to test Access Tokens
+// Administrators have different behaviours to non-administratros
+
+const audienceBad = `
+resource "artifactory_user" "existinguser" {
+	name  = "existinguser"
+    email = "existinguser@a.com"
+	admin = false
+	groups = ["readers"]
+}
+
+resource "artifactory_access_token" "foobar" {
+	end_date_relative = "1s"
+	username = artifactory_user.existinguser.name
+	audience = "bad"
+	refreshable = true
+}
+`
+
+func TestAccAccessTokenAudienceBad(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      audienceBad,
+				ExpectError: regexp.MustCompile("audience can contain only service IDs of Artifactory servers"),
+			},
+		},
+	})
+}
+
+const audienceGood = `
+resource "artifactory_user" "existinguser" {
+	name  = "existinguser"
+    email = "existinguser@a.com"
+	admin = false
+	groups = ["readers"]
+}
+
+resource "artifactory_access_token" "foobar" {
+	end_date_relative = "1s"
+	username = artifactory_user.existinguser.name
+	audience = "jfrt@*"
+	refreshable = true
+}
+`
+
+func TestAccAccessTokenAudienceGood(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: audienceGood,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "access_token"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "username", "existinguser"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "end_date_relative", "1s"),
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "end_date"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "refreshable", "true"),
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "refresh_token"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "groups.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const existingUser = `
+resource "artifactory_user" "existinguser" {
+	name  = "existinguser"
+    email = "existinguser@a.com"
+	admin = false
+	groups = ["readers"]
+}
+
+resource "artifactory_access_token" "foobar" {
+	end_date_relative = "1s"
+	username = artifactory_user.existinguser.name
+}
+`
+
+func TestAccAccessTokenExistingUser(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: existingUser,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "access_token"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "username", "existinguser"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "end_date_relative", "1s"),
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "end_date"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "refreshable", "false"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "refresh_token", ""),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "groups.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func fixedDateGood() string {
+	// Create a "fixed date" in the future
+
+	date := time.Now().Add(time.Second * time.Duration(10)).Format(time.RFC3339)
+	return fmt.Sprintf(`
+resource "artifactory_user" "existinguser" {
+	name  = "existinguser"
+    email = "existinguser@a.com"
+	admin = false
+	groups = ["readers"]
+}
+
+resource "artifactory_access_token" "foobar" {
+	end_date = "%s"
+	username = artifactory_user.existinguser.name
+}
+`, date)
+}
+
+func TestAccAccessTokenFixedDateGood(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fixedDateGood(),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "access_token"),
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "end_date"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "username", "existinguser"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "refreshable", "false"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "refresh_token", ""),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "groups.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+var fixedDateBad = `
+resource "artifactory_user" "existinguser" {
+	name  = "existinguser"
+    email = "existinguser@a.com"
+	admin = false
+	groups = ["readers"]
+}
+
+resource "artifactory_access_token" "foobar" {
+	end_date = "2020-01-01T00:00:00+11:00"
+	username = artifactory_user.existinguser.name
+}
+`
+
+func TestAccAccessTokenFixedDateBad(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      fixedDateBad,
+				ExpectError: regexp.MustCompile("end date must be in the future, but is"),
+			},
+		},
+	})
+}
+
+// I couldn't find a way to retrieve the instance_id for artifactory via the go library.
+// So, we expect this to fail
+const adminToken = `
+resource "artifactory_user" "existinguser" {
+	name  = "existinguser"
+    email = "existinguser@a.com"
+	admin = false
+	groups = ["readers"]
+}
+
+resource "artifactory_access_token" "foobar" {
+	end_date_relative = "1s"
+	username = artifactory_user.existinguser.name
+
+	admin_token {
+		instance_id = "blah"
+	}
+}
+`
+
+func TestAccAccessTokenAdminToken(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      adminToken,
+				ExpectError: regexp.MustCompile("Admin can create token with admin privileges only on this Artifactory instance"),
+			},
+		},
+	})
+}
+
+const refreshableToken = `
+resource "artifactory_user" "existinguser" {
+	name  = "existinguser"
+    email = "existinguser@a.com"
+	admin = false
+	groups = ["readers"]
+}
+
+resource "artifactory_access_token" "foobar" {
+	end_date_relative = "1s"
+	refreshable = true
+	username = artifactory_user.existinguser.name
+}
+`
+
+func TestAccAccessTokenRefreshableToken(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: refreshableToken,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "access_token"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "username", "existinguser"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "end_date_relative", "1s"),
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "end_date"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "refreshable", "true"),
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "refresh_token"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "groups.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+const missingUserBad = `
+resource "artifactory_access_token" "foobar" {
+	end_date_relative = "1s"
+	username = "missing-user"
+	groups = [
+	]
+}
+`
+
+func TestAccAccessTokenMissingUserBad(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      missingUserBad,
+				ExpectError: regexp.MustCompile("you must specify at least 1 group when creating a token for a non-existant user"),
+			},
+		},
+	})
+}
+
+const missingUserGood = `
+resource "artifactory_access_token" "foobar" {
+	end_date_relative = "1s"
+	username = "missing-user"
+	groups = [
+		"readers",
+	]
+}
+`
+
+func TestAccAccessTokenMissingUserGood(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: missingUserGood,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "access_token"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "username", "missing-user"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "end_date_relative", "1s"),
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "end_date"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "refreshable", "false"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "refresh_token", ""),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "groups.#", "1"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "groups.0", "readers"),
+				),
+			},
+		},
+	})
+}
+
+const missingGroup = `
+resource "artifactory_user" "existinguser" {
+	name  = "existinguser"
+    email = "existinguser@a.com"
+	admin = false
+	groups = ["readers"]
+}
+
+resource "artifactory_access_token" "foobar" {
+	end_date_relative = "1s"
+	username = artifactory_user.existinguser.name
+	groups = [
+		"missing-group",
+	]
+}
+`
+
+func TestAccAccessTokenMissingGroup(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config:      missingGroup,
+				ExpectError: regexp.MustCompile("Group must exist in artifactory"),
+			},
+		},
+	})
+}
+
+const nonExpiringToken = `
+resource "artifactory_user" "existinguser" {
+	name  = "existinguser"
+    email = "existinguser@a.com"
+	admin = false
+	groups = ["readers"]
+}
+
+resource "artifactory_access_token" "foobar" {
+	end_date_relative = "0s"
+	username = artifactory_user.existinguser.name
+}
+`
+
+func TestAccAccessTokenNonExpiringToken(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: nonExpiringToken,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "access_token"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "username", "existinguser"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "end_date_relative", "0s"),
+					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "end_date"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "refreshable", "false"),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "refresh_token", ""),
+					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "groups.#", "0"),
+				),
+			},
+		},
+	})
+}
+
+func testAccCheckAccessTokenDestroy(id string) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		rs, ok := s.RootModule().Resources[id]
+
+		if !ok {
+			return fmt.Errorf("err: Resource id[%s] not found", id)
+		}
+
+		// We need to try to auth with the token and check that it errors
+		// Thus, token has really been "destroyed"
+
+		// This is more complicated when token has TTL, as Artifactory **does not** allow you to revoke a token that has a TTL.
+		// https://www.jfrog.com/confluence/display/JFROG/Access+Tokens#AccessTokens-ViewingandRevokingTokens
+		// https://www.jfrog.com/jira/browse/RTFACT-15293
+
+		// Create a new client to auth to Artifactory
+		// We want to check that the token cannot authenticate
+		url := os.Getenv("ARTIFACTORY_URL")
+		var client *http.Client
+		details := auth.NewArtifactoryDetails()
+
+		details.SetUrl(url)
+
+		accessToken := rs.Primary.Attributes["access_token"]
+		details.SetAccessToken(accessToken)
+		tp := &transport.AccessTokenAuth{
+			AccessToken: accessToken,
+		}
+		client = tp.Client()
+
+		rtold, err := artifactoryold.NewClient(url, client)
+
+		if err != nil {
+			return err
+		}
+
+		if err != nil {
+			return err
+		} else if _, resp, err := rtold.V1.System.Ping(context.Background()); err != nil {
+			if resp.StatusCode == 401 {
+				return nil
+			}
+			return fmt.Errorf("failed to ping server. Got %s", err)
+		}
+
+		return nil
+	}
+}
+
+func testAccCheckAccessTokenNotCreated(id string) func(*terraform.State) error {
+	return func(s *terraform.State) error {
+		_, ok := s.RootModule().Resources[id]
+
+		if ok {
+			return fmt.Errorf("err: Resource id[%s] found, but should not exist", id)
+		}
+
+		return nil
+	}
+}

--- a/pkg/artifactory/resource_artifactory_api_key_test.go
+++ b/pkg/artifactory/resource_artifactory_api_key_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/atlassian/go-artifactory/v2/artifactory"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -32,7 +31,8 @@ func TestAccApiKey(t *testing.T) {
 
 func testAccCheckApiKeyDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		apis := testAccProvider.Meta().(*ArtClient)
+		client := apis.ArtOld
 		rs, ok := s.RootModule().Resources[id]
 
 		if !ok {

--- a/pkg/artifactory/resource_artifactory_certificate_test.go
+++ b/pkg/artifactory/resource_artifactory_certificate_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/atlassian/go-artifactory/v2/artifactory"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -71,7 +70,8 @@ func TestAccCertificate_full(t *testing.T) {
 
 func testAccCheckCertificateDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		apis := testAccProvider.Meta().(*ArtClient)
+		client := apis.ArtOld
 		rs, ok := s.RootModule().Resources[id]
 
 		if !ok {

--- a/pkg/artifactory/resource_artifactory_group_test.go
+++ b/pkg/artifactory/resource_artifactory_group_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/atlassian/go-artifactory/v2/artifactory"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -64,7 +63,8 @@ func TestAccGroup_full(t *testing.T) {
 
 func testAccCheckGroupDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		apis := testAccProvider.Meta().(*ArtClient)
+		client := apis.ArtOld
 		rs, ok := s.RootModule().Resources[id]
 		if !ok {
 			return fmt.Errorf("err: Resource id[%s] not found", id)

--- a/pkg/artifactory/resource_artifactory_local_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_local_repository_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/atlassian/go-artifactory/v2/artifactory"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -100,7 +99,8 @@ func TestAccLocalRepository_full(t *testing.T) {
 
 func resourceLocalRepositoryCheckDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		apis := testAccProvider.Meta().(*ArtClient)
+		client := apis.ArtOld
 		rs, ok := s.RootModule().Resources[id]
 
 		if !ok {

--- a/pkg/artifactory/resource_artifactory_permission_target_test.go
+++ b/pkg/artifactory/resource_artifactory_permission_target_test.go
@@ -12,80 +12,72 @@ import (
 const permissionNoIncludes = `
 resource "artifactory_permission_target" "test-perm" {
 	name = "test-perm"
-	repo = {
+	repo {
 		repositories = ["example-repo-local"]
-		actions = {
-			users = [
-				{
-					name = "anonymous"
-					permissions = ["read", "write"]
-				},
-			]
+		actions {
+			users {
+			  name = "anonymous"
+			  permissions = ["read", "write"]
+			}
 		}
 	}
-}`
+}
+`
 
 const permissionJustBuild = `
 resource "artifactory_permission_target" "test-perm" {
 	name = "test-perm"
-	build = {
+	build {
+		includes_pattern = ["**"]
 		repositories = ["artifactory-build-info"]
-		actions = {
-			users = [
-				{
-					name = "anonymous"
-					permissions = ["read", "write"]
-				},
-			]
+		actions {
+			users {
+				name = "anonymous"
+				permissions = ["read", "write"]
+			}
 		}
 	}
-}`
+}
+`
 
 const permissionFull = `
 resource "artifactory_permission_target" "test-perm" {
   name = "test-perm"
 
-  repo = {
+  repo {
     includes_pattern = ["foo/**"]
     excludes_pattern = ["bar/**"]
     repositories     = ["example-repo-local"]
 
-    actions = {
-      users = [
-        {
-          name        = "anonymous"
-          permissions = ["read", "write"]
-        },
-      ]
+    actions {
+      users {
+		name        = "anonymous"
+		permissions = ["read", "write"]
+	  }
 
-      groups = [
-        {
-          name        = "readers"
-          permissions = ["read"]
-        },
-      ]
+      groups {
+        name        = "readers"
+        permissions = ["read"]
+      }
     }
   }
 
-  build = {
+  build {
     includes_pattern = ["foo/**"]
     excludes_pattern = ["bar/**"]
     repositories     = ["artifactory-build-info"]
 
-    actions = {
-      users = [
-        {
-          name        = "anonymous"
-          permissions = ["read", "write"]
-        },
-      ]
+    actions {
+      users {
+        name        = "anonymous"
+        permissions = ["read", "write"]
+      }
       
-      groups = [
-        {
-          name        = "readers"
-          permissions = ["read"]
-        },
-      ]
+      
+      groups {
+        name        = "readers"
+        permissions = ["read"]
+      }
     }
   }
 }
@@ -142,7 +134,7 @@ func TestAccPermissionTarget_addBuild(t *testing.T) {
 					resource.TestCheckResourceAttr("artifactory_permission_target.test-perm", "build.0.actions.0.users.#", "1"),
 					resource.TestCheckResourceAttr("artifactory_permission_target.test-perm", "build.0.actions.0.groups.#", "0"),
 					resource.TestCheckResourceAttr("artifactory_permission_target.test-perm", "build.0.repositories.#", "1"),
-					resource.TestCheckResourceAttr("artifactory_permission_target.test-perm", "build.0.includes_pattern.#", "0"),
+					resource.TestCheckResourceAttr("artifactory_permission_target.test-perm", "build.0.includes_pattern.#", "1"),
 					resource.TestCheckResourceAttr("artifactory_permission_target.test-perm", "build.0.excludes_pattern.#", "0"),
 				),
 			},

--- a/pkg/artifactory/resource_artifactory_permission_target_test.go
+++ b/pkg/artifactory/resource_artifactory_permission_target_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/atlassian/go-artifactory/v2/artifactory"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -169,7 +168,9 @@ func TestAccPermissionTarget_addBuild(t *testing.T) {
 
 func testPermissionTargetCheckDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		apis := testAccProvider.Meta().(*ArtClient)
+		client := apis.ArtOld
+
 		rs, ok := s.RootModule().Resources[id]
 
 		if !ok {

--- a/pkg/artifactory/resource_artifactory_permission_targets_v1_test.go
+++ b/pkg/artifactory/resource_artifactory_permission_targets_v1_test.go
@@ -14,15 +14,13 @@ const permissionV1Basic = `
 resource "artifactory_permission_target" "test-perm" {
 	name 	     = "test-perm"
 	repositories = ["example-repo-local"]
-	users = [
-		{
-			name = "anonymous"
-			permissions = [
-				"r",
-				"w"
-			]
-		}
-    ]
+	users {
+		name = "anonymous"
+		permissions = [
+			"r",
+			"w"
+		]
+	}
 }`
 
 func TestAccPermissionV1_basic(t *testing.T) {

--- a/pkg/artifactory/resource_artifactory_permission_targets_v1_test.go
+++ b/pkg/artifactory/resource_artifactory_permission_targets_v1_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/atlassian/go-artifactory/v2/artifactory"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -44,7 +43,9 @@ func TestAccPermissionV1_basic(t *testing.T) {
 
 func testPermissionTargetV1CheckDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		apis := testAccProvider.Meta().(*ArtClient)
+		client := apis.ArtOld
+
 		rs, ok := s.RootModule().Resources[id]
 
 		if !ok {

--- a/pkg/artifactory/resource_artifactory_remote_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 
 	"github.com/atlassian/go-artifactory/v2/artifactory"
-	"github.com/atlassian/go-artifactory/v2/artifactory/v1"
+	v1 "github.com/atlassian/go-artifactory/v2/artifactory/v1"
 	"github.com/hashicorp/terraform/helper/schema"
 	"github.com/hashicorp/terraform/helper/validation"
 )

--- a/pkg/artifactory/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/atlassian/go-artifactory/v2/artifactory"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -158,7 +157,9 @@ func TestAccRemoteRepository_full(t *testing.T) {
 
 func resourceRemoteRepositoryCheckDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		apis := testAccProvider.Meta().(*ArtClient)
+		client := apis.ArtOld
+
 		rs, ok := s.RootModule().Resources[id]
 
 		if !ok {

--- a/pkg/artifactory/resource_artifactory_replication_config_test.go
+++ b/pkg/artifactory/resource_artifactory_replication_config_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/atlassian/go-artifactory/v2/artifactory"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -59,7 +58,9 @@ func TestAccReplication_full(t *testing.T) {
 
 func testAccCheckReplicationDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		apis := testAccProvider.Meta().(*ArtClient)
+		client := apis.ArtOld
+
 		rs, ok := s.RootModule().Resources[id]
 		if !ok {
 			return fmt.Errorf("err: Resource id[%s] not found", id)

--- a/pkg/artifactory/resource_artifactory_replication_config_test.go
+++ b/pkg/artifactory/resource_artifactory_replication_config_test.go
@@ -22,13 +22,11 @@ resource "artifactory_replication_config" "lib-local" {
 	cron_exp = "0 0 * * * ?"
 	enable_event_replication = true
 	
-	replications = [
-		{
-			url = "%s"
-			username = "%s"
-			password = "%s"
-		}
-	]
+	replications {
+		url = "%s"
+		username = "%s"
+		password = "%s"
+	}
 }
 `
 

--- a/pkg/artifactory/resource_artifactory_single_replication_config_test.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/atlassian/go-artifactory/v2/artifactory"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -56,7 +55,9 @@ func TestAccSingleReplication_full(t *testing.T) {
 
 func testAccCheckSingleReplicationDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		apis := testAccProvider.Meta().(*ArtClient)
+		client := apis.ArtOld
+
 		rs, ok := s.RootModule().Resources[id]
 		if !ok {
 			return fmt.Errorf("err: Resource id[%s] not found", id)

--- a/pkg/artifactory/resource_artifactory_user_test.go
+++ b/pkg/artifactory/resource_artifactory_user_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/atlassian/go-artifactory/v2/artifactory"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -68,7 +67,9 @@ func TestAccUser_full(t *testing.T) {
 
 func testAccCheckUserDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		apis := testAccProvider.Meta().(*ArtClient)
+		client := apis.ArtOld
+
 		rs, ok := s.RootModule().Resources[id]
 
 		if !ok {

--- a/pkg/artifactory/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_virtual_repository_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/atlassian/go-artifactory/v2/artifactory"
 	"github.com/hashicorp/terraform/helper/resource"
 	"github.com/hashicorp/terraform/terraform"
 )
@@ -127,7 +126,9 @@ func TestAccVirtualRepository_full(t *testing.T) {
 
 func testAccCheckVirtualRepositoryDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := testAccProvider.Meta().(*artifactory.Artifactory)
+		apis := testAccProvider.Meta().(*ArtClient)
+		client := apis.ArtOld
+
 		rs, ok := s.RootModule().Resources[id]
 
 		if !ok {


### PR DESCRIPTION
This PR creates a resource to create and revoke access tokens in Artifactory.

As Artifactory does not support Read or Update operations on an Access Token, the resource does not support this either.
As there is no read operation, it cannot support an import of an existing access token.

It implements all the features as per the API specs:
- https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateToken
- https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-RevokeToken

I have changed the inputs for setting the token expiration so that it can be used in different ways - specified either by `end_date_relative` or `end_date`. See the documentation for examples.

Although you can specify a token to be **refreshable**, the resource does not support the refresh action, as this does not align to CRUD operations.


I've also updated a number of the tests so that they reference the correct client instance.


Cheers,

Josh