### PR TITLE
First pass at documentation cleanup.

### DIFF
--- a/docs/data-sources/artifactory_file.md
+++ b/docs/data-sources/artifactory_file.md
@@ -4,11 +4,10 @@ Provides an Artifactory file datasource. This can be used to download a file fro
 
 ## Example Usage
 
-```hcl
-# 
+```hcl 
 data "artifactory_file" "my-file" {
-   repository = "repo-key"
-   path = "/path/to/the/artifact.zip"
+   repository  = "repo-key"
+   path        = "/path/to/the/artifact.zip"
    output_path = "tmp/artifact.zip"
 }
 ```
@@ -18,22 +17,35 @@ data "artifactory_file" "my-file" {
 The following arguments are supported:
 
 * `repository` - (Required) Name of the repository where the file is stored.
+
 * `path` - (Required) The path to the file within the repository.
+
 * `output_path` - (Required) The local path the file should be downloaded to.
-* `force_overwrite` - (Optional) If set to true, an existing file in the output_path will be overwritten. Default: false
+
+* `force_overwrite` - (Optional) If set to `true`, an existing file in the `output_path` will be overwritten. If set to `false`, any existing file in the `output_path` location will prevent the download from writing to that location on disk. The default value is `false`.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `created` - The time & date when the file was created.
-* `created_by` - The user who created the file.
-* `last_modified` - The time & date when the file was last modified.
-* `modified_by` - The user who last modified the file.
-* `last_updated` - The time & date when the file was last updated.
+* `created` - The timestamp for when the file was created.
+
+* `created_by` - The Artifactory user who created the file.
+
+* `last_modified` - The timestamp when the file was last modified.
+
+* `modified_by` - The Artifactory user who last modified the file.
+
+* `last_updated` - The timestamp when the file was last updated.
+
 * `mimetype` - The mimetype of the file.
-* `size` - The size of the file.
+
+* `size` - The size of the file, in bytes.
+
 * `download_uri` - The URI that can be used to download the file.
+
 * `md5` - MD5 checksum of the file.
+
 * `sha1` - SHA1 checksum of the file.
+
 * `sha256` - SHA256 checksum of the file.

--- a/docs/data-sources/artifactory_file.md
+++ b/docs/data-sources/artifactory_file.md
@@ -42,7 +42,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `size` - The size of the file, in bytes.
 
-* `download_uri` - The URI that can be used to download the file.
+* `download_uri` - The URL that can be used to download the file.
 
 * `md5` - MD5 checksum of the file.
 

--- a/docs/data-sources/artifactory_fileinfo.md
+++ b/docs/data-sources/artifactory_fileinfo.md
@@ -1,14 +1,13 @@
-# Artifactory File Info Data Source
+# Artifactory FileInfo Data Source
 
-Provides an Artifactory fileinfo datasource. This can be used to read metadata of files stored in Artifactory repositories.
+Provides an Artifactory FileInfo datasource. This can be used to read metadata of files stored in Artifactory repositories.
 
 ## Example Usage
 
 ```hcl
