### PR TITLE
Adds support for adding users to groups

### DIFF
--- a/pkg/artifactory/resource_artifactory_group.go
+++ b/pkg/artifactory/resource_artifactory_group.go
@@ -58,6 +58,7 @@ func resourceArtifactoryGroup() *schema.Resource {
 				Elem: &schema.Schema{
 					Type: schema.TypeString,
 				},
+				Optional: true,
 			},
 		},
 	}

--- a/pkg/artifactory/resource_artifactory_group.go
+++ b/pkg/artifactory/resource_artifactory_group.go
@@ -147,6 +147,13 @@ func resourceGroupRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
+	// If we 404 it is likely the resources was externally deleted
+	// If the ID is updated to blank, this tells Terraform the resource no longer exist
+	if group == nil {
+		d.SetId("")
+		return nil
+	}
+
 	hasErr := false
 	logError := cascadingErr(&hasErr)
 	logError(d.Set("name", group.Name))

--- a/pkg/artifactory/resource_artifactory_group.go
+++ b/pkg/artifactory/resource_artifactory_group.go
@@ -168,7 +168,9 @@ func resourceGroupUpdate(d *schema.ResourceData, m interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = c.UpdateGroup(groupParams)
+	// Create and Update uses same endpoint, create checks for ReplaceIfExists and then uses put
+	// Update instead uses POST which prevents removing users. This recreates the group with the same permissions and updated users
+	err = c.CreateGroup(groupParams)
 	if err != nil {
 		return err
 	}

--- a/pkg/artifactory/resource_artifactory_group.go
+++ b/pkg/artifactory/resource_artifactory_group.go
@@ -1,15 +1,13 @@
 package artifactory
 
 import (
-	"context"
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
-	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/validation"
 
-	v1 "github.com/atlassian/go-artifactory/v2/artifactory/v1"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	artifactory "github.com/jfrog/jfrog-client-go/artifactory/services"
 )
 
 func resourceArtifactoryGroup() *schema.Resource {
@@ -26,10 +24,10 @@ func resourceArtifactoryGroup() *schema.Resource {
 
 		Schema: map[string]*schema.Schema{
 			"name": {
-				Type:     schema.TypeString,
-				Required: true,
-				ForceNew: true,
-				ValidateFunc:  validation.StringIsNotEmpty,
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     true,
+				ValidateFunc: validation.StringIsNotEmpty,
 			},
 			"description": {
 				Type:     schema.TypeString,
@@ -55,54 +53,78 @@ func resourceArtifactoryGroup() *schema.Resource {
 				Type:     schema.TypeString,
 				Optional: true,
 			},
+			"users_names": {
+				Type: schema.TypeSet,
+				Elem: &schema.Schema{
+					Type: schema.TypeString,
+				},
+			},
 		},
 	}
 }
 
-func unmarshalGroup(s *schema.ResourceData) (*v1.Group, error) {
+func groupParams(s *schema.ResourceData) (artifactory.GroupParams, error) {
 	d := &ResourceData{s}
 
-	group := new(v1.Group)
+	group := artifactory.Group{}
 
-	group.Name = d.getStringRef("name", false)
-	group.Description = d.getStringRef("description", false)
-	group.AutoJoin = d.getBoolRef("auto_join", false)
-	group.AdminPrivileges = d.getBoolRef("admin_privileges", false)
-	group.Realm = d.getStringRef("realm", false)
-	group.RealmAttributes = d.getStringRef("realm_attributes", false)
-
-	// Validator
-	if group.AdminPrivileges != nil && group.AutoJoin != nil && *group.AdminPrivileges && *group.AutoJoin {
-		return nil, fmt.Errorf("error: auto_join cannot be true if admin_privileges is true")
+	if name := d.getStringRef("name", false); name != nil {
+		group.Name = *name
 	}
 
-	return group, nil
+	if description := d.getStringRef("description", false); description != nil {
+		group.Description = *description
+	}
+
+	if autoJoin := d.getBoolRef("auto_join", false); autoJoin != nil {
+		group.AutoJoin = *autoJoin
+	}
+
+	if adminPrivileges := d.getBoolRef("admin_privileges", false); adminPrivileges != nil {
+		group.AdminPrivileges = *adminPrivileges
+	}
+
+	if realm := d.getStringRef("realm", false); realm != nil {
+		group.Realm = *realm
+	}
+
+	if realmAttributes := d.getStringRef("realm_attributes", false); realmAttributes != nil {
+		group.RealmAttributes = *realmAttributes
+	}
+
+	if usersNames := d.getSetRef("user_names"); usersNames != nil {
+		group.UsersNames = *usersNames
+	}
+
+	// Validator
+	if group.AdminPrivileges && group.AutoJoin {
+		return artifactory.GroupParams{}, fmt.Errorf("error: auto_join cannot be true if admin_privileges is true")
+	}
+
+	return artifactory.GroupParams{GroupDetails: group, ReplaceIfExists: false, IncludeUsers: true}, nil
 }
 
 func resourceGroupCreate(d *schema.ResourceData, m interface{}) error {
-	c := m.(*ArtClient).ArtOld
+	c := m.(*ArtClient).ArtNew
 
-	group, err := unmarshalGroup(d)
-
+	groupParams, err := groupParams(d)
 	if err != nil {
 		return err
 	}
 
-	_, err = c.V1.Security.CreateOrReplaceGroup(context.Background(), *group.Name, group)
-
+	err = c.CreateGroup(groupParams)
 	if err != nil {
 		return err
 	}
 
-	d.SetId(*group.Name)
+	d.SetId(groupParams.GroupDetails.Name)
 	return resource.Retry(d.Timeout(schema.TimeoutCreate), func() *resource.RetryError {
-		c := m.(*ArtClient).ArtOld
-		_, resp, err := c.V1.Security.GetGroup(context.Background(), d.Id())
+		exists, err := resourceGroupExists(d, m)
 		if err != nil {
 			return resource.NonRetryableError(fmt.Errorf("error describing group: %s", err))
 		}
 
-		if resp.StatusCode == http.StatusNotFound {
+		if !exists {
 			return resource.RetryableError(fmt.Errorf("expected group to be created, but currently not found"))
 		}
 
@@ -110,19 +132,19 @@ func resourceGroupCreate(d *schema.ResourceData, m interface{}) error {
 	})
 }
 
-func resourceGroupRead(d *schema.ResourceData, m interface{}) error {
-	c := m.(*ArtClient).ArtOld
+func resourceGroupGet(d *schema.ResourceData, m interface{}) (*artifactory.Group, error) {
+	c := m.(*ArtClient).ArtNew
 
-	group, resp, err := c.V1.Security.GetGroup(context.Background(), d.Id())
-	if resp == nil {
-		return fmt.Errorf("no response returned during resourceGroupRead")
-	}
-	// If we 404 it is likely the resources was externally deleted
-	// If the ID is updated to blank, this tells Terraform the resource no longer exist
-	if resp.StatusCode == http.StatusNotFound {
-		d.SetId("")
-		return nil
-	} else if err != nil {
+	params := artifactory.NewGroupParams()
+	params.GroupDetails.Name = d.Id()
+	params.IncludeUsers = true
+
+	return c.GetGroup(params)
+}
+
+func resourceGroupRead(d *schema.ResourceData, m interface{}) error {
+	group, err := resourceGroupGet(d, m)
+	if err != nil {
 		return err
 	}
 
@@ -134,6 +156,7 @@ func resourceGroupRead(d *schema.ResourceData, m interface{}) error {
 	logError(d.Set("admin_privileges", group.AdminPrivileges))
 	logError(d.Set("realm", group.Realm))
 	logError(d.Set("realm_attributes", group.RealmAttributes))
+	logError(d.Set("users_names", group.UsersNames))
 	if hasErr {
 		return fmt.Errorf("failed to marshal group")
 	}
@@ -141,53 +164,35 @@ func resourceGroupRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func resourceGroupUpdate(d *schema.ResourceData, m interface{}) error {
-	c := m.(*ArtClient).ArtOld
-	group, err := unmarshalGroup(d)
+	c := m.(*ArtClient).ArtNew
+	groupParams, err := groupParams(d)
 	if err != nil {
 		return err
 	}
-	_, err = c.V1.Security.UpdateGroup(context.Background(), d.Id(), group)
+	err = c.UpdateGroup(groupParams)
 	if err != nil {
 		return err
 	}
 
-	d.SetId(*group.Name)
+	d.SetId(groupParams.GroupDetails.Name)
 	return resourceGroupRead(d, m)
 }
 
 func resourceGroupDelete(d *schema.ResourceData, m interface{}) error {
-	c := m.(*ArtClient).ArtOld
-	group, err := unmarshalGroup(d)
+	c := m.(*ArtClient).ArtNew
+	groupParams, err := groupParams(d)
 	if err != nil {
 		return err
 	}
 
-	_, resp, err := c.V1.Security.DeleteGroup(context.Background(), *group.Name)
-	if err != nil {
-		return err
-	}
-
-	if resp.StatusCode == http.StatusNotFound {
-		return nil
-	}
-
-	return err
+	return c.DeleteGroup(groupParams.GroupDetails.Name)
 }
 
 func resourceGroupExists(d *schema.ResourceData, m interface{}) (bool, error) {
-	c := m.(*ArtClient).ArtOld
-
-	groupName := d.Id()
-	_, resp, err := c.V1.Security.GetGroup(context.Background(), groupName)
+	group, err := resourceGroupGet(d, m)
 	if err != nil {
 		return false, err
 	}
 
-	if resp.StatusCode == http.StatusNotFound {
-		return false, nil
-	} else if err != nil {
-		return false, err
-	}
-
-	return true, nil
+	return (group != nil), nil
 }

--- a/pkg/artifactory/resource_artifactory_group.go
+++ b/pkg/artifactory/resource_artifactory_group.go
@@ -54,10 +54,8 @@ func resourceArtifactoryGroup() *schema.Resource {
 				Optional: true,
 			},
 			"users_names": {
-				Type: schema.TypeSet,
-				Elem: &schema.Schema{
-					Type: schema.TypeString,
-				},
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
 				Optional: true,
 			},
 		},
@@ -93,7 +91,7 @@ func groupParams(s *schema.ResourceData) (artifactory.GroupParams, error) {
 		group.RealmAttributes = *realmAttributes
 	}
 
-	if usersNames := d.getSetRef("user_names"); usersNames != nil {
+	if usersNames := d.getSetRef("users_names"); usersNames != nil {
 		group.UsersNames = *usersNames
 	}
 
@@ -102,7 +100,7 @@ func groupParams(s *schema.ResourceData) (artifactory.GroupParams, error) {
 		return artifactory.GroupParams{}, fmt.Errorf("error: auto_join cannot be true if admin_privileges is true")
 	}
 
-	return artifactory.GroupParams{GroupDetails: group, ReplaceIfExists: false, IncludeUsers: true}, nil
+	return artifactory.GroupParams{GroupDetails: group, ReplaceIfExists: true, IncludeUsers: true}, nil
 }
 
 func resourceGroupCreate(d *schema.ResourceData, m interface{}) error {
@@ -157,7 +155,7 @@ func resourceGroupRead(d *schema.ResourceData, m interface{}) error {
 	logError(d.Set("admin_privileges", group.AdminPrivileges))
 	logError(d.Set("realm", group.Realm))
 	logError(d.Set("realm_attributes", group.RealmAttributes))
-	logError(d.Set("users_names", group.UsersNames))
+	logError(d.Set("users_names", schema.NewSet(schema.HashString, castToInterfaceArr(group.UsersNames))))
 	if hasErr {
 		return fmt.Errorf("failed to marshal group")
 	}

--- a/pkg/artifactory/resource_artifactory_group_test.go
+++ b/pkg/artifactory/resource_artifactory_group_test.go
@@ -41,6 +41,17 @@ resource "artifactory_group" "test-group" {
 	realm_attributes = "Some attribute"
 }`
 
+const groupUserUpdate1 = `
+resource "artifactory_group" "test-group" {
+	name             = "terraform-group"
+    description 	 = "Test group"
+	auto_join        = true
+	admin_privileges = false
+	realm            = "test"
+	realm_attributes = "Some attribute"
+	users_names = ["anonymous]
+}`
+
 func TestAccGroup_full(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:     func() { testAccPreCheck(t) },
@@ -55,6 +66,18 @@ func TestAccGroup_full(t *testing.T) {
 					resource.TestCheckResourceAttr("artifactory_group.test-group", "admin_privileges", "false"),
 					resource.TestCheckResourceAttr("artifactory_group.test-group", "realm", "test"),
 					resource.TestCheckResourceAttr("artifactory_group.test-group", "realm_attributes", "Some attribute"),
+					resource.TestCheckResourceAttr("artifactory_group.test-group", "users_names", "[]"),
+				),
+			},
+			{
+				Config: groupUserUpdate1,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr("artifactory_group.test-group", "name", "terraform-group"),
+					resource.TestCheckResourceAttr("artifactory_group.test-group", "auto_join", "true"),
+					resource.TestCheckResourceAttr("artifactory_group.test-group", "admin_privileges", "false"),
+					resource.TestCheckResourceAttr("artifactory_group.test-group", "realm", "test"),
+					resource.TestCheckResourceAttr("artifactory_group.test-group", "realm_attributes", "Some attribute"),
+					resource.TestCheckResourceAttr("artifactory_group.test-group", "users_names", "[]"),
 				),
 			},
 		},

--- a/pkg/artifactory/resource_artifactory_group_test.go
+++ b/pkg/artifactory/resource_artifactory_group_test.go
@@ -49,7 +49,7 @@ resource "artifactory_group" "test-group" {
 	admin_privileges = false
 	realm            = "test"
 	realm_attributes = "Some attribute"
-	users_names = ["anonymous", "admin"]
+	users_names = ["anonymous"]
 }`
 
 const groupUserUpdate2 = `

--- a/pkg/artifactory/resource_artifactory_group_test.go
+++ b/pkg/artifactory/resource_artifactory_group_test.go
@@ -94,19 +94,23 @@ func TestAccGroup_full(t *testing.T) {
 			{
 				Config: groupUserUpdate1,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("artifactory_group.test-group", "users_names.#", "2"),
+					resource.TestCheckResourceAttr("artifactory_group.test-group", "users_names.#", "1"),
+					resource.TestCheckResourceAttr("artifactory_group.test-group", "users_names.1386592683", "anonymous"),
 				),
 			},
 			{
 				Config: groupUserUpdate2,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("artifactory_group.test-group", "users_names.#", "2"),
+					resource.TestCheckResourceAttr("artifactory_group.test-group", "users_names.3672628397", "admin"),
+					resource.TestCheckResourceAttr("artifactory_group.test-group", "users_names.1386592683", "anonymous"),
 				),
 			},
 			{
 				Config: groupUserUpdate3,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr("artifactory_group.test-group", "users_names.#", "1"),
+					resource.TestCheckResourceAttr("artifactory_group.test-group", "users_names.3672628397", "admin"),
 				),
 			},
 		},


### PR DESCRIPTION
The jfrog api currently supports updating groups with the list of users that belong to that group. This adds the same functionality to terraform.


Previously was using the atlassian artifactory plugin which is 2 years out of date and lacking features, I updated it to use the new jfrog owned client which is currently maintained.


