### PR TITLE
Resty .SetBody() unsupported body fix

### DIFF
--- a/pkg/artifactory/resource_xray_watch.go
+++ b/pkg/artifactory/resource_xray_watch.go
@@ -310,7 +310,7 @@ func flattenAssignedPolicies(policies *[]WatchAssignedPolicy) []interface{} {
 func resourceXrayWatchCreate(d *schema.ResourceData, m interface{}) error {
 
 	watch := expandWatch(d)
-	_, err := m.(*resty.Client).R().SetBody(&watch).Post("xray/api/v2/watches")
+	_, err := m.(*resty.Client).R().SetBody(watch).Post("xray/api/v2/watches")
 	if err != nil {
 		return err
 	}
@@ -350,7 +350,7 @@ func resourceXrayWatchRead(d *schema.ResourceData, m interface{}) error {
 
 func resourceXrayWatchUpdate(d *schema.ResourceData, m interface{}) error {
 	watch := expandWatch(d)
-	_, err := m.(*resty.Client).R().SetBody(&watch).Put("xray/api/v2/watches/" + d.Id())
+	_, err := m.(*resty.Client).R().SetBody(watch).Put("xray/api/v2/watches/" + d.Id())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This call is erroneously passing `&watch` to SetBody() -- this makes sense for unmarshalling reads, but not for the create & update. This results in resty http client throwing this error below: 

``` Error: unsupported 'Body' type/value```

Fixed by passing `watch` to SetBody().