### PR TITLE
Fix failed replication test

### DIFF
--- a/pkg/artifactory/resource_artifactory_pull_replication_test.go
+++ b/pkg/artifactory/resource_artifactory_pull_replication_test.go
@@ -16,11 +16,13 @@ func mkTclForPullRepConfg(name, cron, url string) string {
 			key = "%s"
 			package_type = "maven"
 		}
-		
+
 		resource "artifactory_pull_replication" "%s" {
 			repo_key = "${artifactory_local_repository.%s.key}"
-			cron_exp = "%s" 
+			cron_exp = "%s"
 			enable_event_replication = true
+			url = "%s"
+			username = "%s"
 		}
 	`
 	return fmt.Sprintf(tcl,
@@ -29,6 +31,8 @@ func mkTclForPullRepConfg(name, cron, url string) string {
 		name,
 		name,
 		cron,
+		url,
+		os.Getenv("ARTIFACTORY_USERNAME"),
 	)
 }
 func TestInvalidCronPullReplication(t *testing.T) {
@@ -97,7 +101,7 @@ func TestAccPullReplicationRemoteRepo(t *testing.T) {
 
 		resource "artifactory_pull_replication" "{{ .repoconfig_name }}" {
 			repo_key = "{{ .remote_name }}"
-			cron_exp = "0 0 12 ? * MON *" 
+			cron_exp = "0 0 12 ? * MON *"
 			enable_event_replication = false
 			depends_on = [artifactory_remote_repository.{{ .remote_name }}]
 		}

--- a/pkg/artifactory/resource_artifactory_single_replication_config_test.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config_test.go
@@ -15,10 +15,10 @@ func mkTclForRepConfg(name, cron, url string) string {
 			key = "%s"
 			package_type = "maven"
 		}
-		
+
 		resource "artifactory_single_replication_config" "%s" {
 			repo_key = "${artifactory_local_repository.%s.key}"
-			cron_exp = "%s" 
+			cron_exp = "%s"
 			enable_event_replication = true
 			url = "%s"
 			username = "%s"
@@ -105,16 +105,17 @@ func TestAccSingleReplicationRemoteRepo(t *testing.T) {
 
 		resource "artifactory_single_replication_config" "{{ .repoconfig_name }}" {
 			repo_key = "{{ .remote_name }}"
-			cron_exp = "0 0 12 ? * MON *" 
+			cron_exp = "0 0 12 ? * MON *"
 			enable_event_replication = false
 			url = "https://repo1.maven.org/maven2/"
-			username = "christianb"
+			username = "{{ .username }}"
 			depends_on = [artifactory_remote_repository.{{ .remote_name }}]
 		}
 	`
 	tcl = executeTemplate("foo", tcl, map[string]string{
 		"repoconfig_name": name,
 		"remote_name":     repo_name,
+		"username":        os.Getenv("ARTIFACTORY_USERNAME"),
 	})
 	resource.Test(t, resource.TestCase{
 		CheckDestroy: compositeCheckDestroy(


### PR DESCRIPTION
Fix failed test in #216.

Turns out more involved than I expected. But the final changes are straightforward. Doesn't help that Artifactory sometimes return the replication payload as an array with single item (vs single object).

@jamestoyer Not sure if the differences in JSON payload from Artifactory is due to versions. We are running the latest released version 7.27.10.