### PR TITLE
Allows underscores in repository keys.

### DIFF
--- a/pkg/artifactory/repositories.go
+++ b/pkg/artifactory/repositories.go
@@ -227,7 +227,7 @@ var repoTypeValidator = validation.StringInSlice(repoTypesSupported, false)
 
 var repoKeyValidator = validation.All(
 	validation.StringDoesNotMatch(regexp.MustCompile("^[0-9].*"), "repo key cannot start with a number"),
-	validation.StringDoesNotContainAny(" !@#$%^&*()_+={}[]:;<>,/?~`|\\"),
+	validation.StringDoesNotContainAny(" !@#$%^&*()+={}[]:;<>,/?~`|\\"),
 )
 
 var repoTypesSupported = []string{

--- a/pkg/artifactory/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository_test.go
@@ -10,10 +10,10 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-func TestAccLocalAllowDotsAndDashesInKeyGH129(t *testing.T) {
+func TestAccLocalAllowDotsUnderscorersAndDashesInKeyGH129(t *testing.T) {
 	_, fqrn, name := mkNames("terraform-local-test-repo-basic", "artifactory_remote_repository")
 
-	key := fmt.Sprintf("debian-remote.teleport%d", randomInt())
+	key := fmt.Sprintf("debian-remote.teleport_%d", randomInt())
 	localRepositoryBasic := fmt.Sprintf(`
 		resource "artifactory_remote_repository" "%s" {
 			key              = "%s"
@@ -40,10 +40,11 @@ func TestAccLocalAllowDotsAndDashesInKeyGH129(t *testing.T) {
 		},
 	})
 }
+
 func TestKeyHasSpecialCharsFails(t *testing.T) {
 	const failKey = `
 		resource "artifactory_remote_repository" "terraform-remote-test-repo-basic" {
-			key                     = "IHave++special_Chars"
+			key                     = "IHave++special,Chars"
 			package_type            = "npm"
 			url                     = "https://registry.npmjs.org/"
 			repo_layout_ref         = "npm-default"


### PR DESCRIPTION
Relates to #129 

Similarly to dots and dashes, use of underscores in repository names is fairly common and allowed by the Artifactory API.

This PR permits underscores in names again.