### PR TITLE
Fix response status code checking

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,6 +10,7 @@ install:
 	mkdir -p terraform.d/plugins/registry.terraform.io/jfrog/artifactory/${NEXT_VERSION}/darwin_amd64 && \
 		(test -f terraform-provider-artifactory || go build -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}'") && \
 		mv terraform-provider-artifactory terraform.d/plugins/registry.terraform.io/jfrog/artifactory/${NEXT_VERSION}/darwin_amd64 && \
+		sed -i 's/version = ".*"/version = "${NEXT_VERSION}"/' sample.tf && \
 		terraform init
 
 clean:
@@ -26,8 +27,8 @@ debug_install:
 	mkdir -p terraform.d/plugins/registry.terraform.io/jfrog/artifactory/${NEXT_VERSION}/darwin_amd64 && \
 		(test -f terraform-provider-artifactory || go build -gcflags "all=-N -l" -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}-develop'") && \
 		mv terraform-provider-artifactory terraform.d/plugins/registry.terraform.io/jfrog/artifactory/${NEXT_VERSION}/darwin_amd64 && \
+		sed -i 's/version = ".*"/version = "${NEXT_VERSION}"/' sample.tf && \
 		terraform init
-
 
 test:
 	@echo "==> Starting unit tests"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -13,7 +13,7 @@ install:
 		terraform init
 
 clean:
-	rm -fR .terraform.d/ .terraform terraform.tfstate* terraform.d/
+	rm -fR .terraform.d/ .terraform terraform.tfstate* terraform.d/ .terraform.lock.hcl
 
 release:
 	@git tag ${NEXT_VERSION} && git push --mirror
@@ -37,10 +37,9 @@ attach:
 	dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient attach $$(pgrep terraform-provider-artifactory)
 
 acceptance: fmtcheck
-	export TF_ACC=1
-	test -n ARTIFACTORY_USERNAME && test -n ARTIFACTORY_PASSWORD && test -n ARTIFACTORY_URL \
+	export TF_ACC=true && \
+		test -n ARTIFACTORY_USERNAME && test -n ARTIFACTORY_PASSWORD && test -n ARTIFACTORY_URL \
 		&& go test -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}-test'" -v -parallel 20 ./pkg/...
-
 
 fmt:
 	@echo "==> Fixing source code with gofmt..."

--- a/pkg/artifactory/provider.go
+++ b/pkg/artifactory/provider.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version for some reason isn't getting updated by the linker
-var Version = "2.6.20"
+var Version = "2.6.18"
 
 // Provider Artifactory provider that supports configuration via username+password or a token
 // Supported resources are repos, users, groups, replications, and permissions

--- a/pkg/artifactory/provider.go
+++ b/pkg/artifactory/provider.go
@@ -11,7 +11,7 @@ import (
 )
 
 // Version for some reason isn't getting updated by the linker
-var Version = "2.6.18"
+var Version = "2.6.20"
 
 // Provider Artifactory provider that supports configuration via username+password or a token
 // Supported resources are repos, users, groups, replications, and permissions

--- a/pkg/artifactory/repositories.go
+++ b/pkg/artifactory/repositories.go
@@ -208,7 +208,6 @@ func checkRepo(id string, request *resty.Request) (*resty.Response, error) {
 func repoExists(d *schema.ResourceData, m interface{}) (bool, error) {
 	_, err := checkRepo(d.Id(), m.(*resty.Client).R().AddRetryCondition(retry400))
 	return err == nil, err
-
 }
 
 var repoTypeValidator = validation.StringInSlice(repoTypesSupported, false)

--- a/pkg/artifactory/repositories.go
+++ b/pkg/artifactory/repositories.go
@@ -155,7 +155,7 @@ func mkRepoRead(pack PackFunc, construct Constructor) schema.ReadContextFunc {
 		resp, err := m.(*resty.Client).R().SetResult(repo).Get(repositoriesEndpoint + d.Id())
 
 		if err != nil {
-			if resp != nil && (resp.StatusCode() == http.StatusNotFound) {
+			if resp != nil && (resp.StatusCode() == http.StatusBadRequest || resp.StatusCode() == http.StatusNotFound) {
 				d.SetId("")
 				return nil
 			}
@@ -185,7 +185,7 @@ func mkRepoUpdate(unpack UnpackFunc, read schema.ReadContextFunc) schema.UpdateC
 func deleteRepo(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	resp, err := m.(*resty.Client).R().Delete(repositoriesEndpoint + d.Id())
 
-	if err != nil && (resp != nil && resp.StatusCode() == http.StatusNotFound) {
+	if err != nil && (resp != nil && (resp.StatusCode() == http.StatusBadRequest || resp.StatusCode() == http.StatusNotFound)) {
 		d.SetId("")
 		return nil
 	}

--- a/sample.tf
+++ b/sample.tf
@@ -206,5 +206,3 @@ resource "artifactory_virtual_maven_repository" "foo" {
   force_maven_authentication               = true
   pom_repository_references_cleanup_policy = "discard_active_reference"
 }
-
-


### PR DESCRIPTION
Fix #221 

Artifactory API for `GET /api/repositories/{{repo_key}}` returns 400 status code for missing/not found repo. Update code to check for 400 as well as 404. This will ensure TF understands the repo is missing and requires to be re-created.