-# 
 data "artifactory_fileinfo" "my-file" {
    repository = "repo-key"
-   path = "/path/to/the/artifact.zip" 
+   path       = "/path/to/the/artifact.zip" 
 }
 ```
 
@@ -17,20 +16,31 @@ data "artifactory_fileinfo" "my-file" {
 The following arguments are supported:
 
 * `repository` - (Required) Name of the repository where the file is stored.
+
 * `path` - (Required) The path to the file within the repository.
 
 ## Attribute Reference
 
 In addition to all arguments above, the following attributes are exported:
 
-* `created` - The time & date when the file was created.
-* `created_by` - The user who created the file.
-* `last_modified` - The time & date when the file was last modified.
-* `modified_by` - The user who last modified the file.
-* `last_updated` - The time & date when the file was last updated.
+* `created` - The timestamp for when the file was created.
+
+* `created_by` - The Artifactory user who created the file.
+
+* `last_modified` - The timestamp when the file was last modified.
+
+* `modified_by` - The Artifactory user who last modified the file.
+
+* `last_updated` - The timestamp when the file was last updated.
+
 * `mimetype` - The mimetype of the file.
-* `size` - The size of the file.
+
+* `size` - The size of the file, in bytes.
+
 * `download_uri` - The URI that can be used to download the file.
+
 * `md5` - MD5 checksum of the file.
+
 * `sha1` - SHA1 checksum of the file.
+
 * `sha256` - SHA256 checksum of the file.

--- a/docs/data-sources/artifactory_fileinfo.md
+++ b/docs/data-sources/artifactory_fileinfo.md
@@ -37,7 +37,7 @@ In addition to all arguments above, the following attributes are exported:
 
 * `size` - The size of the file, in bytes.
 
-* `download_uri` - The URI that can be used to download the file.
+* `download_uri` - The URL that can be used to download the file.
 
 * `md5` - MD5 checksum of the file.
 

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,51 +1,56 @@
-#  Debugging a TerraForm provider 
+#  Debugging a Terraform provider 
 
-## Understanding the design
+## Understanding the Design
 
-In order to do it, you first have to understand how Go builds apps, and then how terraform works with it.
+In order to do debug, you first have to understand how Go builds apps, and then how Terraform works with it.
 
-Every terraform provider is a sort of `module`. In order to support an open, modular system, in almost any language, you need to be able to dynamically load modules and interact with them. Terraform is no exception.
+Every Terraform provider is a sort of `module`. In order to support an open, modular system, in almost any language, you need to be able to dynamically load modules and interact with them. Terraform is no exception.
 
-However, the go lang team long ago decided to compile to statically linked applications; 
-any dependencies you have will be compiled into 1 single binary. Unlike in other native languages (like C, or C++), a 
-`.dll` or `.so` is not used; there is no dynamic library to load at runtime and thus, modularity becomes a whole other trick.
-This is done to avoid the notorious **dll hell** that was so common up until most modern systems included some 
-kind of dependency management. And yes, it can still be an issue.
+However, the Golang team long ago decided to compile to statically linked applications; any dependencies you have will be compiled into a single binary. Unlike in other native languages (like C, or C++), a `.dll` or `.so` is not used; there is no dynamic library to load at runtime and thus, modularity becomes a whole other trick. This is done to avoid the notorious **dll hell** that was so common up until most modern systems included some kind of dependency management. And yes, it can still be an issue.
 
-Every terraform provider is its own mini RPC server. When terraform runs your provider, it actually starts a new process that is your provider, and connects to it through 
-this RPC channel. Compounding the problem is that the lifetime of your provider process is very much 
-ephemeral; potentially lasting no more and a few seconds. It's this process you need to connect to with your debugger
+Every Terraform provider is its own mini gRPC server. When the Terraform client runs your provider, it actually starts a new process that is your provider, and connects to it through this gRPC channel. In other words, the `terraform` binary is the gRPC _client_, and the Terraform provider is the gRPC _server_. Compounding the problem is that the lifetime of your provider process is ephemeral, potentially lasting no more than a few seconds. It's this process where you need to connect with your debugger.
 
-### Normal debugging
-Normally, you would directly spin-up your app, and it would load modules into application memory. That's why you can actually
-debug it, because your debugger knows how to find the exact memory address for your provider. However, you don't have 
-this arrangement, and you need to do a _remote_ debug session. 
+### Normal Debugging
 
-### The conundrum
-So, you don't load terraform directly, and even if you did, your `module` (a.k.a your provider) is in the memory 
-space of an entirely different process; and that lasts no more than a few seconds, potentially.  
+Normally, you would directly spin-up your app, and it would load modules into application memory. That's why you can actually debug it, because your debugger knows how to find the exact memory address for your provider. However, you don't have this arrangement, and you need to do a _remote_ debug session.
 
-## The solution
+### The Conundrum
+
+So, you don't load Terraform directly, and even if you did, your provider (e.g., gRPC server) is in the memory space of an entirely different process; and that lasts no more than a few seconds.
+
+## The Solution
 
 1. You need the debugging tool [delve](https://github.com/go-delve/delve).
-2. You are going to have to place a little bit of shim code close to the spot in the code where you want to begin
-debugging. We need to stop this provider process from exiting before we can connect. So, put this bit of code in place:
-```go
-	connected := false
-	for !connected {
-		time.Sleep(time.Second) // set breakpoint here
-	}
-```
-This code effectively creates an infinite sleep loop; but that's actually essential to solving the problem.
 
-3. Place a break point right inside this loop. It won't do anything, yet. 
-4. Now run the terraform commands you need to, to engage the code you're desiring to debug. Upon doing so,
-terraform will basically stop, as it waits on a response from you provider; because you put an infinite sleep loop in
-5. You must now tell `delve` to connect to this remote process using it's PID. This isn't as hard as it seems.
-Run this commands:
-`dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient attach $(pgrep terraform-provider-artifactory)`
-The last argument gets the `PID` for your provider and supplies it to `delve` to connect. Immediately upon running this 
-command, you're going to hit your break point. Please make sure to substitute `terraform-provider-artifactory` for your provider name
-6. To exit this infinite loop, use your debugger to set `connected` to `true`. By doing so you change the loop predicate 
+1. You are going to have to place a little bit of shim code close to the spot in the code where you want to begin debugging. We need to stop this provider process from exiting before we can connect. So, put this bit of code in place:
+
+    ```go
+    connected := false
+    for !connected {
+        time.Sleep(time.Second) // set breakpoint here
+    }
+    ```
+
+    This code creates an infinite sleep loop, but it's essential to solving the problem.
+
+1. Place a break point right inside this loop. It won't do anything, yet.
+
+1. Now run the Terraform commands you need to, to engage the code you're desiring to debug. Upon doing so, Terraform will stop as it waits on a response from your provider.
+
+1. You must now tell `delve` to connect to this remote process using it's PID. This isn't as hard as it seems. Run these commands:
+
+    ```bash
+    dlv \
+        --listen=:2345 \
+        --headless=true \
+        --api-version=2 \
+        --accept-multiclient attach \
+        $(pgrep terraform-provider-artifactory)
+    ```
+
+    The last argument gets the `PID` for your provider and supplies it to `delve` to connect. Immediately upon running this command, you're going to hit your break point. Please make sure to substitute `terraform-provider-artifactory` for your provider name.
+
+1. To exit this infinite loop, use your debugger to set `connected` to `true`. By doing so you change the loop predicate 
 and it will exit this loop on the next iteration.
-7. *DEBUG!* - At this point you can, step, watch, drop the call stack, etc. Your whole arsenel is available
+
+1. _DEBUG!_ - At this point you can, step, watch, drop the call stack, etc. Your entire arsenal is available.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,18 +1,12 @@
 # Artifactory Provider
 
-The [Artifactory](https://jfrog.com/artifactory/) provider is used to interact with the
-resources supported by Artifactory. The provider needs to be configured
-with the proper credentials before it can be used.
+The [Artifactory](https://jfrog.com/artifactory/) provider is used to interact with the resources supported by Artifactory. The provider needs to be configured with the proper credentials before it can be used.
 
-Links to documentation for specific resources can be found in the table of
-contents to the left.
+Links to documentation for specific resources can be found in the table of contents to the left.
 
-This provider requires access to Artifactory APIs, which are only available in the _licensed_ pro and enterprise editions.
-You can determine which license you have by accessing the following URL
-`${host}/artifactory/api/system/licenses/`
+This provider requires access to Artifactory APIs, which are only available in the _licensed_ pro and enterprise editions. You can determine which license you have by accessing: `${host}/artifactory/api/system/licenses/`.
 
-You can either access it via api, or web browser - it does require admin level credentials, but it's one of the few
-APIs that will work without a license (side node: you can also install your license here with a `POST`)
+You can either access the endpoint via API or web browser. It does require admin-level credentials, but it's one of the few APIs that will work without a license. (Side Note: You can also install your license here with a `POST` request).
 
 ```bash
 curl -sL ${host}/artifactory/api/system/licenses/ | jq .
