### PR TITLE
GH-132 User's .Exists and .Read only needs d.Id()

### DIFF
--- a/pkg/artifactory/resource_artifactory_user.go
+++ b/pkg/artifactory/resource_artifactory_user.go
@@ -97,10 +97,7 @@ func resourceArtifactoryUser() *schema.Resource {
 func resourceUserExists(data *schema.ResourceData, m interface{}) (bool, error) {
 
 	d := &ResourceData{data}
-	name := d.getString("name", false)
-	if name == "" {
-		return false, fmt.Errorf("'name' not supplied")
-	}
+	name := d.Id()
 	return userExists(m.(*resty.Client), name)
 }
 
@@ -179,7 +176,7 @@ func resourceUserCreate(d *schema.ResourceData, m interface{}) error {
 func resourceUserRead(rd *schema.ResourceData, m interface{}) error {
 	d := &ResourceData{rd}
 
-	userName := d.getString("name", false)
+	userName := d.Id()
 	user := &services.User{}
 	resp, err := m.(*resty.Client).R().SetResult(user).Get("artifactory/api/security/users/" + userName)
 

--- a/pkg/artifactory/resource_artifactory_user_test.go
+++ b/pkg/artifactory/resource_artifactory_user_test.go
@@ -37,6 +37,12 @@ func TestAccUser_basic(t *testing.T) {
 					resource.TestCheckNoResourceAttr(fqrn, "profile_updatable"),
 				),
 			},
+			{
+				ResourceName:            fqrn,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"}, // password is never returned via the API, so it cannot be "imported"
+			},
 		},
 	})
 }
@@ -67,6 +73,12 @@ func TestAccUser_full(t *testing.T) {
 					resource.TestCheckResourceAttr(FQRN, "profile_updatable", "true"),
 					resource.TestCheckResourceAttr(FQRN, "groups.#", "1"),
 				),
+			},
+			{
+				ResourceName:            FQRN,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"password"}, // password is never returned via the API, so it cannot be "imported"
 			},
 		},
 	})


### PR DESCRIPTION
In terraform's documentation, it is said that `schema.ImportStatePassthrough` relies on being able to do a `Refresh` solely with `d.Id()`: https://www.terraform.io/docs/extend/resources/import.html#importstateverifyignore
> This function requires the Read function to be able to refresh the entire resource with d.Id() ONLY. 

Although it's not very clear from the docs, but given we have `Exists` defined for `User` here, `Refresh` actually calls both the User's `.Exists` and `.Read`: https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/schema/resource.go#L575

Hence, both `.Exists` and `.Read` need to only rely on `d.Id()`.

NOTE: I've added toggles for testing User import in one of the acceptance tests, but I have not run the tests myself and verified that the tests pass. I have, however, ran the code fix on our artifactory instance and verified that I have successfully imported the user and the user attributes...