### PR TITLE
Make the single repo deprecation more clear

### DIFF
--- a/pkg/artifactory/resource_artifactory_single_replication_config.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config.go
@@ -25,7 +25,7 @@ func resourceArtifactorySingleReplicationConfig() *schema.Resource {
 
 		Schema: mergeSchema(replicationSchemaCommon, replicationSchema),
 		Description: "Used for configuring replications on repos. However, the TCL only makes " +
-			"good sense for local repo replication (PUSH) and not remote (PULL).",
+			"good sense for remote (PULL) repo replication (PUSH) and not local (PUSH).",
 		DeprecationMessage: "The APIs underpinning this resource support local and remote repository replication, " +
 			"but their payloads are entirely different. You should only use this for remote repository replication.",
 	}

--- a/pkg/artifactory/resource_artifactory_single_replication_config.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config.go
@@ -26,8 +26,8 @@ func resourceArtifactorySingleReplicationConfig() *schema.Resource {
 		Schema: mergeSchema(replicationSchemaCommon, replicationSchema),
 		Description: "Used for configuring replications on repos. However, the TCL only makes " +
 			"good sense for local repo replication (PUSH) and not remote (PULL).",
-		DeprecationMessage: "The APIs underpinning this resource support local and remote replication, " +
-			"but their payloads are entirely different. You should only use this for local replication.",
+		DeprecationMessage: "The APIs underpinning this resource support local and remote repository replication, " +
+			"but their payloads are entirely different. You should only use this for remote repository replication.",
 	}
 }
 


### PR DESCRIPTION
The original intended use for `artifactory_single_replication_config` is to support Pull replication, i.e. replication for remote repositories. The underlying API used by `artifactory_replication_config` does not support pull replication. The deprecation warning, of which I'm unclear should really exist, suggests it should only be used for local repository replication, which is incorrect. Whilst I have updated the message here, it's actually very disruptive to have it without a way of migrating to something else. For reference, in one of our configs I've got ~450 warning about this "deprecation", which doesn't help when trying to work out what has changed.

It's probably worthwhile thinking about creating some new resources, for example `artifactory_pull_replication_config` and `artifactory_push_replication_config` to replace the existing ones. If I get time I could contribute something like this back. Maybe the message should be removed until these have been created