### PR TITLE
Fixes #336 Add capability to specify proxy for Artifactory repository replications

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.22.0 (Mar 8, 2022)
+
+FEATURES:
+
+* Add support for specifying proxy on push replications. [GH-336]
+
 ## 2.21.0 (Mar 3, 2022)
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 FEATURES:
 
-* Add support for specifying proxy on push replications. [GH-336]
+* resource/artifactory_push_replication: Add support for specifying proxy. [GH-337]
+* resource/artifactory_replication_config: Add support for specifying proxy. [GH-337]
+* resource/artifactory_single_replication: Add support for specifying proxy. [GH-337]
 
 ## 2.21.0 (Mar 3, 2022)
 

--- a/docs/resources/artifactory_push_replication.md
+++ b/docs/resources/artifactory_push_replication.md
@@ -58,7 +58,7 @@ The following arguments are supported:
     * `sync_properties` - (Optional)
     * `sync_statistics` - (Optional)
     * `path_prefix` - (Optional)
-    * `proxy` - (Optional)
+    * `proxy` - (Optional) Proxy key from Artifactory Proxies setting
 
 ## Import
 

--- a/docs/resources/artifactory_push_replication.md
+++ b/docs/resources/artifactory_push_replication.md
@@ -58,6 +58,7 @@ The following arguments are supported:
     * `sync_properties` - (Optional)
     * `sync_statistics` - (Optional)
     * `path_prefix` - (Optional)
+    * `proxy` - (Optional)
 
 ## Import
 

--- a/docs/resources/artifactory_replication_config.md
+++ b/docs/resources/artifactory_replication_config.md
@@ -58,7 +58,7 @@ The following arguments are supported:
     * `sync_properties` - (Optional)
     * `sync_statistics` - (Optional)
     * `path_prefix` - (Optional)
-    * `proxy` - (Optional)
+    * `proxy` - (Optional) Proxy key from Artifactory Proxies setting
 
 ## Import
 

--- a/docs/resources/artifactory_replication_config.md
+++ b/docs/resources/artifactory_replication_config.md
@@ -58,6 +58,7 @@ The following arguments are supported:
     * `sync_properties` - (Optional)
     * `sync_statistics` - (Optional)
     * `path_prefix` - (Optional)
+    * `proxy` - (Optional)
 
 ## Import
 

--- a/docs/resources/artifactory_single_replication_config.md
+++ b/docs/resources/artifactory_single_replication_config.md
@@ -58,6 +58,7 @@ The following arguments are supported:
 * `sync_properties` - (Optional)
 * `sync_statistics` - (Optional)
 * `path_prefix` - (Optional)
+* `proxy` - (Optional)
 
 ## Import
 

--- a/docs/resources/artifactory_single_replication_config.md
+++ b/docs/resources/artifactory_single_replication_config.md
@@ -58,7 +58,7 @@ The following arguments are supported:
 * `sync_properties` - (Optional)
 * `sync_statistics` - (Optional)
 * `path_prefix` - (Optional)
-* `proxy` - (Optional)
+* `proxy` - (Optional) Proxy key from Artifactory Proxies setting
 
 ## Import
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-json v0.13.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
-	github.com/jfrog/jfrog-client-go v1.10.0
+	github.com/jfrog/jfrog-client-go v0.27.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/tools v0.1.5 // indirect
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-json v0.13.0 // indirect
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.7.0
-	github.com/jfrog/jfrog-client-go v0.27.0
+	github.com/jfrog/jfrog-client-go v1.10.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/tools v0.1.5 // indirect
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect

--- a/pkg/artifactory/resource_artifactory_pull_replication.go
+++ b/pkg/artifactory/resource_artifactory_pull_replication.go
@@ -27,9 +27,9 @@ func resourceArtifactoryPullReplication() *schema.Resource {
 	}
 }
 
