### PR TITLE
Extend pipeline step timeout to 20 mins

### DIFF
--- a/TFproviderTest.yml
+++ b/TFproviderTest.yml
@@ -129,6 +129,7 @@ pipelines:
         type: Bash
         configuration:
           priority: 1
+          timeoutSeconds: 1200 // 20 minutes
           runtime:
             type: image
             image:


### PR DESCRIPTION
Pipeline step fails after 10 min (current timeout).