### PR TITLE
Add PERM_MANAGE_XRAY_METADATA to actions schema

### DIFF
--- a/pkg/artifactory/resource_artifactory_permission_target.go
+++ b/pkg/artifactory/resource_artifactory_permission_target.go
@@ -3,8 +3,9 @@ package artifactory
 import (
 	"context"
 	"fmt"
-	"github.com/hashicorp/terraform/helper/resource"
 	"net/http"
+
+	"github.com/hashicorp/terraform/helper/resource"
 
 	v2 "github.com/atlassian/go-artifactory/v2/artifactory/v2"
 	"github.com/hashicorp/terraform/helper/schema"
@@ -62,6 +63,7 @@ func resourceArtifactoryPermissionTarget() *schema.Resource {
 							v2.PERM_WRITE,
 							v2.PERM_DELETE,
 							v2.PERM_MANAGE,
+							v2.PERM_MANAGE_XRAY_METADATA,
 						}, false),
 					},
 					Set:      schema.HashString,


### PR DESCRIPTION
Adds the `PERM_MANAGE_XRAY_METADATA` permission to the `actionSchema`.

This PR depends on https://github.com/atlassian/go-artifactory/pull/28