### PR TITLE
Guard against dereference nil pointers

### DIFF
--- a/pkg/artifactory/resource_xray_policy.go
+++ b/pkg/artifactory/resource_xray_policy.go
@@ -453,8 +453,10 @@ func resourceXrayPolicyRead(d *schema.ResourceData, m interface{}) error {
 	if err := d.Set("type", *policy.Type); err != nil {
 		return err
 	}
-	if err := d.Set("description", *policy.Description); err != nil {
-		return err
+	if policy.Description != nil {
+		if err := d.Set("description", *policy.Description); err != nil {
+			return err
+		}
 	}
 	if err := d.Set("author", *policy.Author); err != nil {
 		return err


### PR DESCRIPTION
This fixes an issue when someone doesn't provide a description.

```text
panic: runtime error: invalid memory address or nil pointer dereference
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: [signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xe4f544]
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: 
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: goroutine 59 [running]:
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: github.com/atlassian/terraform-provider-artifactory/pkg/artifactory.resourceXrayPolicyRead(0xc00022d7a0, 0xebf580, 0xc0000faaf8, 0xc000591b00, 0xc000206090)
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: 	/home/jason.barnett/git/terraform-provider-artifactory/pkg/artifactory/resource_xray_policy.go:456 +0x2e4
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: github.com/atlassian/terraform-provider-artifactory/pkg/artifactory.resourceXrayPolicyCreate(0xc00022d7a0, 0xebf580, 0xc0000faaf8, 0x2, 0x1857c20)
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: 	/home/jason.barnett/git/terraform-provider-artifactory/pkg/artifactory/resource_xray_policy.go:438 +0x187
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Resource).Apply(0xc000223780, 0xc0000b6500, 0xc00052c9a0, 0xebf580, 0xc0000faaf8, 0xf43501, 0xc00051efd8, 0xc0002a30e0)
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: 	/home/jason.barnett/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.7.0/helper/schema/resource.go:305 +0x375
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: github.com/hashicorp/terraform-plugin-sdk/helper/schema.(*Provider).Apply(0xc000223b00, 0xc0000198e8, 0xc0000b6500, 0xc00052c9a0, 0xc0004adca8, 0xc0006da1f0, 0xf45920)
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: 	/home/jason.barnett/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.7.0/helper/schema/provider.go:294 +0x99
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: github.com/hashicorp/terraform-plugin-sdk/internal/helper/plugin.(*GRPCProviderServer).ApplyResourceChange(0xc000194b20, 0x1240ea0, 0xc0005f4150, 0xc000196420, 0xc000194b20, 0xc0005f4150, 0xc0005a2a50)
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: 	/home/jason.barnett/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.7.0/internal/helper/plugin/grpc_provider.go:885 +0x8a5
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: github.com/hashicorp/terraform-plugin-sdk/internal/tfplugin5._Provider_ApplyResourceChange_Handler(0x10551a0, 0xc000194b20, 0x1240ea0, 0xc0005f4150, 0xc0001963c0, 0x0, 0x1240ea0, 0xc0005f4150, 0xc0000f8000, 0x2b2)
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: 	/home/jason.barnett/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk@v1.7.0/internal/tfplugin5/tfplugin5.pb.go:3189 +0x214
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: google.golang.org/grpc.(*Server).processUnaryRPC(0xc0001d0160, 0x1249bb8, 0xc000103c80, 0xc00047a000, 0xc0001107b0, 0x18176a0, 0x0, 0x0, 0x0)
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: 	/home/jason.barnett/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:995 +0x482
2021-03-22T11:47:51.699-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: google.golang.org/grpc.(*Server).handleStream(0xc0001d0160, 0x1249bb8, 0xc000103c80, 0xc00047a000, 0x0)
2021-03-22T11:47:51.700-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: 	/home/jason.barnett/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:1275 +0xd2c
2021-03-22T11:47:51.700-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: google.golang.org/grpc.(*Server).serveStreams.func1.1(0xc00011e1b0, 0xc0001d0160, 0x1249bb8, 0xc000103c80, 0xc00047a000)
2021-03-22T11:47:51.700-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: 	/home/jason.barnett/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:710 +0xab
2021-03-22T11:47:51.700-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: created by google.golang.org/grpc.(*Server).serveStreams.func1
2021-03-22T11:47:51.700-0400 [DEBUG] plugin.terraform-provider-artifactory_v2.2.7: 	/home/jason.barnett/go/pkg/mod/google.golang.org/grpc@v1.23.0/server.go:708 +0xa5
2021-03-22T11:47:51.702-0400 [DEBUG] plugin: plugin process exited: path=.terraform/plugins/registry.terraform.io/jfrog/artifactory/2.2.7/linux_amd64/terraform-provider-artifactory_v2.2.7 pid=108070 error="exit status 2"
```