### PR TITLE
Installing the latest version of Go

### DIFF
--- a/TFproviderTest.yml
+++ b/TFproviderTest.yml
@@ -39,7 +39,17 @@ pipelines:
             - echo "Run Helm installation script" && ./get_helm.sh && rm get_helm.sh
             - helm version
             - apt update
-            - apt install -y golang # this host (Ubuntu 20.04) doesn't have Golang installed by default
+            - export GO_VERSION="1.17.8"
+            - export GO_ARCH="amd64"
+            - curl -O -L "https://golang.org/dl/go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
+            - ls -l
+            - tar -xf "go${GO_VERSION}.linux-${GO_ARCH}.tar.gz"
+            - sudo chown -R root:root ./go
+            - sudo mv -v go /usr/local
+            - echo "export GOPATH=$HOME/go" >> ~/.bash_profile1
+            - echo "export PATH=$PATH:/usr/local/go/bin:$GOPATH/bin" >> ~/.bash_profile
+            - source ~/.bash_profile
+            - cat ~/.bash_profile
             - go version
             - echo "Install Terraform"
             - sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys DA418C88A3219F7B


### PR DESCRIPTION
`apt install` install Go 1.13 on Ubuntu by default. Installing Go 1.17 from the tgz file now. 