### PR TITLE
Project support for repo only

### DIFF
--- a/docs/resources/artifactory_local_repository.md
+++ b/docs/resources/artifactory_local_repository.md
@@ -18,6 +18,8 @@ Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/c
 
 * `key` - (Required)
 * `package_type` - (Required)
+* `project_key` - (Optional)
+* `environments`  - (Optional, ["DEV", "PROD"])
 * `description` - (Optional)
 * `notes` - (Optional)
 * `includes_pattern` - (Optional)

--- a/docs/resources/artifactory_remote_repository.md
+++ b/docs/resources/artifactory_remote_repository.md
@@ -33,6 +33,8 @@ Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/c
 * `key` - (Required)
 * `package_type` - (Required)
 * `url` - (Required)
+* `project_key` - (Optional)
+* `environments`  - (Optional, ["DEV", "PROD"])
 * `description` - (Optional)
 * `notes` - (Optional)
 * `includes_pattern` - (Optional)

--- a/docs/resources/artifactory_virtual_repository.md
+++ b/docs/resources/artifactory_virtual_repository.md
@@ -32,6 +32,8 @@ Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/c
 * `key` - (Required)
 * `package_type` - (Required)
 * `repositories` - (Required)
+* `project_key` - (Optional)
+* `environments`  - (Optional, ["DEV", "PROD"])
 * `description` - (Optional)
 * `notes` - (Optional)
 * `includes_pattern` - (Optional)

--- a/pkg/artifactory/resource_artifactory_local_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_repository.go
@@ -30,6 +30,16 @@ func resourceArtifactoryLocalRepository() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: repoKeyValidator,
 			},
+			"project_key": {
+				Type:         schema.TypeString,
+				Optional:     true,
+			},
+			"environments": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+				Optional: true,
+			},
 			"package_type": {
 				Type:         schema.TypeString,
 				Optional:     true,
@@ -162,6 +172,8 @@ func unmarshalLocalRepository(data *schema.ResourceData) MessyRepo {
 	repo.Rclass = "local"
 	repo.Key = d.getString("key", false)
 	repo.PackageType = d.getString("package_type", false)
+	repo.ProjectKey = d.getString("project_key", false)
+	repo.Environments = d.getString("environments")
 	repo.Description = d.getString("description", false)
 	repo.Notes = d.getString("notes", false)
 	repo.DebianTrivialLayout = d.getBoolRef("debian_trivial_layout", false)
@@ -233,6 +245,8 @@ func resourceLocalRepositoryRead(d *schema.ResourceData, m interface{}) error {
 	// type 'yum' is not to be supported, as this is really of type 'rpm'. When 'yum' is used on create, RT will
 	// respond with 'rpm' and thus confuse TF into think there has been a state change.
 	setValue("package_type", repo.PackageType)
+	setValue("project_key", repo.ProjectKey)
+	setValue("environments", schema.NewSet(schema.HashString, castToInterfaceArr(repo.Environments)))
 	setValue("description", repo.Description)
 	setValue("notes", repo.Notes)
 	setValue("includes_pattern", repo.IncludesPattern)

--- a/pkg/artifactory/resource_artifactory_local_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_local_repository_test.go
@@ -115,8 +115,8 @@ func TestAccLocalRepository_basic_with_project_key(t *testing.T) {
 	localRepositoryBasic := fmt.Sprintf(`
 		resource "artifactory_local_repository" "%s" {
 			key 	     = "%s"
-			project_key                     = "frog-proj"
-			environments                    = [ "DEV", "PROD" ]
+			project_key  = "frog-proj"
+			environments = [ "DEV", "PROD" ]
 		}
 	`, name, name) // we use randomness so that, in the case of failure and dangle, the next test can run without collision
 	resource.Test(t, resource.TestCase{

--- a/pkg/artifactory/resource_artifactory_local_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_local_repository_test.go
@@ -108,3 +108,33 @@ func TestAccAllRepoTypesLocal(t *testing.T) {
 		})
 	}
 }
+
+func TestAccLocalRepository_basic_with_project_key(t *testing.T) {
+	name := fmt.Sprintf("terraform-local-test-repo-basic-with-project-key%d", rand.Int())
+	resourceName := fmt.Sprintf("artifactory_local_repository.%s", name)
+	localRepositoryBasic := fmt.Sprintf(`
+		resource "artifactory_local_repository" "%s" {
+			key 	     = "%s"
+			project_key                     = "frog-proj"
+			environments                    = [ "DEV", "PROD" ]
+		}
+	`, name, name) // we use randomness so that, in the case of failure and dangle, the next test can run without collision
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckRepositoryDestroy(resourceName),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: localRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "key", name),
+					resource.TestCheckResourceAttr(resourceName, "package_type", "docker"),
+					resource.TestCheckResourceAttr(resourceName, "project_key", "frog-proj"),
+					resource.TestCheckResourceAttr(resourceName, "environments.#", "2"),
+					resource.TestCheckResourceAttr(resourceName, "environments.0", "DEV"),
+					resource.TestCheckResourceAttr(resourceName, "environments.1", "PROD"),
+				),
+			},
+		},
+	})
+}

