### PR TITLE
Set Computed to true for fields that are computed

### DIFF
--- a/pkg/artifactory/resource_artifactory_remote_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository.go
@@ -58,6 +58,7 @@ func resourceArtifactoryRemoteRepository() *schema.Resource {
 			"repo_layout_ref": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"handle_releases": {
 				Type:     schema.TypeBool,
@@ -96,6 +97,7 @@ func resourceArtifactoryRemoteRepository() *schema.Resource {
 			"proxy": {
 				Type:     schema.TypeString,
 				Optional: true,
+				Computed: true,
 			},
 			"remote_repo_checksum_policy_type": {
 				Type:     schema.TypeString,
@@ -261,8 +263,8 @@ func resourceArtifactoryRemoteRepository() *schema.Resource {
 			"content_synchronisation": {
 				Type:     schema.TypeList,
 				Optional: true,
+				Computed: true,
 				MaxItems: 1,
-				MinItems: 1,
 				Elem: &schema.Resource{
 					Schema: map[string]*schema.Schema{
 						"enabled": {


### PR DESCRIPTION
This fixes issues with the remote repository where after you initial create a new remote repositry and re-run terraform it doesn't attempt to remove the repo_layout_ref, content_synchronization or proxy.

This fixes #13

I am running this in production without any issues.

Another reference for these computed values, hashicorp/terraform#21278