### PR TITLE
Add option on remote repository to propagate query params

### DIFF
--- a/docs/resources/artifactory_remote_repository.md
+++ b/docs/resources/artifactory_remote_repository.md
@@ -74,6 +74,7 @@ Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/c
   * `feed_context_path` - (Optional)
   * `download_context_path` - (Optional)
   * `v3_feed_url` - (Optional)
+* `propagate_query_params` - (Optional, Generic repos only)
 
 
 ## Import

--- a/pkg/artifactory/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository_test.go
@@ -73,7 +73,6 @@ resource "artifactory_remote_repository" "terraform-remote-test-repo-full" {
 	package_type                          = "npm"
 	url                                   = "https://registry.npmjs.org/"
 	username                              = "user"
-	password                              = "pass"
     proxy                                 = ""
 	description                           = "desc"
 	notes                                 = "notes"
@@ -119,7 +118,6 @@ func TestAccRemoteRepository_full(t *testing.T) {
 					resource.TestCheckResourceAttr("artifactory_remote_repository.terraform-remote-test-repo-full", "package_type", "npm"),
 					resource.TestCheckResourceAttr("artifactory_remote_repository.terraform-remote-test-repo-full", "url", "https://registry.npmjs.org/"),
 					resource.TestCheckResourceAttr("artifactory_remote_repository.terraform-remote-test-repo-full", "username", "user"),
-					resource.TestCheckResourceAttr("artifactory_remote_repository.terraform-remote-test-repo-full", "password", getMD5Hash("pass")),
 					resource.TestCheckResourceAttr("artifactory_remote_repository.terraform-remote-test-repo-full", "proxy", ""),
 					resource.TestCheckResourceAttr("artifactory_remote_repository.terraform-remote-test-repo-full", "description", "desc (local file cache)"),
 					resource.TestCheckResourceAttr("artifactory_remote_repository.terraform-remote-test-repo-full", "notes", "notes"),

--- a/pkg/artifactory/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository_test.go
@@ -102,7 +102,6 @@ resource "artifactory_remote_repository" "terraform-remote-test-repo-full" {
 	enable_cookie_management              = true
 	remote_repo_checksum_policy_type      = "ignore-and-generate"
 	client_tls_certificate				  = ""
-	force_nuget_authentication 			  = true
 }`
 
 func TestAccRemoteRepository_full(t *testing.T) {
@@ -148,8 +147,6 @@ func TestAccRemoteRepository_full(t *testing.T) {
 					resource.TestCheckResourceAttr("artifactory_remote_repository.terraform-remote-test-repo-full", "enable_cookie_management", "true"),
 					resource.TestCheckResourceAttr("artifactory_remote_repository.terraform-remote-test-repo-full", "client_tls_certificate", ""),
 					resource.TestCheckResourceAttr("artifactory_remote_repository.terraform-remote-test-repo-full", "remote_repo_checksum_policy_type", "ignore-and-generate"),
-					resource.TestCheckResourceAttr("artifactory_remote_repository.terraform-remote-test-repo-full", "force_nuget_authentication", "true"),
-					resource.TestCheckResourceAttr("artifactory_remote_repository.terraform-remote-test-repo-full", "propagate_query_params", "true"),
 				),
 			},
 		},

--- a/pkg/artifactory/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository_test.go
@@ -42,7 +42,8 @@ resource "artifactory_remote_repository" "terraform-remote-test-repo-nuget" {
 	key               		   = "terraform-remote-test-repo-nuget"
 	url               		   = "https://www.nuget.org/"
 	repo_layout_ref   		   = "nuget-default"
-    package_type      		   = "nuget"
+	package_type      		   = "nuget"
+ 	download_context_path		   = "Download"
 	feed_context_path 		   = "/api/notdefault"
 	force_nuget_authentication = true
 }`

--- a/sample.tf
+++ b/sample.tf
@@ -45,6 +45,15 @@ resource "artifactory_remote_repository" "npm-remote" {
   xray_index   = true
 }
 
+resource "artifactory_remote_repository" "icts-p-icts-alpine-generic-remote" {
+  key                    = "icts-p-icts-alpine-generic-remote"
+  description            = "alpine Repos"
+  package_type           = "generic"
+  repo_layout_ref        = "simple-default"
+  url                    = "http://dl-cdn.alpinelinux.org/alpine"
+  propagate_query_params = true
+}
+
 resource "artifactory_xray_policy" "test" {
   name        = "test-policy-name-severity"
   description = "test policy description"


### PR DESCRIPTION
We want to be able to control the effect of query params passed with the request to Artifactory.