### PR TITLE
Bump Go version to 1.6 enabling Mac M1 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.16
       -
         name: Import GPG key
         id: import_gpg


### PR DESCRIPTION
As everyone in provider space is switching up to more recent go version, its great time to bump it here as well. This version of Go adds support for `darwin/arm64` (Apple Silicon) but deprecates support for macOS 10.12 (Sierra).