### PR TITLE
Add helm repo fields

### DIFF
--- a/docs/resources/artifactory_remote_repository.md
+++ b/docs/resources/artifactory_remote_repository.md
@@ -64,6 +64,7 @@ Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/c
 * `enable_cookie_management` - (Optional)
 * `client_tls_certificate` - (Optional)
 * `pypi_registry_url` - (Optional)
+* `helm_charts_base_url` - Base URL for the translation of chart source URLs in the index.yaml of virtual repos. Artifactory will only translate URLs matching the index.yamls hostname or URLs starting with this base url. (Optional)
 * `bypass_head_requests` - (Optional)
 * `enable_token_authentication` - (Optional)
 * `feed_context_path` - (Optional, Nuget repos only)

--- a/pkg/artifactory/resource_artifactory_remote_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository.go
@@ -13,6 +13,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
+type HelmRemoteRepositoryParams struct {
+	services.RemoteRepositoryBaseParams
+	HelmChartsBaseURL string `json:"chartsBaseUrl,omitempty"`
+}
+
 type MessyRemoteRepo struct {
 	services.RemoteRepositoryBaseParams
 	services.BowerRemoteRepositoryParams
@@ -21,6 +26,7 @@ type MessyRemoteRepo struct {
 	services.VcsRemoteRepositoryParams
 	services.PypiRemoteRepositoryParams
 	services.NugetRemoteRepositoryParams
+	HelmRemoteRepositoryParams
 	PropagateQueryParams bool `json:"propagateQueryParams"`
 }
 
@@ -266,6 +272,10 @@ func resourceArtifactoryRemoteRepository() *schema.Resource {
 				Optional: true,
 				Computed: true,
 			},
+			"helm_charts_base_url": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
 			"feed_context_path": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -362,6 +372,7 @@ func unpackRemoteRepo(s *schema.ResourceData) (MessyRemoteRepo, error) {
 	repo.UnusedArtifactsCleanupPeriodHours = d.getInt("unused_artifacts_cleanup_period_hours", true)
 	repo.Url = d.getString("url", true)
 	repo.Username = d.getString("username", true)
+	repo.HelmChartsBaseURL = d.getString("helm_charts_base_url", true)
 	repo.VcsGitDownloadUrl = d.getString("vcs_git_download_url", true)
 	repo.VcsGitProvider = d.getString("vcs_git_provider", true)
 	repo.VcsType = d.getString("vcs_type", true)
@@ -425,6 +436,7 @@ func packRemoteRepo(repo MessyRemoteRepo, d *schema.ResourceData) error {
 	setValue("unused_artifacts_cleanup_period_hours", repo.UnusedArtifactsCleanupPeriodHours)
 	setValue("url", repo.Url)
 	setValue("username", repo.Username)
+	setValue("helm_charts_base_url", repo.HelmChartsBaseURL)
 	setValue("vcs_git_download_url", repo.VcsGitDownloadUrl)
 	setValue("vcs_git_provider", repo.VcsGitProvider)
 	setValue("vcs_type", repo.VcsType)


### PR DESCRIPTION
Hi,

we are using Artifactory to store helm charts via remote repositories. Recently many chart repositories are hosting their chart tgz under a different URL than the index.yaml itself. 

Artifactory introduced a special field in helm remote repos to handle this case, namely the charts base URL. When this is set the base URL of charts is replaced with the correct artifactory URL in the index.yaml of a derived virtual repository.

This pull request adds this field. I tested this on Artifactory Version 7.21.5

