### PR TITLE
GH-298 Update go.mod and main.go to use /v2 for module and import path

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,6 +22,11 @@ clean:
 release:
 	@git tag ${NEXT_VERSION} && git push --mirror
 	@echo "Pushed ${NEXT_VERSION}"
+	GOPROXY=https://proxy.golang.org GO111MODULE=on go get github.com/jfrog/terraform-provider-artifactory@v${NEXT_VERSION}
+	@echo "Updated pkg cache"
+
+update_pkg_cache:
+	GOPROXY=https://proxy.golang.org GO111MODULE=on go get github.com/jfrog/terraform-provider-artifactory@v${VERSION}
 
 build: fmtcheck
 	go build -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}'"

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jfrog/terraform-provider-artifactory
+module github.com/jfrog/terraform-provider-artifactory/v2
 
 require (
 	github.com/go-resty/resty/v2 v2.6.1-0.20210916045937-1792d629c3c6

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"github.com/jfrog/terraform-provider-artifactory/pkg/artifactory"
+	"github.com/jfrog/terraform-provider-artifactory/v2/pkg/artifactory"
 )
 
 func main() {


### PR DESCRIPTION
Fixes #298 

Add new command to make file to update https://pkg.go.dev/ after release