### PR TITLE
GH-340 Remove hashing of password for TF state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 3.1.3 (Apr 1, 2022)
+
+BUG FIXES:
+
+* Fix blank password getting sent to Artifactory when updating other attributes of `artifactory_user` resource. [GH-]
+
 ## 3.1.2 (Mar 31, 2022)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* Fix blank password getting sent to Artifactory when updating other attributes of `artifactory_user` resource. [GH-]
+* Fix blank password getting sent to Artifactory when updating other attributes of `artifactory_user` resource. [GH-383]
 
 ## 3.1.2 (Mar 31, 2022)
 

--- a/pkg/artifactory/resource_artifactory_user.go
+++ b/pkg/artifactory/resource_artifactory_user.go
@@ -1,8 +1,6 @@
 package artifactory
 
 import (
-	"crypto/sha256"
-	"encoding/base64"
 	"fmt"
 	"net/http"
 
@@ -94,15 +92,6 @@ func resourceArtifactoryUser() *schema.Resource {
 				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 				Description: "Password for the user. Password validation is not done by the provider and is " +
 					"offloaded onto the Artifactory.",
-				StateFunc: func(str interface{}) string {
-					// Avoid storing the actual value in the state and instead store the hash of it
-					value, ok := str.(string)
-					if !ok {
-						panic(fmt.Errorf("'str' is not a string %s", str))
-					}
-					hash := sha256.Sum256([]byte(value))
-					return base64.StdEncoding.EncodeToString(hash[:])
-				},
 			},
 		},
 	}
@@ -130,7 +119,7 @@ func unpackUser(s *schema.ResourceData) User {
 	return User{
 		Name:                     d.getString("name", false),
 		Email:                    d.getString("email", false),
-		Password:                 d.getString("password", true),
+		Password:                 d.getString("password", false),
 		Admin:                    d.getBool("admin", false),
 		ProfileUpdatable:         d.getBool("profile_updatable", false),
 		DisableUIAccess:          d.getBool("disable_ui_access", false),


### PR DESCRIPTION
Fixes #340 

Per [Terraform recommendation](https://www.terraform.io/plugin/sdkv2/best-practices/sensitive-state#don-t-encrypt-state), encrypting/hashing password is discouraged.

Switch to always unpack password attribute value