### PR TITLE
GH-370 fix max unique tags does not reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* resource/artifactory_local_docker_v1_repository: Fix `max_unique_tags` with value 0 being ignored. [GH-]
+* resource/artifactory_local_docker_v1_repository: Fix `max_unique_tags` with value 0 being ignored. [GH-376]
 
 ## 3.0.2 (Mar 29, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* resource/artifactory_local_docker_v1_repository: Fix `max_unique_tags` with value 0 being ignored. [GH-376]
+* resource/artifactory_local_docker_v2_repository: Fix `max_unique_tags` with value 0 being ignored. [GH-376]
 
 ## 3.1.0 (Mar 29, 2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.0.3 (Mar 30, 2022)
+
+BUG FIXES:
+
+* resource/artifactory_local_docker_v1_repository: Fix `max_unique_tags` with value 0 being ignored. [GH-]
+
 ## 3.0.2 (Mar 29, 2022)
 
 IMPROVEMENTS:
@@ -92,7 +98,7 @@ FEATURES:
 
 BUG FIXES:
 
-*Conditional file download depending on `force_overwrite` value of data source `artifactory_file`. [GH-352]
+* Conditional file download depending on `force_overwrite` value of data source `artifactory_file`. [GH-352]
 
 ## 2.22.2 (Mar 10, 2022)
 

--- a/pkg/artifactory/resource_artifactory_local_docker_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_docker_repository.go
@@ -13,7 +13,7 @@ func resourceArtifactoryLocalDockerV2Repository() *schema.Resource {
 		"max_unique_tags": {
 			Type:     schema.TypeInt,
 			Optional: true,
-			Computed: false,
+			Default:  0,
 			Description: "The maximum number of unique tags of a single Docker image to store in this repository.\n" +
 				"Once the number tags for an image exceeds this setting, older tags are removed. A value of 0 (default) indicates there is no limit.\n" +
 				"This only applies to manifest v2",
@@ -127,7 +127,7 @@ func resourceArtifactoryLocalDockerV1Repository() *schema.Resource {
 
 type DockerLocalRepositoryParams struct {
 	LocalRepositoryBaseParams
-	MaxUniqueTags       int    `hcl:"max_unique_tags" json:"maxUniqueTags,omitempty"`
+	MaxUniqueTags       int    `hcl:"max_unique_tags" json:"maxUniqueTags"`
 	DockerApiVersion    string `hcl:"api_version" json:"dockerApiVersion"`
 	TagRetention        int    `hcl:"tag_retention" json:"dockerTagRetention"`
 	BlockPushingSchema1 bool   `hcl:"block_pushing_schema1" json:"blockPushingSchema1"`

--- a/pkg/artifactory/resource_artifactory_local_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_local_repository_test.go
@@ -327,6 +327,35 @@ func TestAccLocalDockerV2Repository(t *testing.T) {
 		},
 	})
 }
+
+func TestAccLocalDockerV2RepositoryWithDefaultMaxUniqueTagsGH370(t *testing.T) {
+
+	_, fqrn, name := mkNames("dockerv2-local", "artifactory_local_docker_v2_repository")
+	params := map[string]interface{}{
+		"name":  name,
+	}
+	localRepositoryBasic := executeTemplate("TestAccLocalDockerV2Repository", `
+		resource "artifactory_local_docker_v2_repository" "{{ .name }}" {
+			key = "{{ .name }}"
+		}
+	`, params)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
+		ProviderFactories: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: localRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "max_unique_tags", "0"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccLocalNugetRepository(t *testing.T) {
 
 	_, fqrn, name := mkNames("nuget-local", "artifactory_local_nuget_repository")


### PR DESCRIPTION
Fixes #370

- Fix `max_unique_tags` ignores 0 value
- Add default value (0) to the same