### PR TITLE
Fix artifactory_remote_repository.proxy not being reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.15.2 (Feb, 4, 2022)
+
+BUG FIXES:
+
+* resource/artifactory_remote_repository: Fix unable to reset `proxy` attribute [GH-307]
+
 ## 2.15.1 (Feb, 4, 2022)
 
 BUG FIXES:
@@ -26,7 +32,7 @@ IMPROVEMENTS:
 
 * Add missing documentations for Federated repo resources [GH-304]
 * Add additional repo types for Federated repo resources [GH-304]
-  
+
 ## 2.13.0 (Feb, 1, 2022)
 
 FEATURES:

--- a/pkg/artifactory/repositories.go
+++ b/pkg/artifactory/repositories.go
@@ -781,19 +781,18 @@ func unpackBaseRemoteRepo(s *schema.ResourceData, packageType string) RemoteRepo
 	return repo
 }
 
-// Special handling of DefaultDeploymentRepo field
+// Special handling for field that requires non-existant value for RT
+//
 // Artifactory REST API will not accept empty string or null to reset value to not set
-// Instead, using a non-existant repo key works as a workaround
-// To ensure we don't accidentally set the value to a valid repo, we use a UUID v4 string
-// for the repo key
-func getDefaultDeploymentRepo(d *ResourceData) string {
-	key := "default_deployment_repo"
+// Instead, using a non-existant value works as a workaround
+// To ensure we don't accidentally set the value to a valid value, we use a UUID v4 string
+func handleResetWithNonExistantValue(d *ResourceData, key string) string {
 	value := d.getString(key, false)
 
 	// When value has changed and is empty string, then it has been removed from
 	// the Terraform configuration.
 	if value == "" && d.HasChange(key) {
-		return fmt.Sprintf("non-existant-repo-%d", randomInt())
+		return fmt.Sprintf("non-existant-value-%d", randomInt())
 	}
 
 	return value
@@ -814,7 +813,7 @@ func unpackBaseVirtRepo(s *schema.ResourceData, packageType string) VirtualRepos
 		Repositories:          d.getList("repositories"),
 		Description:           d.getString("description", false),
 		Notes:                 d.getString("notes", false),
-		DefaultDeploymentRepo: getDefaultDeploymentRepo(d),
+		DefaultDeploymentRepo: handleResetWithNonExistantValue(d, "default_deployment_repo"),
 	}
 }
 

--- a/pkg/artifactory/resource_artifactory_remote_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository.go
@@ -2,6 +2,7 @@ package artifactory
 
 import (
 	"fmt"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -135,9 +136,9 @@ var legacyRemoteSchema = map[string]*schema.Schema{
 		Description: "This field can only be used if encryption has been turned off",
 	},
 	"proxy": {
-		Type:     schema.TypeString,
-		Optional: true,
-		Computed: true,
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Proxy key from Artifactory Proxies setting",
 	},
 	"remote_repo_checksum_policy_type": {
 		Type:     schema.TypeString,
@@ -385,7 +386,7 @@ func unpackLegacyRemoteRepo(s *schema.ResourceData) (interface{}, string, error)
 	repo.PackageType = d.getString("package_type", true)
 	repo.Password = d.getString("password", true)
 	repo.PropertySets = d.getSet("property_sets")
-	repo.Proxy = d.getString("proxy", true)
+	repo.Proxy = handleResetWithNonExistantValue(d, "proxy")
 	repo.PypiRegistryUrl = d.getString("pypi_registry_url", true)
 	repo.RepoLayoutRef = d.getString("repo_layout_ref", true)
 	repo.RetrievalCachePeriodSecs = d.getInt("retrieval_cache_period_seconds", true)

--- a/pkg/artifactory/resource_artifactory_virtual_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_repository.go
@@ -158,7 +158,7 @@ func unpackVirtualRepository(s *schema.ResourceData) (interface{}, string, error
 	repo.Notes = d.getString("notes", false)
 	repo.KeyPair = d.getString("key_pair", false)
 	repo.PomRepositoryReferencesCleanupPolicy = d.getString("pom_repository_references_cleanup_policy", false)
-	repo.DefaultDeploymentRepo = getDefaultDeploymentRepo(d)
+	repo.DefaultDeploymentRepo = handleResetWithNonExistantValue(d, "default_deployment_repo")
 	// because this doesn't apply to all repo types, RT isn't required to honor what you tell it.
 	// So, saying the type is "maven" but then setting this to 'true' doesn't make sense, and RT doesn't seem to care what you tell it
 	repo.ForceNugetAuthentication = d.getBoolRef("force_nuget_authentication", false)


### PR DESCRIPTION
Fixes #2 

Refactor `getDefaultDeploymentRepo()` into generic function to provide non-existent value for resetting RT attribute.