### PR TITLE
#173 Fix error with Xray policy resource

### DIFF
--- a/pkg/artifactory/resource_xray_policy.go
+++ b/pkg/artifactory/resource_xray_policy.go
@@ -498,7 +498,7 @@ func resourceXrayPolicyCreate(d *schema.ResourceData, m interface{}) error {
 
 func getPolicy(id string, client *resty.Client) (Policy, *resty.Response, error) {
 	policy := Policy{}
-	resp, err := client.R().SetResult(&policy).Put("xray/api/v1/policies/" + id)
+	resp, err := client.R().SetResult(&policy).Get("xray/api/v1/policies/" + id)
 	return policy, resp, err
 }
 func resourceXrayPolicyRead(d *schema.ResourceData, m interface{}) error {

--- a/sample.tf
+++ b/sample.tf
@@ -95,7 +95,6 @@ resource "artifactory_xray_policy" "test" {
 }
 resource "artifactory_virtual_go_repository" "baz-go" {
   key          = "baz-go"
-  package_type = "go"
   repo_layout_ref = "go-default"
   repositories = []
   description = "A test virtual repo"
@@ -111,7 +110,6 @@ resource "artifactory_virtual_go_repository" "baz-go" {
 
 resource "artifactory_virtual_maven_repository" "foo" {
   key          = "maven-virt-repo"
-  package_type = "maven"
   repo_layout_ref = "maven-2-default"
   repositories = []
   description = "A test virtual repo"


### PR DESCRIPTION
Remove package_type for go and maven virtual repos from .tf file. Type is assigned automatically.