### PR TITLE
update artifactory_group documentation

### DIFF
--- a/docs/resources/artifactory_group.md
+++ b/docs/resources/artifactory_group.md
@@ -10,6 +10,7 @@ resource "artifactory_group" "test-group" {
   name             = "terraform"
   description      = "test group"
   admin_privileges = false
+  users_names      = [ "foobar" ]
 }
 ```
 
@@ -23,6 +24,7 @@ The following arguments are supported:
 * `admin_privileges`    - (Optional) Any users added to this group will automatically be assigned with admin privileges in the system.
 * `realm`               - (Optional) The realm for the group.
 * `realm_attributes`    - (Optional) The realm attributes for the group.
+* `users_names`         - (Optional) List of users assigned to the group.
 
 ## Import
 


### PR DESCRIPTION
The resource `artifactory_group` has an undocumented parameter `users_names` which appears to be required when importing resources (we had to re import everything after recovering from a backup)

version = 2.3.6

```
resource "artifactory_group" "npm-write" {
  name = "npm-write"
}
```

terraform apply: 
(notice how its going to remove 'npm-write' from the users_name parameter? )

```
  # artifactory_group.npm-write will be updated in-place
  ~ resource "artifactory_group" "npm-write" {
        id               = "npm-write"
        name             = "npm-write"
      ~ users_names      = [
          - "npm-write",
        ]
        # (3 unchanged attributes hidden)
    }

```

Looking at the documentation, `users_names` is not something that we can define.

https://registry.terraform.io/providers/jfrog/artifactory/latest/docs/resources/artifactory_group