@@ -21,17 +15,19 @@ curl -sL ${host}/artifactory/api/system/licenses/ | jq .
   "validThrough" : "Jan 29, 2022",
   "licensedTo" : "JFrog Ltd"
 }
-
 ```
 
 The following 3 license types (`jq .type`) do **NOT** support APIs:
-- Community Edition for C/C++
-- JCR Edition
-- OSS
+
+* Community Edition for C/C++
+* JCR Edition
+* OSS
 
 ## Example Usage
+
 ```hcl
-# Required for Terraform 0.13 and up (https://www.terraform.io/upgrade-guides/0-13.html)
+# Required for Terraform 0.13+
+# https://www.terraform.io/upgrade-guides/0-13.html
 terraform {
   required_providers {
     artifactory = {
@@ -43,13 +39,13 @@ terraform {
 
 # Configure the Artifactory provider
 provider "artifactory" {
-  url = "${var.artifactory_url}/artifactory"
+  url      = "${var.artifactory_url}/artifactory"
   username = "${var.artifactory_username}"
   password = "${var.artifactory_password}"
 }
 
 # Create a new repository
-resource "artifactory_local_repository" "pypi-libs" {
+resource "artifactory_local_repository" "pypi_libs" {
   key             = "pypi-libs"
   package_type    = "pypi"
   repo_layout_ref = "simple-default"
@@ -58,63 +54,68 @@ resource "artifactory_local_repository" "pypi-libs" {
 ```
 
 ## Authentication
+
 The Artifactory provider supports multiple means of authentication. The following methods are supported:
 
-    * Basic Auth
-    * Bearer Token
-    * JFrog API Key Header
+* Basic Auth (Discouraged)
+* JFrog API Key Header (Good support)
+* Bearer Token (The future of the API)
 
 ### Basic Auth
-Basic auth may be used by adding a `username` and `password` field to the provider block
-Getting this value from the environment is supported with the `ARTIFACTORY_USERNAME` and `ARITFACTORY_PASSWORD` variable
 
-Usage:
+Basic authentication may be used by adding a `username` and `password` field to the provider block. Getting this value from the environment is supported with the `ARTIFACTORY_USERNAME` and `ARITFACTORY_PASSWORD` variables.
+
+#### Usage
+
 ```hcl
 # Configure the Artifactory provider
 provider "artifactory" {
-  url = "artifactory.site.com/"
+  url      = "artifactory.site.com/"
   username = "myusername"
   password = "mypassword"
 }
 ```
 
-### Bearer Token
-Artifactory access tokens may be used via the Authorization header by providing the `access_token` field to the provider
-block. Getting this value from the environment is supported with the `ARTIFACTORY_ACCESS_TOKEN` variable
+### JFrog API Key Header
 
-Usage:
+Artifactory API keys may be used with the `X-JFrog-Art-Api` header by providing the `api_key` field in the provider block. Getting this value from the environment is supported with the `ARTIFACTORY_API_KEY` variable.
+
+#### Usage
+
 ```hcl
 # Configure the Artifactory provider
 provider "artifactory" {
-  url = "artifactory.site.com/artifactory"
-  access_token = "abc...xy"
+  url     = "artifactory.site.com/artifactory"
+  api_key = "abc...xy"
 }
 ```
 
-### JFrog API Key Header
-Artifactory API keys may be used via the `X-JFrog-Art-Api` header by providing the `api_key` field in the provider block.
-Getting this value from the environment is supported with the `ARTIFACTORY_API_KEY` variable
+### Bearer Token
 
-Usage:
+Artifactory access tokens may be used via the `Authorization` header by providing the `access_token` field to the provider block. Getting this value from the environment is supported with the `ARTIFACTORY_ACCESS_TOKEN` variable.
+
+#### Usage
+
 ```hcl
 # Configure the Artifactory provider
 provider "artifactory" {
-  url = "artifactory.site.com/artifactory"
-  api_key = "abc...xy"
+  url          = "artifactory.site.com/artifactory"
+  access_token = "abc...xy"
 }
 ```
 
 ## Argument Reference
 
-The following arguments are supported:
+The following arguments are supported.
 
-* `url` - (Required) URL of Artifactory. This can also be sourced from the `ARTIFACTORY_URL` environment variable.
-* `username` - (Optional) Username for basic auth. Requires `password` to be set.
-    Conflicts with `api_key`, and `access_token`. This can also be sourced from the `ARTIFACTORY_USERNAME` environment variable.
-* `password` - (Optional) Password for basic auth. Requires `username` to be set.
-    Conflicts with `api_key`, and `access_token`. This can also be sourced from the `ARTIFACTORY_PASSWORD` environment variable.
-* `api_key` - (Optional) API key for api auth. Uses `X-JFrog-Art-Api` header.
-    Conflicts with `username`, `password`, and `access_token`. This can also be sourced from the `ARTIFACTORY_API_KEY` environment variable.
-* `access_token` - (Optional) API key for token auth. Uses `Authorization: Bearer` header. For xray functionality, this is the only auth method accepted
-    Conflicts with `username` and `password`, and `api_key`. This can also be sourced from the `ARTIFACTORY_ACCESS_TOKEN` environment variable.
-* `check_license` - (Optional) Toggle for pre-flight checking of Artifactory license. Default to `true`.
+* `url` - (Required) URL of Artifactory. This can also be sourced from the `ARTIFACTORY_URL` environment variable. This should include the `/artifactory` portion of the path.
+
+* `username` - (Optional) Username for basic authentication. Requires `password`. Conflicts with `api_key` and `access_token`. This can also be sourced from the `ARTIFACTORY_USERNAME` environment variable.
+
+* `password` - (Optional) Password for basic authentication. Requires `username`. Conflicts with `api_key`, and `access_token`. This can also be sourced from the `ARTIFACTORY_PASSWORD` environment variable.
+
+* `api_key` - (Optional) Referred to as “API Key” in the JFrog docs, this is for API Key authentication. Equivalent to passing the value to the `X-JFrog-Art-Api` header over the API. Conflicts with `username`, `password`, and `access_token`. This can also be sourced from the `ARTIFACTORY_API_KEY` environment variable.
+
+* `access_token` - (Optional) Referred to as “Access Token” in the JFrog docs, this is for JSON Web Token ([RFC 7519](https://datatracker.ietf.org/doc/html/rfc7519)) Authentication. Equivalent to passing the value to the `Authorization: Bearer` header over the API. For Xray functionality, this is the only accepted authentication method. Conflicts with `username`, `password`, and `api_key`. This can also be sourced from the `ARTIFACTORY_ACCESS_TOKEN` environment variable.
+
+* `check_license` - (Optional) Toggle for pre-flight checking of Artifactory license. The default value is `true`.

--- a/docs/resources/artifactory_access_token.md
+++ b/docs/resources/artifactory_access_token.md
@@ -7,6 +7,7 @@ state](https://www.terraform.io/docs/state/sensitive-data.html).
 
 
 ## Example Usages
+
 ### Create a new Artifactory Access Token for an existing user
 
 ```hcl
@@ -16,9 +17,10 @@ resource "artifactory_access_token" "exising_user" {
 }
 ```
 
-Note: This assumes that the user `existing-user` has already been created in Artifactory by different means, i.e. manually or in a separate terraform apply.
+~> **Note:** This assumes that the user `existing-user` has already been created in Artifactory by different means, (e.g., manually, or in a separate `terraform apply`).
 
 ### Create a new Artifactory User and Access token
+
 ```hcl
 resource "artifactory_user" "new_user" {
   name   = "new_user"
@@ -36,7 +38,9 @@ resource "artifactory_access_token" "new_user" {
 ```
 
 ### Creates a new token for groups
-This creates a transient user called `temporary-user`.
+
+This creates an ephemeral user called `temporary-user`.
+
 ```hcl
 resource "artifactory_access_token" "temporary_user" {
   username          = "temporary-user"
@@ -49,6 +53,7 @@ resource "artifactory_access_token" "temporary_user" {
 ```
 
 ### Create token with no expiry
+
 ```hcl
 resource "artifactory_access_token" "no_expiry" {
   username          = "existing-user"
@@ -57,6 +62,7 @@ resource "artifactory_access_token" "no_expiry" {
 ```
 
 ### Creates a refreshable token
+
 ```hcl
 resource "artifactory_access_token" "refreshable" {
   username          = "refreshable"
@@ -71,29 +77,32 @@ resource "artifactory_access_token" "refreshable" {
 ```
 
 ### Creates an administrator token
+
 ```hcl
 resource "artifactory_access_token" "admin" {
   username          = "admin"
   end_date_relative = "1m"
 
   admin_token {
-    instance_id = "<instance id>"
+    instance_id = "jfrt@<instance id>"
   }
 }
 ```
 
 ### Creates a token with an audience
+
 ```hcl
 resource "artifactory_access_token" "audience" {
   username          = "audience"
   end_date_relative = "1m"
 
-  audience = "jfrt@*"
+  audience    = "jfrt@*"
   refreshable = true
 }
 ```
 
 ### Creates a token with a fixed end date
+
 ```hcl
 resource "artifactory_access_token" "fixeddate" {
   username = "fixeddate"
@@ -106,10 +115,7 @@ resource "artifactory_access_token" "fixeddate" {
 ```
 
 ### Rotate token after it expires
-This example will generate a token that will expire in 1 hour.
-
-If `terraform apply` is run before 1 hour, nothing changes.
-One an hour has passed, `terraform apply` will generate a new token.
+This example will generate a token that will expire in 1 hour. If `terraform apply` is run before 1 hour has passed, nothing changes. Once an hour has passed, `terraform apply` will generate a new token.
 
 ```hcl
 resource "time_rotating" "now_plus_1_hours" {
@@ -128,10 +134,9 @@ resource "artifactory_access_token" "rotating" {
 }
 ```
 
-### Rotate token each terraform apply
-This example will generate a token that will expire in 1 hour.
+### Rotate token each `terraform apply`
 
-If `terraform apply` is run before 1 hour, a new token is generated with an expiry of 1 hour.
+This example will generate a token that will expire in 1 hour. If `terraform apply` is run before 1 hour has passed, a new token is generated with an expiry of 1 hour.
 
 ```hcl
 resource "time_rotating" "now_plus_1_hours" {
@@ -154,7 +159,7 @@ resource "artifactory_access_token" "rotating" {
 }
 ```
 
-## Attribute Reference
+## Argument Reference
 
 The following arguments are supported:
 
@@ -162,32 +167,38 @@ The following arguments are supported:
 
 * One of `end_date` or `end_date_relative` must be set.
 
-    * `end_date` - (Optional) The end date which the token is valid until, formatted as a RFC3339 date string (e.g. `2018-01-01T01:02:03Z`).
+    * `end_date` - (Optional) The end date which the token is valid until, formatted as an [RFC 3339](https://datatracker.ietf.org/doc/html/rfc3339) date string (e.g. `2018-01-01T01:02:03Z`).
 
-    * `end_date_relative` - (Optional) A relative duration for which the token is valid until, for example `240h` (10 days) or `2400h30m`. Valid time units are "s", "m", "h".
+    * `end_date_relative` - (Optional) A relative duration for which the token is valid. For example `240h` (10 days) or `2400h30m`. Valid time units are the same as Golang’s [`time.ParseDuration`](https://pkg.go.dev/time#ParseDuration) method: `s`, `m`, `h`.
 
 * `groups` - (Optional) List of groups. The token is granted access based on the permissions of the groups. Specify `["*"]` for all groups that the user belongs to. `groups` cannot be specified with `admin_token`.
+
 * `admin_token` - (Optional) Specify the `instance_id` in this block to grant this token admin privileges. This can only be created when the authenticated user is an admin. `admin_token` cannot be specified with `groups`.
-* `refreshable` - (Optional) Is this token refreshable? Defaults to `false`
-* `audience` - (Optional) A space-separate list of the other Artifactory instances or services that should accept this token identified by their Artifactory Service IDs. You may set `"jfrt@*"` so the token to be accepted by all Artifactory instances.
 
-  Refreshable must be `true` to set the `audience`. 
-    
-    For instructions to retrieve the Artifactory Service ID see this [documentation](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-GetServiceID).
+* `refreshable` - (Optional) Should this token refreshable? A value of `true` means that the token is refreshable and the response will include a refresh token. A value of `false` means that the token is _not_ refreshable and the response will not include a refresh token value. The default value is `false`.
 
-**Notes:**
-- Changing **any** field forces a new resource to be created.
-- Although you can create a refreshable token, by setting `refreshable` to true, the resource does **not** implement a token refresh on subsequent executions of Terraform.
+* `audience` - (Optional) A space-separate list of the other Artifactory instances or services that should accept this token identified by their Artifactory Service IDs. You may set `jfrt@*` so the token to be accepted by all Artifactory instances.
 
-The following additional attributes are exported:
+    The `refreshable` attribute must be set to `true` in order to set the `audience`. [How to retrieve the Artifactory Service ID](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-GetServiceID).
 
-* `access_token` - Returns the access token to authenciate to Artifactory
-* `refresh_token` - Returns the refresh token when `refreshable` is true, or an empty string when `refreshable` is false
+### Notes
+
+* Changing **any** field forces a new resource to be created.
+
+* Although you can create a refreshable token by setting `refreshable` to true, the resource does **not** implement a token refresh on subsequent executions of Terraform.
+
+## Attribute Reference
+
+In addition to all arguments above, the following attributes are exported:
+
+* `access_token` - Returns the access token for authenciating with Artifactory.
+
+* `refresh_token` - Returns the refresh token when `refreshable` is set to `true`, or an empty string when `refreshable` is set to `false`.
 
 ## References
 
-- https://www.jfrog.com/confluence/display/ACC1X/Access+Tokens
-- https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateToken
+* https://www.jfrog.com/confluence/display/ACC1X/Access+Tokens
+* https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateToken
 
 ## Import
 

--- a/docs/resources/artifactory_access_token.md
+++ b/docs/resources/artifactory_access_token.md
@@ -2,8 +2,7 @@
 
 Provides an Artifactory Access Token resource. This can be used to create and manage Artifactory Access Tokens.
 
-~> **Note:** Access Tokens will be stored in the raw state as plain-text. [Read more about sensitive data in
-state](https://www.terraform.io/docs/state/sensitive-data.html).
+~> **Note:** Access Tokens will be stored in the raw state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 
 
 ## Example Usages
@@ -115,6 +114,7 @@ resource "artifactory_access_token" "fixeddate" {
 ```
 
 ### Rotate token after it expires
+
 This example will generate a token that will expire in 1 hour. If `terraform apply` is run before 1 hour has passed, nothing changes. Once an hour has passed, `terraform apply` will generate a new token.
 
 ```hcl

--- a/docs/resources/artifactory_api_key.md
+++ b/docs/resources/artifactory_api_key.md
@@ -2,14 +2,12 @@
 
 Provides an Artifactory API key resource. This can be used to create and manage Artifactory API keys.
 
-~> **Note:** API keys will be stored in the raw state as plain-text. [Read more about sensitive data in
-state](https://www.terraform.io/docs/state/sensitive-data.html).
-
+~> **Note:** API keys will be stored in the raw state as plain-text. [Read more about sensitive data in state](https://www.terraform.io/docs/state/sensitive-data.html).
 
 ## Example Usage
 
 ```hcl
-# Create a new Artifactory API key for the configured user
+# Create a new Artifactory API key for the configured user.
 resource "artifactory_api_key" "ci" {}
 ```
 
@@ -17,12 +15,12 @@ resource "artifactory_api_key" "ci" {}
 
 The following attributes are exported:
 
-* `api_key` - The API key.
+* `api_key` - An API key that can be used with the `X-JFrog-Art-Api` HTTP header to authenticate requests.
 
 ## Import
 
-A user's API key can be imported using any identifier, e.g.
+A user's API key can be imported using any identifier.
 
 ```
-$ terraform import artifactory_api_key.test import
+terraform import artifactory_api_key.test import
 ```

--- a/docs/resources/artifactory_certificate.md
+++ b/docs/resources/artifactory_certificate.md
@@ -24,7 +24,7 @@ The following arguments are supported:
 
 * `alias` - (Required) Name of the certificate.
 
-* `content` - (Required) PEM-encoded client certificate and private key.
+* `content` - (Required) PEM-encoded client certificate and private key, as a string.
 
 ## Attribute Reference
 

--- a/docs/resources/artifactory_certificate.md
+++ b/docs/resources/artifactory_certificate.md
@@ -13,9 +13,8 @@ resource "artifactory_certificate" "my-cert" {
 
 # This can then be used by a remote repository
 resource "artifactory_remote_repository" "my-remote" {
-  // more code
   client_tls_certificate = "${artifactory_certificate.my-cert.alias}"
-  // more code
+  // ...
 }
 ```
 
@@ -23,7 +22,8 @@ resource "artifactory_remote_repository" "my-remote" {
 
 The following arguments are supported:
 
-* `alias` - (Required) Name of certificate.
+* `alias` - (Required) Name of the certificate.
+
 * `content` - (Required) PEM-encoded client certificate and private key.
 
 ## Attribute Reference
@@ -31,15 +31,19 @@ The following arguments are supported:
 In addition to all arguments above, the following attributes are exported:
 
 * `fingerprint` - SHA256 fingerprint of the certificate.
+
 * `issued_by` - Name of the certificate authority that issued the certificate.
-* `issued_on` - The time & date when the certificate is valid from.
+
+* `issued_on` - The timestamp when the certificate is valid from.
+
 * `issued_to` - Name of whom the certificate has been issued to.
+
 * `valid_until` - The time & date when the certificate expires.
 
 ## Import
 
-Certificates can be imported using their alias, e.g.
+Certificates can be imported using their alias.
 
 ```
-$ terraform import artifactory_certificate.my-cert my-cert
+terraform import artifactory_certificate.my-cert my-cert
 ```

--- a/docs/resources/artifactory_general_security.md
+++ b/docs/resources/artifactory_general_security.md
@@ -1,8 +1,6 @@
 # Artifactory General Security Resource
 
-This resource can be used to manage Artifactory's general security settings.
-
-Only a single `artifactory_general_security` resource is meant to be defined.
+This resource can be used to manage Artifactory's general security settings. Only a single `artifactory_general_security` resource is meant to be defined.
 
 ## Example Usage
 
@@ -17,12 +15,12 @@ resource "artifactory_general_security" "security" {
 
 The following arguments are supported:
 
-* `enable_anonoymous_access`    - (Optional) Enable anonymous access.  Default value is `false`.
+* `enable_anonymous_access` - (Optional) Enable anonymous READ access. The default value is `false`.
 
 ## Import
 
-Current general security settings can be imported using `security` as the `ID`, e.g.
+Current general security settings can be imported using `security` as the `ID`.
 
 ```
-$ terraform import artifactory_general_security.security security
+terraform import artifactory_general_security.security security
 ```

--- a/docs/resources/artifactory_group.md
+++ b/docs/resources/artifactory_group.md
@@ -1,6 +1,6 @@
 # Artifactory Group Resource
 
-Provides an Artifactory group resource. This can be used to create and manage Artifactory groups.
+Provides an Artifactory user-group resource. This can be used to create and manage Artifactory user-group.
 
 ## Example Usage
 
@@ -18,28 +18,32 @@ resource "artifactory_group" "test-group" {
 
 The following arguments are supported:
 
-* `name`                - (Required) Name of the group
-* `description`         - (Optional) A description for the group
-* `auto_join`           - (Optional) When this parameter is set, any new users defined in the system are automatically assigned to this group.
-* `admin_privileges`    - (Optional) Any users added to this group will automatically be assigned with admin privileges in the system.
+* `name`                - (Required) Name of the user-group.
+
+* `description`         - (Optional) A description for the user-group.
+
+* `auto_join`           - (Optional) A value of `true` means that new users defined in the system are automatically assigned to this user-group. A value of `false` means that new users defined in the system are NOT assigned to this user-group. The default value is `false`.
+
+* `admin_privileges`    - (Optional) A value of `true` means that any users added to this group will automatically be assigned with admin privileges in the system. A value of `false` means that users added to this group will NOT be automatically assigned with admin privileges. The default value is `false`.
+
 * `realm`               - (Optional) The realm for the group.
+
 * `realm_attributes`    - (Optional) The realm attributes for the group.
-* `users_names`         - (Optional) List of users assigned to the group. If missing or empty, tf will not manage group membership
-* `detach_all_users`    - (Optional) When this override is set, an empty or missing usernames array will detach all users from the group
+
+* `users_names`         - (Optional) List of users assigned to the group. If missing or empty, Terraform will not manage group membership.
+
+* `detach_all_users`    - (Optional) A value of `true` means that an empty or missing `users_names` array will detach all users from the group. A value of `false` means that an empty or missing `users_names` array will NOT detach all users from the group. The default value is `false`.
 
 ## Import
 
-Groups can be imported using their name, e.g.
+Groups can be imported using their name.
 
 ```
-$ terraform import artifactory_group.terraform-group mygroup
+terraform import artifactory_group.terraform-group mygroup
 ```
-
 
 ## Managed vs Unmanaged Group Membership
-TF does not distinguish between an absent UsersNames array and setting to an array of length 0
-To prevent accidental deletion of existing membership, the default was chosen to mean that tf does not manage membership
-and that to detach all users would require an explicit bool.
 
-Note when moving from managed group membership to unmanaged the tf plan will show the users previously in the array
-being removed from terraform state, but it will not actually delete any members.
+Terraform does not distinguish between an _absent_ vs _empty_ `users_names` array. To prevent accidental deletion of existing membership, the default value means that Terraform does not manage membership. To detach all users would require an explicit boolean `true`.
+
+~> **Note:** When moving from managed group membership to unmanaged, the `terraform plan` will show the users previously in the array being removed from `terraform.tfstate` file, but it will not actually delete any members from the Artifactory system.

--- a/docs/resources/artifactory_keypair.md
+++ b/docs/resources/artifactory_keypair.md
@@ -1,4 +1,4 @@
-# Artifactory keypair Resource
+# Artifactory Keypair Resource
 
 Creates a Keypair resource.
 

--- a/docs/resources/artifactory_keypair.md
+++ b/docs/resources/artifactory_keypair.md
@@ -1,27 +1,21 @@
 # Artifactory keypair Resource
 
-Creates an RSA Keypair resource - suitable for signing alpine indices. 
-- Currently, only RSA is supported.
-- Passphrases are not currently supported, though they exist in the API
+Creates a Keypair resource.
 
+~> **Note:** Presently, only **RSA** keys are supported which are suitable for signing Alpine Linux indices. Passphrases are not currently supported, though they exist in the API for GPG keys. GPG support is stubbed-out in the provider, but not fully implemented.
 
 ## Example Usage
 
 ```hcl
-terraform {
-  required_providers {
-    artifactory = {
-      source  = "registry.terraform.io/jfrog/artifactory"
-      version = "2.6.14"
-    }
-  }
-}
-resource "artifactory_keypair" "some-keypair6543461672124900137" {
-  pair_name   = "some-keypair6543461672124900137"
+resource "artifactory_keypair" "my_keypair" {
   pair_type   = "RSA"
+  pair_name   = "some-keypair6543461672124900137"
   alias       = "foo-alias6543461672124900137"
-  private_key = file("samples/rsa.priv")
+
+  private_key = file("samples/rsa.pem")
   public_key  = file("samples/rsa.pub")
+  # passphrase = ""
+
   lifecycle {
     ignore_changes = [
       private_key,
@@ -35,13 +29,16 @@ resource "artifactory_keypair" "some-keypair6543461672124900137" {
 
 The following arguments are supported:
 
-* `pair_name` - (Required) name of the key pair and the identity of the resource.
-* `pair_type` - (Required) RT requires this - presumably for verification purposes.
-* `alias` - (Required) Required but for unknown reasons
-* `private_key` - (Required)  - duh! This will have it's pem format validated
-* `passphrase` - (Optional/Questionable)  - This will be used to decrypt the private key. Validated server side.
-* `public_key` - (Required)  - duh! This will have it's pem format validated
-* `unavailable` - (Computed) - it's unknown what this does, but, it's returned in the payload and there is no known place to set it in the UI
+* `pair_name` - (Required) Name of the keypair and the identity of the resource.
 
-Artifactory REST API call Get Key Pair doesn't return keys `private_key` and `passphrase`, but consumes these keys in the POST call.
-The meta-argument `lifecycle` used here to make Provider ignore the changes for these two keys in the Terraform state. 
+* `pair_type` - (Required) The type of key. Allowed values are: `RSA` or `GPG`.
+
+* `alias` - (Required) Appears with the keypairs in the Admin UI for _signing keys_.
+
+* `private_key` - (Required) The private key portion of the RSA/GPG keypair, as a string.
+
+* `passphrase` - (Optional) - The passphrase for the GPG key. Validated server side. (Not currently implemented until GPG support is added.)
+
+* `public_key` - (Required) The public key portion of the RSA/GPG keypair, as a string.
+
+~> **Note:** The Artifactory API call _Get Key Pair_ doesn't return `private_key` or `passphrase`, but consumes these keys in the `POST` call. The meta-argument `lifecycle` is used here to ensure the provider ignores the changes for these two keys in the Terraform state.


### PR DESCRIPTION
I haven't gone through everything yet, but this is a start of the first several pages. Here are the overall guidelines I'm applying as I go through the docs:

* Full and complete sentences, with appropriate grammar.
* Replace internal acronyms (e.g., `RT`) with the correct external terminology (e.g., `Artifactory`).
* Correct the spelling of _Terraform_ in all of its different forms.
* Adjusted the formatting of the examples to match both HashiCorp’s documented best practices, as well as what it would look like if you ran `terraform fmt` on them.
* Don't use ampersands -- not in professional writing.
* Knowing how GitHub-Flavored Commonmark (GFM) works, fixed the spacing and alignment of multi-paragraph list items.
* Rewrote a few bits to bring additional clarity to how things work.

If there are a different set of rules you'd prefer I follow for technical writing, please let me know. If these changes are good, I will go through the next set of pages.