### PR TITLE
Fix Pipelines, keep ARTIFACTORY_USERNAME var, because it used in the …

### DIFF
--- a/TFproviderTest.yml
+++ b/TFproviderTest.yml
@@ -192,8 +192,8 @@ pipelines:
                                   --header "x-requested-with: XMLHttpRequest" \
                                   --header "cookie: ACCESSTOKEN=${ACCESSTOKEN}; REFRESHTOKEN=${REFRESHTOKEN}")
             - add_run_variables ARTIFACTORY_ACCESS_TOKEN=${ACCESS_KEY}
-            - echo "Unset ARTIFACTORY_USERNAME and ARTIFACTORY_PASSWORD, acceptance test will use ARTIFACTORY_ACCESS_TOKEN instead"
-            - unset ARTIFACTORY_USERNAME && unset ARTIFACTORY_PASSWORD
+            - echo "Unset ARTIFACTORY_PASSWORD, acceptance test will use ARTIFACTORY_ACCESS_TOKEN instead"
+            - unset ARTIFACTORY_PASSWORD
             - export TF_ACC=1
             - make acceptance
             - make install


### PR DESCRIPTION
…replication tests now