### PR TITLE
Fix remote repo proxy test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.16.1 (Feb, 7, 2022)
+
+BUG FIXES:
+
+* resource/artifactory_remote_repository: Fix failing test for `proxy` attribute [GH-311]
+
 ## 2.16.0 (Feb, 4, 2022)
 
 IMPROVEMENTS:
@@ -21,7 +27,6 @@ BUG FIXES:
 FEATURES:
 
 * **New Resource:** `artifactory_virtual_rpm_repository` with support for `primary_keypair_ref` and `secondary_keypair_ref` and [GH-303]
-
 
 ## 2.14.0 (Feb, 3, 2022)
 


### PR DESCRIPTION
In #307 I didn't realize the test was broken. I had the `test-proxy` setup in my RT instance manually so test passes. The CI build fails to setup itself so I didn't notice test was wrong before PR was merged.

Test now inserts/removes the test proxy during setup/teardown. Took me a little time to decipher the yaml structure for the configuration patch API.