### PR TITLE
Remove validation on file path. 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
 	github.com/jfrog/jfrog-client-go v0.23.1
 	github.com/stretchr/testify v1.7.0
+	golang.org/x/sys v0.0.0-20210510120138-977fb7262007
 	golang.org/x/tools v0.1.5 // indirect
 	gopkg.in/yaml.v2 v2.4.0
 )

--- a/pkg/artifactory/resource_xray_policy.go
+++ b/pkg/artifactory/resource_xray_policy.go
@@ -25,7 +25,7 @@ type PolicyRuleCriteria struct {
 	CVSSRange       *PolicyCVSSRange `json:"cvss_range,omitempty"`
 
 	// License Criteria
-	AllowUnkown     *bool     `json:"allow_unknown,omitempty"`
+	AllowUnknown     *bool     `json:"allow_unknown,omitempty"`
 	BannedLicenses  *[]string `json:"banned_licenses,omitempty"`
 	AllowedLicenses *[]string `json:"allowed_licenses,omitempty"`
 }
@@ -282,7 +282,7 @@ func expandCriteria(l []interface{}, policyType *string) (*PolicyRuleCriteria, e
 		}
 
 		// If these are both the default values, we must be using license criteria
-		criteria.AllowUnkown = allowUnk // "Unkown" is a typo in xray-oss
+		criteria.AllowUnknown = allowUnk
 		criteria.BannedLicenses = banned
 		criteria.AllowedLicenses = allowed
 	} else {
@@ -412,8 +412,8 @@ func flattenCriteria(criteria *PolicyRuleCriteria) []interface{} {
 	if criteria.MinimumSeverity != nil {
 		m["min_severity"] = *criteria.MinimumSeverity
 	}
-	if criteria.AllowUnkown != nil {
-		m["allow_unknown"] = *criteria.AllowUnkown // Same typo in the library
+	if criteria.AllowUnknown != nil {
+		m["allow_unknown"] = *criteria.AllowUnknown // Same typo in the library
 	}
 	if criteria.BannedLicenses != nil {
 		m["banned_licenses"] = *criteria.BannedLicenses

--- a/pkg/artifactory/validators.go
+++ b/pkg/artifactory/validators.go
@@ -2,13 +2,12 @@ package artifactory
 
 import (
 	"fmt"
+	"github.com/gorhill/cronexpr"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"net/mail"
 	"os"
 	"regexp"
 	"strings"
-
-	"github.com/gorhill/cronexpr"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )


### PR DESCRIPTION
There are a lot of complications to prevalidating. Ultimately, the OS will put the break on an invalid write. Also, remove a logical error where in an empty file would fail a check sum, and thus now allow an overwrite. Resolving #118 