### PR TITLE
Update virtual repo docs to show required fields

### DIFF
--- a/docs/resources/artifactory_virtual_repository.md
+++ b/docs/resources/artifactory_virtual_repository.md
@@ -29,9 +29,9 @@ resource "artifactory_virtual_repository" "foo" {
 
 Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/confluence/display/RTF/Repository+Configuration+JSON). The following arguments are supported:
 
-* `key` - (Optional)
-* `package_type` - (Optional)
-* `repositories` - (Optional)
+* `key` - (Required)
+* `package_type` - (Required)
+* `repositories` - (Required)
 * `description` - (Optional)
 * `notes` - (Optional)
 * `includes_pattern` - (Optional)


### PR DESCRIPTION
Based on the [source](https://github.com/jfrog/terraform-provider-artifactory/blob/master/pkg/artifactory/resource_artifactory_virtual_repository.go#L25-L40) it seems some fields are required.