--- a/pkg/artifactory/resource_artifactory_remote_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository.go
@@ -50,6 +50,16 @@ func resourceArtifactoryRemoteRepository() *schema.Resource {
 				Default:      "generic",
 				ValidateFunc: repoTypeValidator,
 			},
+			"project_key": {
+				Type:         schema.TypeString,
+				Optional:     true,
+			},
+			"environments": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+				Optional: true,
+			},
 			"description": {
 				Type:     schema.TypeString,
 				Optional: true,
@@ -348,6 +358,8 @@ func unpackRemoteRepo(s *schema.ResourceData) (MessyRemoteRepo, error) {
 	repo.Notes = d.getString("notes", true)
 	repo.Offline = d.getBoolRef("offline", true)
 	repo.PackageType = d.getString("package_type", true)
+	repo.ProjectKey = d.getString("project_key", false)
+	repo.Environments = d.getString("environments")
 	repo.Password = d.getString("password", true)
 	repo.PropertySets = d.getSet("property_sets")
 	repo.Proxy = d.getString("proxy", true)
@@ -406,6 +418,8 @@ func packRemoteRepo(repo MessyRemoteRepo, d *schema.ResourceData) error {
 	setValue("hard_fail", repo.HardFail)
 	setValue("includes_pattern", repo.IncludesPattern)
 	setValue("key", repo.Key)
+	setValue("project_key", repo.ProjectKey)
+	setValue("environments", schema.NewSet(schema.HashString, castToInterfaceArr(repo.Environments)))
 	setValue("local_address", repo.LocalAddress)
 	setValue("max_unique_snapshots", repo.MaxUniqueSnapshots)
 	setValue("missed_cache_period_seconds", repo.MissedRetrievalCachePeriodSecs)

--- a/pkg/artifactory/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository_test.go
@@ -281,3 +281,38 @@ func TestAccRemoteRepository_generic_with_propagate(t *testing.T) {
 		},
 	})
 }
+
+func TestAccRemoteRepository_basic_with_project_key(t *testing.T) {
+	id := rand.Int()
+	name := fmt.Sprintf("terraform-remote-test-repo-basic%d", id)
+	fqrn := fmt.Sprintf("artifactory_remote_repository.%s", name)
+	const remoteRepoBasic = `
+		resource "artifactory_remote_repository" "%s" {
+			key 				  = "%s"
+			package_type          = "npm"
+			url                   = "https://registry.npmjs.org/"
+			repo_layout_ref       = "npm-default"
+			project_key           = "frog-proj"
+			environments          = [ "DEV", "PROD" ]
+		}
+	`
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckRepositoryDestroy(fqrn),
+		Providers:    testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(remoteRepoBasic, name, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "npm"),
+					resource.TestCheckResourceAttr(fqrn, "url", "https://registry.npmjs.org/"),
+					resource.TestCheckResourceAttr(fqrn, "project_key", "frog-proj"),
+					resource.TestCheckResourceAttr(fqrn, "environments.#", "2"),
+					resource.TestCheckResourceAttr(fqrn, "environments.0", "DEV"),
+					resource.TestCheckResourceAttr(fqrn, "environments.1", "PROD"),
+				),
+			},
+		},
+	})
+}

