### PR TITLE
Update module paths for v3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 
-* Update module path to `/v3` in `go.mod` and `main.go` [GH-]
+* Update module path to `/v3` in `go.mod` and `main.go` [GH-374]
 
 ## 3.0.1 (Mar 28, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,16 @@
+## 3.0.2 (Mar 29, 2022)
+
+IMPROVEMENTS:
+
+* Update module path to `/v3` in `go.mod` and `main.go` [GH-]
+
 ## 3.0.1 (Mar 28, 2022)
 
 BUG FIXES:
 
 * Fix retrieval_cache_period_seconds to be set to 0 for artifactory_remote_*_repository resources. [GH-373]
 
-## 3.0.0 (Apr 1, 2022)
+## 3.0.0 (Mar 28, 2022)
 
 BREAKING CHANGES:
 
@@ -57,12 +63,12 @@ FEATURES:
   * "artifactory_remote_puppet_repository"
   * "artifactory_remote_rpm_repository"
   * "artifactory_remote_nuget_repository"
-  
+
 ## 2.23.2 (Mar 17, 2022)
 
 IMPROVEMENTS:
 
-* Datasource `datasource_artifactory_file`, added a parameter `path_is_aliased`, 
+* Datasource `datasource_artifactory_file`, added a parameter `path_is_aliased`,
   assumes that the path supplied is an alias for the most recent version of the artifact and doesn't try to resolve it to a specific, timestamped, artifact
 
 ## 2.23.1 (Mar 15, 2022)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
-module github.com/jfrog/terraform-provider-artifactory/v2
+module github.com/jfrog/terraform-provider-artifactory/v3
 
 require (
+	github.com/andybalholm/brotli v1.0.4 // indirect
 	github.com/go-resty/resty/v2 v2.6.1-0.20210916045937-1792d629c3c6
 	github.com/google/go-querystring v1.1.0
 	github.com/gorhill/cronexpr v0.0.0-20180427100037-88b0669f7d75

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/agext/levenshtein v1.2.2 h1:0S/Yg6LYmFJ5stwQeRp6EeOcCbj7xiqQSdNelsXva
 github.com/agext/levenshtein v1.2.2/go.mod h1:JEDfjyjHDjOF/1e4FlBE/PkbqA9OfWu2ki2W0IB5558=
 github.com/andybalholm/brotli v1.0.1 h1:KqhlKozYbRtJvsPrrEeXcO+N2l6NYT5A2QAFmSULpEc=
 github.com/andybalholm/brotli v1.0.1/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
+github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
+github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/andybalholm/crlf v0.0.0-20171020200849-670099aa064f/go.mod h1:k8feO4+kXDxro6ErPXBRTJ/ro2mf0SsFG8s7doP9kJE=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239 h1:kFOfPq6dUM1hTo4JG6LR5AXSUEsOjtdm0kw0FtQtMJA=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=

--- a/main.go
+++ b/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/plugin"
 
-	"github.com/jfrog/terraform-provider-artifactory/v2/pkg/artifactory"
+	"github.com/jfrog/terraform-provider-artifactory/v3/pkg/artifactory"
 )
 
 func main() {


### PR DESCRIPTION
Also updated brotli package because `go get` returns:

```
go: warning: github.com/andybalholm/brotli@v1.0.1: retracted by module author: occasional panics and data corruption
```