### PR TITLE
update documentation to be referenced correctly

### DIFF
--- a/docs/resources/artifactory_xray_policy.md
+++ b/docs/resources/artifactory_xray_policy.md
@@ -71,8 +71,8 @@ The nested `criteria` block is a list of one item, supporting the following:
 
 The nested `cvss_range` block is a list of one object that contains the following attributes:
 
-* `to` - (Required) The beginning of the range of CVS scores (from 1-10) to flag.
-* `from` - (Required) The end of the range of CVS scores (from 1-10) to flag.
+* `to` - (Required) The end of the range of CVS scores (from 1-10) to flag.
+* `from` - (Required) The beginning of the range of CVS scores (from 1-10) to flag.
 
 ##### License criteria
 

--- a/docs/resources/artifactory_xray_policy.md
+++ b/docs/resources/artifactory_xray_policy.md
@@ -71,7 +71,7 @@ The nested `criteria` block is a list of one item, supporting the following:
 
 The nested `cvss_range` block is a list of one object that contains the following attributes:
 
-* `to` - (Required) The end of the range of CVS scores (from 1-10) to flag.
+* `to` - (Required) The end of the range of CVS scores (from 1-10) to flag. 
 * `from` - (Required) The beginning of the range of CVS scores (from 1-10) to flag.
 
 ##### License criteria


### PR DESCRIPTION
Fix documentation references.  the `to` value should be the end value and the `from` value should be the beginning value.
Error: {"error":"my_rule_name criteria cvss_range value is invalid : 'from' value is bigger than 'to' value"}