--- a/pkg/artifactory/resource_artifactory_virtual_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_repository.go
@@ -32,6 +32,16 @@ func resourceArtifactoryVirtualRepository() *schema.Resource {
 				ForceNew:     true,
 				ValidateFunc: repoTypeValidator,
 			},
+			"project_key": {
+				Type:         schema.TypeString,
+				Optional:     true,
+			},
+			"environments": {
+				Type:     schema.TypeSet,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Set:      schema.HashString,
+				Optional: true,
+			},
 			"repositories": {
 				Type:     schema.TypeList,
 				Elem:     &schema.Schema{Type: schema.TypeString},
@@ -106,6 +116,8 @@ func unpackVirtualRepository(s *schema.ResourceData) MessyVirtualRepo {
 	repo.Key = d.getString("key", false)
 	repo.Rclass = "virtual"
 	repo.PackageType = d.getString("package_type", false)
+	repo.ProjectKey = d.getString("project_key", false)
+	repo.Environments = d.getString("environments")
 	repo.IncludesPattern = d.getString("includes_pattern", false)
 	repo.ExcludesPattern = d.getString("excludes_pattern", false)
 	repo.RepoLayoutRef = d.getString("repo_layout_ref", false)
@@ -129,6 +141,8 @@ func packVirtualRepository(repo MessyVirtualRepo, d *schema.ResourceData) error 
 
 	setValue("key", repo.Key)
 	setValue("package_type", repo.PackageType)
+	setValue("project_key", repo.ProjectKey)
+	setValue("environments", schema.NewSet(schema.HashString, castToInterfaceArr(repo.Environments)))
 	setValue("description", repo.Description)
 	setValue("notes", repo.Notes)
 	setValue("includes_pattern", repo.IncludesPattern)

--- a/pkg/artifactory/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_virtual_repository_test.go
@@ -233,3 +233,39 @@ func testAccCheckRepositoryDestroy(id string) func(*terraform.State) error {
 		return nil
 	}
 }
+
+
+func TestAccVirtualRepository_basic_with_project_key(t *testing.T) {
+	id := randomInt()
+	name := fmt.Sprintf("foo-with-project-key%d", id)
+	fqrn := fmt.Sprintf("artifactory_virtual_repository.%s", name)
+	const virtualRepositoryBasic = `
+		resource "artifactory_virtual_repository" "%s" {
+			key          = "%s"
+			package_type = "maven"
+			repositories = []
+			project_key = "frog-proj"
+			environments = [ "DEV", "PROD" ]
+		}
+	`
+	resource.Test(t, resource.TestCase{
+		PreCheck:     func() { testAccPreCheck(t) },
+		CheckDestroy: testAccCheckRepositoryDestroy(fqrn),
+		Providers:    testAccProviders,
+
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(virtualRepositoryBasic, name, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "maven"),
+					resource.TestCheckResourceAttr(fqrn, "repositories.#", "0"),
+					resource.TestCheckResourceAttr(fqrn, "project_key", "frog-proj"),
+					resource.TestCheckResourceAttr(fqrn, "environments.#", "2"),
+					resource.TestCheckResourceAttr(fqrn, "environments.0", "DEV"),
+					resource.TestCheckResourceAttr(fqrn, "environments.1", "PROD"),
+				),
+			},
+		},
+	})
+}

--- a/pkg/artifactory/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_virtual_repository_test.go
@@ -244,7 +244,7 @@ func TestAccVirtualRepository_basic_with_project_key(t *testing.T) {
 			key          = "%s"
 			package_type = "maven"
 			repositories = []
-			project_key = "frog-proj"
+			project_key  = "frog-proj"
 			environments = [ "DEV", "PROD" ]
 		}
 	`


### PR DESCRIPTION
Hi,

Little contrib to try to push forward the new feature `Project`. I have added the param needed to create a repo (local/virtual/remote) in project.

This pull request adds 2 params:
- project_key
- environments

I couldn't test it since I don't have access to an Artifactory licence.
