### PR TITLE
Stop 404s for permission and user "exists" requests causing errors

### DIFF
--- a/pkg/artifactory/resource_artifactory_group.go
+++ b/pkg/artifactory/resource_artifactory_group.go
@@ -2,6 +2,7 @@ package artifactory
 
 import (
 	"fmt"
+	"net/http"
 
 	"github.com/go-resty/resty/v2"
 
@@ -197,7 +198,12 @@ func resourceGroupExists(d *schema.ResourceData, m interface{}) (bool, error) {
 }
 
 func groupExists(client *resty.Client, groupName string) (bool, error) {
-	_, err := client.R().Head(groupsEndpoint + groupName)
+	resp, err := client.R().Head(groupsEndpoint + groupName)
+	if err != nil && resp != nil && resp.StatusCode() == http.StatusNotFound {
+		// Do not error on 404s as this causes errors when the upstream user has been manually removed
+		return false, nil
+	}
+
 	return err == nil, err
 }
 

--- a/pkg/artifactory/resource_artifactory_permission_target.go
+++ b/pkg/artifactory/resource_artifactory_permission_target.go
@@ -338,7 +338,11 @@ func resourcePermissionTargetExists(d *schema.ResourceData, m interface{}) (bool
 }
 
 func permTargetExists(id string, m interface{}) (bool, error) {
-	_, err := m.(*resty.Client).R().Head(permissionsEndPoint + id)
+	resp, err := m.(*resty.Client).R().Head(permissionsEndPoint + id)
+	if err != nil && resp != nil && resp.StatusCode() == http.StatusNotFound {
+		// Do not error on 404s as this causes errors when the upstream permission has been manually removed
+		return false, nil
+	}
 
 	return err == nil, err
 }

--- a/pkg/artifactory/resource_artifactory_user.go
+++ b/pkg/artifactory/resource_artifactory_user.go
@@ -102,7 +102,12 @@ func resourceUserExists(data *schema.ResourceData, m interface{}) (bool, error) 
 }
 
 func userExists(client *resty.Client, userName string) (bool, error) {
-	_, err := client.R().Head("artifactory/api/security/users/" + userName)
+	resp, err := client.R().Head("artifactory/api/security/users/" + userName)
+	if err != nil && resp != nil && resp.StatusCode() == http.StatusNotFound {
+		// Do not error on 404s as this causes errors when the upstream user has been manually removed
+		return false, nil
+	}
+
 	return err == nil, err
 }
 


### PR DESCRIPTION
When a permission or user that is managed by Terraform is deleted from Artifactory manually the provider will error out as it does not treat a 404 as it not existing. This means it's impossible to get a clean plan without manually re-adding the permission or user, defeating the object of managing it in Terraform. This fixes that by checking for a 404 and returning `false` when that happens.

I'm also aware that `Exists` goes away with later Terraform provider framework versions, but this is how it's currently done, so I thought it'd be best to just update the current function.

@alexhung and @chb0github 