-func unpackPullReplication(s *schema.ResourceData) *utils.ReplicationBody {
+func unpackPullReplication(s *schema.ResourceData) *utils.UpdateReplicationBody {
 	d := &ResourceData{s}
-	replicationConfig := new(utils.ReplicationBody)
+	replicationConfig := new(utils.UpdateReplicationBody)
 
 	replicationConfig.RepoKey = d.getString("repo_key", false)
 	replicationConfig.CronExp = d.getString("cron_exp", false)

--- a/pkg/artifactory/resource_artifactory_pull_replication.go
+++ b/pkg/artifactory/resource_artifactory_pull_replication.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jfrog/jfrog-client-go/artifactory/services/utils"
 )
 
 func resourceArtifactoryPullReplication() *schema.Resource {
@@ -27,9 +26,9 @@ func resourceArtifactoryPullReplication() *schema.Resource {
 	}
 }
 
-func unpackPullReplication(s *schema.ResourceData) *utils.UpdateReplicationBody {
+func unpackPullReplication(s *schema.ResourceData) *replicationBody {
 	d := &ResourceData{s}
-	replicationConfig := new(utils.UpdateReplicationBody)
+	replicationConfig := new(replicationBody)
 
 	replicationConfig.RepoKey = d.getString("repo_key", false)
 	replicationConfig.CronExp = d.getString("cron_exp", false)

--- a/pkg/artifactory/resource_artifactory_pull_replication.go
+++ b/pkg/artifactory/resource_artifactory_pull_replication.go
@@ -26,9 +26,9 @@ func resourceArtifactoryPullReplication() *schema.Resource {
 	}
 }
 
-func unpackPullReplication(s *schema.ResourceData) *replicationBody {
+func unpackPullReplication(s *schema.ResourceData) *ReplicationBody {
 	d := &ResourceData{s}
-	replicationConfig := new(replicationBody)
+	replicationConfig := new(ReplicationBody)
 
 	replicationConfig.RepoKey = d.getString("repo_key", false)
 	replicationConfig.CronExp = d.getString("cron_exp", false)

--- a/pkg/artifactory/resource_artifactory_push_replication.go
+++ b/pkg/artifactory/resource_artifactory_push_replication.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
 
-type replicationBody struct {
+type ReplicationBody struct {
 	Username               string `json:"username"`
 	Password               string `json:"password"`
 	URL                    string `json:"url"`
@@ -28,12 +28,12 @@ type replicationBody struct {
 }
 
 type getReplicationBody struct {
-	replicationBody
+	ReplicationBody
 	ProxyRef string `json:"proxyRef"`
 }
 
 type updateReplicationBody struct {
-	replicationBody
+	ReplicationBody
 	Proxy string `json:"proxy"`
 }
 

--- a/pkg/artifactory/resource_artifactory_push_replication.go
+++ b/pkg/artifactory/resource_artifactory_push_replication.go
@@ -13,11 +13,18 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
 
-type PushReplication struct {
-	RepoKey                string                  `json:"-"`
-	CronExp                string                  `json:"cronExp,omitempty"`
-	EnableEventReplication bool                    `json:"enableEventReplication,omitempty"`
-	Replications           []utils.ReplicationBody `json:"replications,omitempty"`
+type GetPushReplication struct {
+	RepoKey                string                     `json:"-"`
+	CronExp                string                     `json:"cronExp,omitempty"`
+	EnableEventReplication bool                       `json:"enableEventReplication,omitempty"`
+	Replications           []utils.GetReplicationBody `json:"replications,omitempty"`
+}
+
+type UpdatePushReplication struct {
+	RepoKey                string                        `json:"-"`
+	CronExp                string                        `json:"cronExp,omitempty"`
+	EnableEventReplication bool                          `json:"enableEventReplication,omitempty"`
+	Replications           []utils.UpdateReplicationBody `json:"replications,omitempty"`
 }
 
 var pushReplicationSchemaCommon = map[string]*schema.Schema{
@@ -95,6 +102,10 @@ var pushReplicationSchema = map[string]*schema.Schema{
 		Type:     schema.TypeString,
 		Optional: true,
 	},
+	"proxy": {
+		Type:     schema.TypeString,
+		Optional: true,
+	},
 }
 
 func resourceArtifactoryPushReplication() *schema.Resource {
@@ -112,16 +123,16 @@ func resourceArtifactoryPushReplication() *schema.Resource {
 	}
 }
 
-func unpackPushReplication(s *schema.ResourceData) PushReplication {
+func unpackPushReplication(s *schema.ResourceData) UpdatePushReplication {
 	d := &ResourceData{s}
-	pushReplication := new(PushReplication)
+	pushReplication := new(UpdatePushReplication)
 
 	repo := d.getString("repo_key", false)
 
 	if v, ok := d.GetOk("replications"); ok {
 		arr := v.([]interface{})
 
-		tmp := make([]utils.ReplicationBody, 0, len(arr))
+		tmp := make([]utils.UpdateReplicationBody, 0, len(arr))
 		pushReplication.Replications = tmp
 
 		for i, o := range arr {
@@ -133,7 +144,7 @@ func unpackPushReplication(s *schema.ResourceData) PushReplication {
 
 			m := o.(map[string]interface{})
 
-			var replication utils.ReplicationBody
+			var replication utils.UpdateReplicationBody
 
 			replication.RepoKey = repo
 
@@ -169,6 +180,10 @@ func unpackPushReplication(s *schema.ResourceData) PushReplication {
 				replication.PathPrefix = prefix.(string)
 			}
 
+			if proxy, ok := m["proxy"]; ok {
+				replication.Proxy = proxy.(string)
+			}
+
 			if pass, ok := m["password"]; ok {
 				replication.Password = pass.(string)
 			}
@@ -180,7 +195,7 @@ func unpackPushReplication(s *schema.ResourceData) PushReplication {
 	return *pushReplication
 }
 
-func packPushReplication(pushReplication *PushReplication, d *schema.ResourceData) diag.Diagnostics {
+func packPushReplication(pushReplication *GetPushReplication, d *schema.ResourceData) diag.Diagnostics {
 	var errors []error
 	setValue := mkLens(d)
 
@@ -202,6 +217,7 @@ func packPushReplication(pushReplication *PushReplication, d *schema.ResourceDat
 			replication["sync_properties"] = repo.SyncProperties
 			replication["sync_statistics"] = repo.SyncStatistics
 			replication["path_prefix"] = repo.PathPrefix
+			replication["proxy"] = repo.ProxyRef
 			replications = append(replications, replication)
 		}
 
@@ -228,14 +244,14 @@ func resourcePushReplicationCreate(ctx context.Context, d *schema.ResourceData, 
 
 func resourcePushReplicationRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(*resty.Client)
-	var replications []utils.ReplicationBody
+	var replications []utils.GetReplicationBody
 	_, err := c.R().SetResult(&replications).Get("artifactory/api/replications/" + d.Id())
 
 	if err != nil {
 		return diag.FromErr(err)
 	}
 
-	repConfig := PushReplication{
+	repConfig := GetPushReplication{
 		RepoKey:      d.Id(),
 		Replications: replications,
 	}

--- a/pkg/artifactory/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"gopkg.in/yaml.v2"
 )
 
 func TestAccLocalAllowDotsUnderscorersAndDashesInKeyGH129(t *testing.T) {
@@ -680,52 +679,6 @@ func TestAccRemoteProxyUpdateGH2(t *testing.T) {
 			url             = "https://gocenter.io"
 		}
 	`, name, key)
-
-	type Proxy struct {
-		Key             string `yaml:"key"`
-		Host            string `yaml:"host"`
-		Port            int    `yaml:"port"`
-		PlatformDefault bool   `yaml:"platformDefault"`
-	}
-
-	var updateProxiesConfig = func(t *testing.T, proxyKey string, getProxiesBody func() []byte) {
-		body := getProxiesBody()
-		restyClient := getTestResty(t)
-
-		err := sendConfigurationPatch(body, restyClient)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	var createProxy = func(t *testing.T, proxyKey string) {
-		updateProxiesConfig(t, proxyKey, func() []byte {
-			testProxy := Proxy{
-				Key:             proxyKey,
-				Host:            "http://fake-proxy.org",
-				Port:            8080,
-				PlatformDefault: false,
-			}
-
-			constructBody := map[string][]Proxy{
-				"proxies": {testProxy},
-			}
-
-			body, err := yaml.Marshal(&constructBody)
-			if err != nil {
-				t.Errorf("failed to marshal proxies settings during Update")
-			}
-
-			return body
-		})
-	}
-
-	var deleteProxy = func(t *testing.T, proxyKey string) {
-		updateProxiesConfig(t, proxyKey, func() []byte {
-			// Return empty yaml to clean up all proxies
-			return []byte(`proxies: ~`)
-		})
-	}
 
 	testProxyKey := "test-proxy"
 

--- a/pkg/artifactory/resource_artifactory_single_replication_config.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config.go
@@ -33,9 +33,9 @@ func resourceArtifactorySingleReplicationConfig() *schema.Resource {
 	}
 }
 
-func unpackSingleReplicationConfig(s *schema.ResourceData) *utils.ReplicationBody {
+func unpackSingleReplicationConfig(s *schema.ResourceData) *utils.UpdateReplicationBody {
 	d := &ResourceData{s}
-	replicationConfig := new(utils.ReplicationBody)
+	replicationConfig := new(utils.UpdateReplicationBody)
 
 	replicationConfig.RepoKey = d.getString("repo_key", false)
 	replicationConfig.CronExp = d.getString("cron_exp", false)
@@ -53,7 +53,7 @@ func unpackSingleReplicationConfig(s *schema.ResourceData) *utils.ReplicationBod
 	return replicationConfig
 }
 
-func packPushReplicationBody(config utils.ReplicationBody, d *schema.ResourceData) diag.Diagnostics {
+func packPushReplicationBody(config utils.GetReplicationBody, d *schema.ResourceData) diag.Diagnostics {
 	setValue := mkLens(d)
 
 	setValue("repo_key", config.RepoKey)
@@ -131,7 +131,7 @@ func resourceSingleReplicationConfigRead(_ context.Context, d *schema.ResourceDa
 		if len(result.([]interface{})) > 1 {
 			return diag.Errorf("resource_single_replication_config does not support multiple replication config on a repo. Use resource_artifactory_replication_config instead")
 		}
-		var final []utils.ReplicationBody
+		var final []utils.GetReplicationBody
 		err = json.Unmarshal(resp.Body(), &final)
 		if err != nil {
 			return diag.FromErr(err)

--- a/pkg/artifactory/util_test.go
+++ b/pkg/artifactory/util_test.go
@@ -2,6 +2,7 @@ package artifactory
 
 import (
 	"fmt"
+	"gopkg.in/yaml.v2"
 	"math"
 	"net/http"
 	"reflect"
@@ -151,4 +152,53 @@ func deleteProject(t *testing.T, projectKey string) {
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+// updateProxiesConfig is used by createProxy and deleteProxy to interact with a proxy on Artifactory
+var updateProxiesConfig = func(t *testing.T, proxyKey string, getProxiesBody func() []byte) {
+	body := getProxiesBody()
+	restyClient := getTestResty(t)
+
+	err := sendConfigurationPatch(body, restyClient)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+// createProxy creates a new proxy on Artifactory with the given key
+var createProxy = func(t *testing.T, proxyKey string) {
+	type proxy struct {
+		Key             string `yaml:"key"`
+		Host            string `yaml:"host"`
+		Port            int    `yaml:"port"`
+		PlatformDefault bool   `yaml:"platformDefault"`
+	}
+
+	updateProxiesConfig(t, proxyKey, func() []byte {
+		testProxy := proxy{
+			Key:             proxyKey,
+			Host:            "http://fake-proxy.org",
+			Port:            8080,
+			PlatformDefault: false,
+		}
+
+		constructBody := map[string][]proxy{
+			"proxies": {testProxy},
+		}
+
+		body, err := yaml.Marshal(&constructBody)
+		if err != nil {
+			t.Errorf("failed to marshal proxies settings during Update")
+		}
+
+		return body
+	})
+}
+
+// createProxy deletes an existing proxy on Artifactory with the given key
+var deleteProxy = func(t *testing.T, proxyKey string) {
+	updateProxiesConfig(t, proxyKey, func() []byte {
+		// Return empty yaml to clean up all proxies
+		return []byte(`proxies: ~`)
+	})
 }


### PR DESCRIPTION
See https://github.com/jfrog/jfrog-client-go/pull/524 for the changes to the client to support the proxy field.

Things to note:
* This change would only support Artifactory 7.x+
* There is a pretty significant jump in the `jfrog-client-go` version so a bit worried about that.
* Even though all of the replication related tests passed for me, I was not able to get some of the other tests to pass.  Even when I tried running the tests on the `master` branch of the repo.  It might just be because of the Artifactory instance that I tested against.
* I wanted to added a test for this, but unfortunately was not able to figure out how to dynamically create a proxy via a REST API (couldn't find anything on https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API). If you can help point me in the right direction wrt this, I would love to add a test for configuring proxy. I have tested the changes using a GUI/manually created proxy.