### PR TITLE
enable to use wildcard in access_token's group

### DIFF
--- a/pkg/artifactory/resource_artifactory_access_token.go
+++ b/pkg/artifactory/resource_artifactory_access_token.go
@@ -300,9 +300,10 @@ func unpackGroups(d *schema.ResourceData, client *resty.Client, tokenOptions *Ac
 		for i, group := range srcGroups.([]interface{}) {
 			groups[i] = group.(string)
 
-			exist, err := checkGroupExists(client, groups[i])
-			if !exist && groups[i] != "*" {
-				return err
+			if groups[i] != "*" {
+				if exist, err := checkGroupExists(client, groups[i]); !exist {
+					return err
+				}
 			}
 		}
 

--- a/pkg/artifactory/resource_artifactory_access_token.go
+++ b/pkg/artifactory/resource_artifactory_access_token.go
@@ -300,7 +300,8 @@ func unpackGroups(d *schema.ResourceData, client *resty.Client, tokenOptions *Ac
 		for i, group := range srcGroups.([]interface{}) {
 			groups[i] = group.(string)
 
-			if exist, err := checkGroupExists(client, groups[i]); !exist {
+			exist, err := checkGroupExists(client, groups[i])
+			if !exist && groups[i] != "*" {
 				return err
 			}
 		}


### PR DESCRIPTION
According to https://github.com/jfrog/terraform-provider-artifactory/blob/master/docs/resources/artifactory_access_token.md?plain=1#L169, the wildcard is allowed in groups attribute of access_token resource.
However, an error occurs because there is no group named `*`.

### Test Result
```
$ go test ./pkg/... -run TestAccAccessToken
ok      github.com/jfrog/terraform-provider-artifactory/pkg/artifactory 47.587s
```