### PR TITLE
:sparkles: Add support for priority resolution in local repositories

### DIFF
--- a/docs/resources/artifactory_local_repository.md
+++ b/docs/resources/artifactory_local_repository.md
@@ -38,7 +38,7 @@ Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/c
 * `yum_root_depth` - (Optional) 
 * `docker_api_version` - (Optional) 
 * `enable_file_lists_indexing` - (Optional) 
-* `force_nuget_authentication` - (Optional, Nuget repos only) 
+* `force_nuget_authentication` - (Optional, Nuget repos only)
 
 ## Import
 

--- a/pkg/artifactory/repositories.go
+++ b/pkg/artifactory/repositories.go
@@ -30,6 +30,7 @@ type LocalRepositoryBaseParams struct {
 	PropertySets           []string `hcl:"property_sets" json:"propertySets,omitempty"`
 	ArchiveBrowsingEnabled *bool    `hcl:"archive_browsing_enabled" json:"archiveBrowsingEnabled,omitempty"`
 	DownloadRedirect       *bool    `hcl:"download_direct" json:"downloadRedirect,omitempty"`
+	PriorityResolution     bool     `hcl:"priority_resolution" json:"priorityResolution"`
 }
 
 var compressionFormats = map[string]*schema.Schema{
@@ -316,6 +317,12 @@ var baseLocalRepoSchema = map[string]*schema.Schema{
 		Optional: true,
 		Computed: true,
 	},
+	"priority_resolution": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+		Description: "Setting repositories with priority will cause metadata to be merged only from repositories set with this field",
+	},
 	"property_sets": {
 		Type:     schema.TypeSet,
 		Elem:     &schema.Schema{Type: schema.TypeString},
@@ -519,9 +526,10 @@ var baseRemoteSchema = map[string]*schema.Schema{
 		Description: "Before caching an artifact, Artifactory first sends a HEAD request to the remote resource. In some remote resources, HEAD requests are disallowed and therefore rejected, even though downloading the artifact is allowed. When checked, Artifactory will bypass the HEAD request and cache the artifact directly using a GET request.",
 	},
 	"priority_resolution": {
-		Type:     schema.TypeBool,
-		Optional: true,
-		Computed: true,
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Computed:    true,
+		Description: "Setting repositories with priority will cause metadata to be merged only from repositories set with this field",
 	},
 	"client_tls_certificate": {
 		Type:     schema.TypeString,
@@ -620,6 +628,7 @@ func unpackBaseLocalRepo(s *schema.ResourceData, packageType string) LocalReposi
 		PropertySets:           d.getSet("property_sets"),
 		XrayIndex:              d.getBoolRef("xray_index", false),
 		DownloadRedirect:       d.getBoolRef("download_direct", false),
+		PriorityResolution:     d.getBool("priority_resolution", false),
 	}
 }
 func unpackBaseRemoteRepo(s *schema.ResourceData, packageType string) RemoteRepositoryBaseParams {

--- a/pkg/artifactory/resource_artifactory_local_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_local_repository_test.go
@@ -439,11 +439,13 @@ func TestAccLocalGenericRepository(t *testing.T) {
 
 	_, fqrn, name := mkNames("generic-local", "artifactory_local_generic_repository")
 	params := map[string]interface{}{
-		"name": name,
+		"name":                name,
+		"priority_resolution": randBool(),
 	}
 	localRepositoryBasic := executeTemplate("TestAccLocalGenericRepository", `
 		resource "artifactory_local_generic_repository" "{{ .name }}" {
 		  key                 = "{{ .name }}"
+			priority_resolution = "{{ .priority_resolution }}"
 		}
 	`, params)
 	resource.Test(t, resource.TestCase{
@@ -455,6 +457,7 @@ func TestAccLocalGenericRepository(t *testing.T) {
 				Config: localRepositoryBasic,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "priority_resolution", fmt.Sprintf("%t", params["priority_resolution"])),
 				),
 			},
 		},

--- a/sample.tf
+++ b/sample.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     artifactory = {
       source  = "registry.terraform.io/jfrog/artifactory"
-      version = "2.6.22"
+      version = "2.7.1"
     }
   }
 }


### PR DESCRIPTION
Add priority resolution field to local repo base so it is
possible to enable this security flag on local repos.

Solves https://github.com/jfrog/terraform-provider-artifactory/issues/266