### PR TITLE
Use singular form of the license API endpoint

### DIFF
--- a/pkg/artifactory/provider.go
+++ b/pkg/artifactory/provider.go
@@ -235,7 +235,7 @@ func checkArtifactoryLicense(client *resty.Client) error {
 	licensesWrapper := LicensesWrapper{}
 	_, err := client.R().
 		SetResult(&licensesWrapper).
-		Get("/artifactory/api/system/licenses")
+		Get("/artifactory/api/system/license")
 
 	if err != nil {
 		return fmt.Errorf("Failed to check for license. If your usage doesn't require admin permission, you can set `check_license` attribute to `false` to skip this check. %s", err)


### PR DESCRIPTION
This works for both on-prem and SaaS versions.