### PR TITLE
GH-347 remote repo password always update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.1 (Apr 4, 2022)
+
+BUG FIXES:
+
+* Fix remote repos' `password` attribute always being updated after initial `terraform apply` [GH-]
+
 ## 4.0.0 (Mar 31, 2022)
 
 BREAKING CHANGE:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* Fix remote repos' `password` attribute always being updated after initial `terraform apply` [GH-]
+* Fix remote repos' `password` attribute always being updated after initial `terraform apply` [GH-385]
 
 ## 4.0.0 (Mar 31, 2022)
 

--- a/pkg/artifactory/repositories.go
+++ b/pkg/artifactory/repositories.go
@@ -1273,7 +1273,6 @@ func composePacker(packers ...PackFunc) PackFunc {
 }
 
 var defaultPacker = universalPack(noClass)
-var noPasswordPacker = universalPack(noPassword)
 
 func inSchema(skeema map[string]*schema.Schema) func(payload interface{}, d *schema.ResourceData) error {
 	return universalPack(schemaHasKey(skeema))

--- a/pkg/artifactory/repositories.go
+++ b/pkg/artifactory/repositories.go
@@ -79,7 +79,7 @@ type RemoteRepositoryBaseParams struct {
 	PackageType              string   `hcl:"package_type" json:"packageType,omitempty"`
 	Url                      string   `hcl:"url" json:"url"`
 	Username                 string   `hcl:"username" json:"username,omitempty"`
-	Password                 string   `hcl:"password" json:"password,omitempty"`
+	Password                 string   `json:"password"`
 	Proxy                    string   `hcl:"proxy" json:"proxy"`
 	Description              string   `hcl:"description" json:"description,omitempty"`
 	Notes                    string   `hcl:"notes" json:"notes,omitempty"`
@@ -522,7 +522,6 @@ var baseRemoteRepoSchema = map[string]*schema.Schema{
 		Type:      schema.TypeString,
 		Optional:  true,
 		Sensitive: true,
-		StateFunc: getMD5Hash,
 	},
 	"proxy": {
 		Type:     schema.TypeString,
@@ -972,7 +971,7 @@ func unpackBaseRemoteRepo(s *schema.ResourceData, packageType string) RemoteRepo
 		PackageType:              packageType, // must be set independently
 		Url:                      d.getString("url", false),
 		Username:                 d.getString("username", true),
-		Password:                 d.getString("password", true),
+		Password:                 d.getString("password", false),
 		Proxy:                    d.getString("proxy", false),
 		Description:              d.getString("description", true),
 		Notes:                    d.getString("notes", true),
@@ -1092,11 +1091,7 @@ func universalUnpack(payload reflect.Type, s *schema.ResourceData) (interface{},
 		t = t.Elem()
 		v = v.Elem()
 	}
-	//lookup := map[reflect.Kind]func(field, val reflect.Value) {
-	//	reflect.String: func(field, val reflect.Value)  {
-	//		val.SetString(field.String())
-	//	},
-	//}
+
 	for i := 0; i < t.NumField(); i++ {
 		thing := v.Field(i)
 
@@ -1130,6 +1125,7 @@ func checkForHcl(mapper AutoMapper) AutoMapper {
 		return map[string]interface{}{}
 	}
 }
+
 func findInspector(kind reflect.Kind) AutoMapper {
 	switch kind {
 	case reflect.Struct:
@@ -1242,6 +1238,7 @@ func allHclPredicate(predicates ...HclPredicate) HclPredicate {
 }
 
 var noClass = ignoreHclPredicate("class", "rclass")
+var noPassword = ignoreHclPredicate("class", "rclass", "password")
 
 var allowAllPredicate = func(hcl string) bool {
 	return true
@@ -1276,6 +1273,7 @@ func composePacker(packers ...PackFunc) PackFunc {
 }
 
 var defaultPacker = universalPack(noClass)
+var noPasswordPacker = universalPack(noPassword)
 
 func inSchema(skeema map[string]*schema.Schema) func(payload interface{}, d *schema.ResourceData) error {
 	return universalPack(schemaHasKey(skeema))

--- a/pkg/artifactory/resource_artifactory_backup.go
+++ b/pkg/artifactory/resource_artifactory_backup.go
@@ -105,11 +105,8 @@ func resourceArtifactoryBackup() *schema.Resource {
 		}
 
 		matchedBackup := findBackup(backups, backup.Key)
-		packer := universalPack(
-			allHclPredicate(
-				noClass, schemaHasKey(backupSchema),
-			),
-		)
+		packer := universalPack(backupSchema, noClass)
+
 		return diag.FromErr(packer(&matchedBackup, d))
 	}
 

--- a/pkg/artifactory/resource_artifactory_backup.go
+++ b/pkg/artifactory/resource_artifactory_backup.go
@@ -105,7 +105,7 @@ func resourceArtifactoryBackup() *schema.Resource {
 		}
 
 		matchedBackup := findBackup(backups, backup.Key)
-		packer := universalPack(backupSchema, noClass)
+		packer := defaultPacker(backupSchema)
 
 		return diag.FromErr(packer(&matchedBackup, d))
 	}

--- a/pkg/artifactory/resource_artifactory_federated_generic_repository.go
+++ b/pkg/artifactory/resource_artifactory_federated_generic_repository.go
@@ -105,7 +105,7 @@ func resourceArtifactoryFederatedGenericRepository(repoType string) *schema.Reso
 	}
 
 	packer := composePacker(
-		universalPack(ignoreHclPredicate("class", "rclass", "member")),
+		universalPack(federatedSchema, ignoreHclPredicate("class", "rclass", "member")),
 		packMembers,
 	)
 

--- a/pkg/artifactory/resource_artifactory_federated_generic_repository.go
+++ b/pkg/artifactory/resource_artifactory_federated_generic_repository.go
@@ -105,7 +105,7 @@ func resourceArtifactoryFederatedGenericRepository(repoType string) *schema.Reso
 	}
 
 	packer := composePacker(
-		universalPack(federatedSchema, ignoreHclPredicate("class", "rclass", "member")),
+		universalPack(ignoreHclPredicate("class", "rclass", "member")),
 		packMembers,
 	)
 

--- a/pkg/artifactory/resource_artifactory_keypair.go
+++ b/pkg/artifactory/resource_artifactory_keypair.go
@@ -185,7 +185,11 @@ func unpackKeyPair(s *schema.ResourceData) (interface{}, string, error) {
 	return &result, result.PairName, nil
 }
 
-var keyPairPacker = universalPack(keyPairSchema, ignoreHclPredicate("class", "rclass", "private_key"))
+var keyPairPacker = universalPack(
+	allHclPredicate(
+		ignoreHclPredicate("private_key"), schemaHasKey(keyPairSchema),
+	),
+)
 
 func createKeyPair(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	keyPair, key, _ := unpackKeyPair(d)

--- a/pkg/artifactory/resource_artifactory_ldap_group_setting.go
+++ b/pkg/artifactory/resource_artifactory_ldap_group_setting.go
@@ -115,11 +115,8 @@ Hierarchy: The user's DN is indicative of the groups the user belongs to by usin
 				break
 			}
 		}
-		packer := universalPack(
-			allHclPredicate(
-				noClass, schemaHasKey(ldapGroupSettingsSchema),
-			),
-		)
+		packer := universalPack(ldapGroupSettingsSchema, noClass)
+
 		return diag.FromErr(packer(&matchedLdapGroupSetting, d))
 	}
 

--- a/pkg/artifactory/resource_artifactory_ldap_group_setting.go
+++ b/pkg/artifactory/resource_artifactory_ldap_group_setting.go
@@ -115,7 +115,7 @@ Hierarchy: The user's DN is indicative of the groups the user belongs to by usin
 				break
 			}
 		}
-		packer := universalPack(ldapGroupSettingsSchema, noClass)
+		packer := defaultPacker(ldapGroupSettingsSchema)
 
 		return diag.FromErr(packer(&matchedLdapGroupSetting, d))
 	}

--- a/pkg/artifactory/resource_artifactory_ldap_setting.go
+++ b/pkg/artifactory/resource_artifactory_ldap_setting.go
@@ -161,11 +161,8 @@ func resourceArtifactoryLdapSetting() *schema.Resource {
 			}
 		}
 		var ldapSettingClass = ignoreHclPredicate("class", "rclass", "manager_password")
-		packer := universalPack(
-			allHclPredicate(
-				ldapSettingClass, schemaHasKey(ldapSettingsSchema),
-			),
-		)
+		packer := universalPack(ldapSettingsSchema, ldapSettingClass)
+
 		return diag.FromErr(packer(&matchedLdapSetting, d))
 	}
 

--- a/pkg/artifactory/resource_artifactory_ldap_setting.go
+++ b/pkg/artifactory/resource_artifactory_ldap_setting.go
@@ -160,8 +160,12 @@ func resourceArtifactoryLdapSetting() *schema.Resource {
 				break
 			}
 		}
-		var ldapSettingClass = ignoreHclPredicate("class", "rclass", "manager_password")
-		packer := universalPack(ldapSettingsSchema, ldapSettingClass)
+
+		packer := universalPack(
+			allHclPredicate(
+				ignoreHclPredicate("class", "rclass", "manager_password"), schemaHasKey(ldapSettingsSchema),
+			),
+		)
 
 		return diag.FromErr(packer(&matchedLdapSetting, d))
 	}

--- a/pkg/artifactory/resource_artifactory_local_alpine_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_alpine_repository.go
@@ -31,7 +31,7 @@ func resourceArtifactoryLocalAlpineRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(alpineLocalSchema, defaultPacker, unPackLocalAlpineRepository, func() interface{} {
+	return mkResourceSchema(alpineLocalSchema, defaultPacker(alpineLocalSchema), unPackLocalAlpineRepository, func() interface{} {
 		return &AlpineLocalRepo{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
 				PackageType: packageType,

--- a/pkg/artifactory/resource_artifactory_local_cargo_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_cargo_repository.go
@@ -31,7 +31,7 @@ func resourceArtifactoryLocalCargoRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(cargoLocalSchema, defaultPacker, unPackLocalCargoRepository, func() interface{} {
+	return mkResourceSchema(cargoLocalSchema, defaultPacker(cargoLocalSchema), unPackLocalCargoRepository, func() interface{} {
 		return &CargoLocalRepo{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
 				PackageType: packageType,

--- a/pkg/artifactory/resource_artifactory_local_debian_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_debian_repository.go
@@ -46,7 +46,7 @@ func resourceArtifactoryLocalDebianRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(debianLocalSchema, defaultPacker, unPackLocalDebianRepository, func() interface{} {
+	return mkResourceSchema(debianLocalSchema, defaultPacker(debianLocalSchema), unPackLocalDebianRepository, func() interface{} {
 		return &DebianLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
 				PackageType: packageType,

--- a/pkg/artifactory/resource_artifactory_local_docker_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_docker_repository.go
@@ -39,7 +39,7 @@ func resourceArtifactoryLocalDockerV2Repository() *schema.Resource {
 		},
 	}, repoLayoutRefSchema("local", packageType))
 
-	packer := universalPack(dockerV2LocalSchema, noClass)
+	packer := defaultPacker(dockerV2LocalSchema)
 
 	var unPackLocalDockerV2Repository = func(data *schema.ResourceData) (interface{}, string, error) {
 		d := &ResourceData{ResourceData: data}
@@ -107,7 +107,7 @@ func resourceArtifactoryLocalDockerV1Repository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(skeema, defaultPacker, unPackLocalDockerV1Repository, func() interface{} {
+	return mkResourceSchema(skeema, defaultPacker(dockerV1LocalSchema), unPackLocalDockerV1Repository, func() interface{} {
 		return &DockerLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
 				PackageType: packageType,

--- a/pkg/artifactory/resource_artifactory_local_docker_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_docker_repository.go
@@ -39,11 +39,7 @@ func resourceArtifactoryLocalDockerV2Repository() *schema.Resource {
 		},
 	}, repoLayoutRefSchema("local", packageType))
 
-	packer := universalPack(
-		allHclPredicate(
-			noClass, schemaHasKey(dockerV2LocalSchema),
-		),
-	)
+	packer := universalPack(dockerV2LocalSchema, noClass)
 
 	var unPackLocalDockerV2Repository = func(data *schema.ResourceData) (interface{}, string, error) {
 		d := &ResourceData{ResourceData: data}

--- a/pkg/artifactory/resource_artifactory_local_generic_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_generic_repository.go
@@ -16,5 +16,5 @@ func resourceArtifactoryLocalGenericRepository(pkt string) *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 	mergedLocalRepoSchema := mergeSchema(baseLocalRepoSchema, repoLayoutRefSchema("local", pkt))
-	return mkResourceSchema(mergedLocalRepoSchema, universalPack(mergedLocalRepoSchema), unpack, constructor)
+	return mkResourceSchema(mergedLocalRepoSchema, defaultPacker(mergedLocalRepoSchema), unpack, constructor)
 }

--- a/pkg/artifactory/resource_artifactory_local_generic_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_generic_repository.go
@@ -16,5 +16,5 @@ func resourceArtifactoryLocalGenericRepository(pkt string) *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 	mergedLocalRepoSchema := mergeSchema(baseLocalRepoSchema, repoLayoutRefSchema("local", pkt))
-	return mkResourceSchema(mergedLocalRepoSchema, inSchema(mergedLocalRepoSchema), unpack, constructor)
+	return mkResourceSchema(mergedLocalRepoSchema, universalPack(mergedLocalRepoSchema), unpack, constructor)
 }

--- a/pkg/artifactory/resource_artifactory_local_java_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_java_repository.go
@@ -83,7 +83,7 @@ func resourceArtifactoryLocalJavaRepository(repoType string, suppressPom bool) *
 
 		return repo, repo.Id(), nil
 	}
-	return mkResourceSchema(javaLocalSchema, universalPack(javaLocalSchema), unPackLocalJavaRepository, func() interface{} {
+	return mkResourceSchema(javaLocalSchema, defaultPacker(javaLocalSchema), unPackLocalJavaRepository, func() interface{} {
 		return &JavaLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
 				PackageType: repoType,

--- a/pkg/artifactory/resource_artifactory_local_java_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_java_repository.go
@@ -83,7 +83,7 @@ func resourceArtifactoryLocalJavaRepository(repoType string, suppressPom bool) *
 
 		return repo, repo.Id(), nil
 	}
-	return mkResourceSchema(javaLocalSchema, inSchema(javaLocalSchema), unPackLocalJavaRepository, func() interface{} {
+	return mkResourceSchema(javaLocalSchema, universalPack(javaLocalSchema), unPackLocalJavaRepository, func() interface{} {
 		return &JavaLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
 				PackageType: repoType,

--- a/pkg/artifactory/resource_artifactory_local_nuget_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_nuget_repository.go
@@ -42,7 +42,7 @@ func resourceArtifactoryLocalNugetRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(nugetLocalSchema, defaultPacker, unPackLocalNugetRepository, func() interface{} {
+	return mkResourceSchema(nugetLocalSchema, defaultPacker(nugetLocalSchema), unPackLocalNugetRepository, func() interface{} {
 		return &NugetLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
 				PackageType: packageType,

--- a/pkg/artifactory/resource_artifactory_local_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_repository.go
@@ -126,7 +126,7 @@ var legacyLocalSchema = mergeSchema(map[string]*schema.Schema{
 }, compressionFormats)
 
 func resourceArtifactoryLocalRepository() *schema.Resource {
-	return mkResourceSchema(legacyLocalSchema, universalPack(legacyLocalSchema), unmarshalLocalRepository, func() interface{} {
+	return mkResourceSchema(legacyLocalSchema, defaultPacker(legacyLocalSchema), unmarshalLocalRepository, func() interface{} {
 		return &MessyLocalRepo{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
 				Rclass: "local",

--- a/pkg/artifactory/resource_artifactory_local_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_repository.go
@@ -126,7 +126,7 @@ var legacyLocalSchema = mergeSchema(map[string]*schema.Schema{
 }, compressionFormats)
 
 func resourceArtifactoryLocalRepository() *schema.Resource {
-	return mkResourceSchema(legacyLocalSchema, inSchema(legacyLocalSchema), unmarshalLocalRepository, func() interface{} {
+	return mkResourceSchema(legacyLocalSchema, universalPack(legacyLocalSchema), unmarshalLocalRepository, func() interface{} {
 		return &MessyLocalRepo{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
 				Rclass: "local",

--- a/pkg/artifactory/resource_artifactory_local_rpm_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_rpm_repository.go
@@ -63,7 +63,7 @@ func resourceArtifactoryLocalRpmRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(rpmLocalSchema, universalPack(rpmLocalSchema), unPackLocalRpmRepository, func() interface{} {
+	return mkResourceSchema(rpmLocalSchema, defaultPacker(rpmLocalSchema), unPackLocalRpmRepository, func() interface{} {
 		return &RpmLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
 				PackageType: packageType,

--- a/pkg/artifactory/resource_artifactory_local_rpm_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_rpm_repository.go
@@ -63,7 +63,7 @@ func resourceArtifactoryLocalRpmRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(rpmLocalSchema, inSchema(rpmLocalSchema), unPackLocalRpmRepository, func() interface{} {
+	return mkResourceSchema(rpmLocalSchema, universalPack(rpmLocalSchema), unPackLocalRpmRepository, func() interface{} {
 		return &RpmLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
 				PackageType: packageType,

--- a/pkg/artifactory/resource_artifactory_remote_bower_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_bower_repository.go
@@ -34,7 +34,14 @@ func resourceArtifactoryRemoteBowerRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(bowerRemoteSchema, noPasswordPacker, unpackBowerRemoteRepo, func() interface{} {
+	bowerRemoteRepoPacker := universalPack(
+		allHclPredicate(
+			noPassword,
+			schemaHasKey(bowerRemoteSchema),
+		),
+	)
+
+	return mkResourceSchema(bowerRemoteSchema, bowerRemoteRepoPacker, unpackBowerRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &BowerRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_bower_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_bower_repository.go
@@ -34,12 +34,7 @@ func resourceArtifactoryRemoteBowerRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	bowerRemoteRepoPacker := universalPack(
-		allHclPredicate(
-			noPassword,
-			schemaHasKey(bowerRemoteSchema),
-		),
-	)
+	bowerRemoteRepoPacker := universalPack(bowerRemoteSchema, noPassword)
 
 	return mkResourceSchema(bowerRemoteSchema, bowerRemoteRepoPacker, unpackBowerRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()

--- a/pkg/artifactory/resource_artifactory_remote_bower_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_bower_repository.go
@@ -34,9 +34,7 @@ func resourceArtifactoryRemoteBowerRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	bowerRemoteRepoPacker := universalPack(bowerRemoteSchema, noPassword)
-
-	return mkResourceSchema(bowerRemoteSchema, bowerRemoteRepoPacker, unpackBowerRemoteRepo, func() interface{} {
+	return mkResourceSchema(bowerRemoteSchema, defaultPacker(bowerRemoteSchema), unpackBowerRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &BowerRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_bower_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_bower_repository.go
@@ -34,7 +34,7 @@ func resourceArtifactoryRemoteBowerRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(bowerRemoteSchema, defaultPacker, unpackBowerRemoteRepo, func() interface{} {
+	return mkResourceSchema(bowerRemoteSchema, noPasswordPacker, unpackBowerRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &BowerRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_cargo_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_cargo_repository.go
@@ -39,7 +39,14 @@ func resourceArtifactoryRemoteCargoRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(cargoRemoteSchema, noPasswordPacker, unpackCargoRemoteRepo, func() interface{} {
+	cargoRemoteRepoPacker := universalPack(
+		allHclPredicate(
+			noPassword,
+			schemaHasKey(cargoRemoteSchema),
+		),
+	)
+
+	return mkResourceSchema(cargoRemoteSchema, cargoRemoteRepoPacker, unpackCargoRemoteRepo, func() interface{} {
 		return &CargoRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{
 				Rclass:      "remote",

--- a/pkg/artifactory/resource_artifactory_remote_cargo_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_cargo_repository.go
@@ -39,12 +39,7 @@ func resourceArtifactoryRemoteCargoRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	cargoRemoteRepoPacker := universalPack(
-		allHclPredicate(
-			noPassword,
-			schemaHasKey(cargoRemoteSchema),
-		),
-	)
+	cargoRemoteRepoPacker := universalPack(cargoRemoteSchema, noPassword)
 
 	return mkResourceSchema(cargoRemoteSchema, cargoRemoteRepoPacker, unpackCargoRemoteRepo, func() interface{} {
 		return &CargoRemoteRepo{

--- a/pkg/artifactory/resource_artifactory_remote_cargo_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_cargo_repository.go
@@ -39,9 +39,7 @@ func resourceArtifactoryRemoteCargoRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	cargoRemoteRepoPacker := universalPack(cargoRemoteSchema, noPassword)
-
-	return mkResourceSchema(cargoRemoteSchema, cargoRemoteRepoPacker, unpackCargoRemoteRepo, func() interface{} {
+	return mkResourceSchema(cargoRemoteSchema, defaultPacker(cargoRemoteSchema), unpackCargoRemoteRepo, func() interface{} {
 		return &CargoRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{
 				Rclass:      "remote",

--- a/pkg/artifactory/resource_artifactory_remote_cargo_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_cargo_repository.go
@@ -39,7 +39,7 @@ func resourceArtifactoryRemoteCargoRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(cargoRemoteSchema, defaultPacker, unpackCargoRemoteRepo, func() interface{} {
+	return mkResourceSchema(cargoRemoteSchema, noPasswordPacker, unpackCargoRemoteRepo, func() interface{} {
 		return &CargoRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{
 				Rclass:      "remote",

--- a/pkg/artifactory/resource_artifactory_remote_cocoapods_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_cocoapods_repository.go
@@ -34,12 +34,7 @@ func resourceArtifactoryRemoteCocoapodsRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	cocapodsRemoteRepoPacker := universalPack(
-		allHclPredicate(
-			noPassword,
-			schemaHasKey(cocoapodsRemoteSchema),
-		),
-	)
+	cocapodsRemoteRepoPacker := universalPack(cocoapodsRemoteSchema, noPassword)
 
 	return mkResourceSchema(cocoapodsRemoteSchema, cocapodsRemoteRepoPacker, unpackCocoapodsRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()

--- a/pkg/artifactory/resource_artifactory_remote_cocoapods_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_cocoapods_repository.go
@@ -34,7 +34,7 @@ func resourceArtifactoryRemoteCocoapodsRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(cocoapodsRemoteSchema, defaultPacker, unpackCocoapodsRemoteRepo, func() interface{} {
+	return mkResourceSchema(cocoapodsRemoteSchema, noPasswordPacker, unpackCocoapodsRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &CocoapodsRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_cocoapods_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_cocoapods_repository.go
@@ -34,7 +34,14 @@ func resourceArtifactoryRemoteCocoapodsRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(cocoapodsRemoteSchema, noPasswordPacker, unpackCocoapodsRemoteRepo, func() interface{} {
+	cocapodsRemoteRepoPacker := universalPack(
+		allHclPredicate(
+			noPassword,
+			schemaHasKey(cocoapodsRemoteSchema),
+		),
+	)
+
+	return mkResourceSchema(cocoapodsRemoteSchema, cocapodsRemoteRepoPacker, unpackCocoapodsRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &CocoapodsRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_cocoapods_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_cocoapods_repository.go
@@ -34,9 +34,7 @@ func resourceArtifactoryRemoteCocoapodsRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	cocapodsRemoteRepoPacker := universalPack(cocoapodsRemoteSchema, noPassword)
-
-	return mkResourceSchema(cocoapodsRemoteSchema, cocapodsRemoteRepoPacker, unpackCocoapodsRemoteRepo, func() interface{} {
+	return mkResourceSchema(cocoapodsRemoteSchema, defaultPacker(cocoapodsRemoteSchema), unpackCocoapodsRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &CocoapodsRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_composer_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_composer_repository.go
@@ -34,7 +34,14 @@ func resourceArtifactoryRemoteComposerRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(composerRemoteSchema, noPasswordPacker, unpackComposerRemoteRepo, func() interface{} {
+	composerRemoteRepoPacker := universalPack(
+		allHclPredicate(
+			noPassword,
+			schemaHasKey(composerRemoteSchema),
+		),
+	)
+
+	return mkResourceSchema(composerRemoteSchema, composerRemoteRepoPacker, unpackComposerRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &ComposerRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_composer_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_composer_repository.go
@@ -34,12 +34,7 @@ func resourceArtifactoryRemoteComposerRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	composerRemoteRepoPacker := universalPack(
-		allHclPredicate(
-			noPassword,
-			schemaHasKey(composerRemoteSchema),
-		),
-	)
+	composerRemoteRepoPacker := universalPack(composerRemoteSchema, noPassword)
 
 	return mkResourceSchema(composerRemoteSchema, composerRemoteRepoPacker, unpackComposerRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()

--- a/pkg/artifactory/resource_artifactory_remote_composer_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_composer_repository.go
@@ -34,7 +34,7 @@ func resourceArtifactoryRemoteComposerRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(composerRemoteSchema, defaultPacker, unpackComposerRemoteRepo, func() interface{} {
+	return mkResourceSchema(composerRemoteSchema, noPasswordPacker, unpackComposerRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &ComposerRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_composer_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_composer_repository.go
@@ -34,9 +34,7 @@ func resourceArtifactoryRemoteComposerRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	composerRemoteRepoPacker := universalPack(composerRemoteSchema, noPassword)
-
-	return mkResourceSchema(composerRemoteSchema, composerRemoteRepoPacker, unpackComposerRemoteRepo, func() interface{} {
+	return mkResourceSchema(composerRemoteSchema, defaultPacker(composerRemoteSchema), unpackComposerRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &ComposerRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_docker_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_docker_repository.go
@@ -63,13 +63,7 @@ func resourceArtifactoryRemoteDockerRepository() *schema.Resource {
 	}
 
 	// Special handling for "external_dependencies_patterns" attribute to match default value behavior in UI.
-	dockerRemoteRepoPacker := universalPack(
-		allHclPredicate(
-			noPassword,
-			ignoreHclPredicate("external_dependencies_patterns"),
-			schemaHasKey(dockerRemoteSchema),
-		),
-	)
+	dockerRemoteRepoPacker := universalPack(dockerRemoteSchema, noPassword, ignoreHclPredicate("external_dependencies_patterns"))
 
 	return mkResourceSchema(dockerRemoteSchema, dockerRemoteRepoPacker, unpackDockerRemoteRepo, func() interface{} {
 		return &DockerRemoteRepository{

--- a/pkg/artifactory/resource_artifactory_remote_docker_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_docker_repository.go
@@ -63,7 +63,13 @@ func resourceArtifactoryRemoteDockerRepository() *schema.Resource {
 	}
 
 	// Special handling for "external_dependencies_patterns" attribute to match default value behavior in UI.
-	dockerRemoteRepoPacker := universalPack(dockerRemoteSchema, noPassword, ignoreHclPredicate("external_dependencies_patterns"))
+	dockerRemoteRepoPacker := universalPack(
+		allHclPredicate(
+			schemaHasKey(dockerRemoteSchema),
+			noPassword,
+			ignoreHclPredicate("external_dependencies_patterns"),
+		),
+	)
 
 	return mkResourceSchema(dockerRemoteSchema, dockerRemoteRepoPacker, unpackDockerRemoteRepo, func() interface{} {
 		return &DockerRemoteRepository{

--- a/pkg/artifactory/resource_artifactory_remote_docker_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_docker_repository.go
@@ -65,7 +65,8 @@ func resourceArtifactoryRemoteDockerRepository() *schema.Resource {
 	// Special handling for "external_dependencies_patterns" attribute to match default value behavior in UI.
 	dockerRemoteRepoPacker := universalPack(
 		allHclPredicate(
-			ignoreHclPredicate("class", "rclass", "external_dependencies_patterns"),
+			noPassword,
+			ignoreHclPredicate("external_dependencies_patterns"),
 			schemaHasKey(dockerRemoteSchema),
 		),
 	)

--- a/pkg/artifactory/resource_artifactory_remote_generic_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_generic_repository.go
@@ -21,12 +21,7 @@ func resourceArtifactoryRemoteGenericRepository(pkt string) *schema.Resource {
 
 	mergedRemoteRepoSchema := mergeSchema(baseRemoteRepoSchema, repoLayoutRefSchema("remote", pkt))
 
-	genericRepoPacker := universalPack(
-		allHclPredicate(
-			noPassword,
-			schemaHasKey(mergedRemoteRepoSchema),
-		),
-	)
+	genericRepoPacker := universalPack(mergedRemoteRepoSchema, noPassword)
 
 	return mkResourceSchema(mergedRemoteRepoSchema, genericRepoPacker, unpack, constructor)
 }

--- a/pkg/artifactory/resource_artifactory_remote_generic_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_generic_repository.go
@@ -21,7 +21,5 @@ func resourceArtifactoryRemoteGenericRepository(pkt string) *schema.Resource {
 
 	mergedRemoteRepoSchema := mergeSchema(baseRemoteRepoSchema, repoLayoutRefSchema("remote", pkt))
 
-	genericRepoPacker := universalPack(mergedRemoteRepoSchema, noPassword)
-
-	return mkResourceSchema(mergedRemoteRepoSchema, genericRepoPacker, unpack, constructor)
+	return mkResourceSchema(mergedRemoteRepoSchema, defaultPacker(mergedRemoteRepoSchema), unpack, constructor)
 }

--- a/pkg/artifactory/resource_artifactory_remote_generic_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_generic_repository.go
@@ -13,10 +13,20 @@ func resourceArtifactoryRemoteGenericRepository(pkt string) *schema.Resource {
 			RemoteRepoLayoutRef: repoLayout.(string),
 		}
 	}
+
 	unpack := func(data *schema.ResourceData) (interface{}, string, error) {
 		repo := unpackBaseRemoteRepo(data, pkt)
 		return repo, repo.Id(), nil
 	}
+
 	mergedRemoteRepoSchema := mergeSchema(baseRemoteRepoSchema, repoLayoutRefSchema("remote", pkt))
-	return mkResourceSchema(mergedRemoteRepoSchema, inSchema(mergedRemoteRepoSchema), unpack, constructor)
+
+	genericRepoPacker := universalPack(
+		allHclPredicate(
+			noPassword,
+			schemaHasKey(mergedRemoteRepoSchema),
+		),
+	)
+
+	return mkResourceSchema(mergedRemoteRepoSchema, genericRepoPacker, unpack, constructor)
 }

--- a/pkg/artifactory/resource_artifactory_remote_go_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_go_repository.go
@@ -32,7 +32,7 @@ func resourceArtifactoryRemoteGoRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(goRemoteSchema, defaultPacker, unpackGoRemoteRepo, func() interface{} {
+	return mkResourceSchema(goRemoteSchema, noPasswordPacker, unpackGoRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &GoRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_go_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_go_repository.go
@@ -32,7 +32,14 @@ func resourceArtifactoryRemoteGoRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(goRemoteSchema, noPasswordPacker, unpackGoRemoteRepo, func() interface{} {
+	goRemoteRepoPacker := universalPack(
+		allHclPredicate(
+			noPassword,
+			schemaHasKey(goRemoteSchema),
+		),
+	)
+
+	return mkResourceSchema(goRemoteSchema, goRemoteRepoPacker, unpackGoRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &GoRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_go_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_go_repository.go
@@ -32,9 +32,7 @@ func resourceArtifactoryRemoteGoRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	goRemoteRepoPacker := universalPack(goRemoteSchema, noPassword)
-
-	return mkResourceSchema(goRemoteSchema, goRemoteRepoPacker, unpackGoRemoteRepo, func() interface{} {
+	return mkResourceSchema(goRemoteSchema, defaultPacker(goRemoteSchema), unpackGoRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &GoRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_go_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_go_repository.go
@@ -32,12 +32,7 @@ func resourceArtifactoryRemoteGoRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	goRemoteRepoPacker := universalPack(
-		allHclPredicate(
-			noPassword,
-			schemaHasKey(goRemoteSchema),
-		),
-	)
+	goRemoteRepoPacker := universalPack(goRemoteSchema, noPassword)
 
 	return mkResourceSchema(goRemoteSchema, goRemoteRepoPacker, unpackGoRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()

--- a/pkg/artifactory/resource_artifactory_remote_helm_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_helm_repository.go
@@ -58,13 +58,7 @@ func resourceArtifactoryRemoteHelmRepository() *schema.Resource {
 	}
 
 	// Special handling for "external_dependencies_patterns" attribute to match default value behavior in UI.
-	helmRemoteRepoPacker := universalPack(
-		allHclPredicate(
-			noPassword,
-			ignoreHclPredicate("external_dependencies_patterns"),
-			schemaHasKey(helmRemoteSchema),
-		),
-	)
+	helmRemoteRepoPacker := universalPack(helmRemoteSchema, noPassword, ignoreHclPredicate("external_dependencies_patterns"))
 
 	return mkResourceSchema(helmRemoteSchema, helmRemoteRepoPacker, unpackHelmRemoteRepo, func() interface{} {
 		return &HelmRemoteRepo{

--- a/pkg/artifactory/resource_artifactory_remote_helm_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_helm_repository.go
@@ -58,7 +58,13 @@ func resourceArtifactoryRemoteHelmRepository() *schema.Resource {
 	}
 
 	// Special handling for "external_dependencies_patterns" attribute to match default value behavior in UI.
-	helmRemoteRepoPacker := universalPack(helmRemoteSchema, noPassword, ignoreHclPredicate("external_dependencies_patterns"))
+	helmRemoteRepoPacker := universalPack(
+		allHclPredicate(
+			schemaHasKey(helmRemoteSchema),
+			noPassword,
+			ignoreHclPredicate("external_dependencies_patterns"),
+		),
+	)
 
 	return mkResourceSchema(helmRemoteSchema, helmRemoteRepoPacker, unpackHelmRemoteRepo, func() interface{} {
 		return &HelmRemoteRepo{

--- a/pkg/artifactory/resource_artifactory_remote_helm_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_helm_repository.go
@@ -60,7 +60,8 @@ func resourceArtifactoryRemoteHelmRepository() *schema.Resource {
 	// Special handling for "external_dependencies_patterns" attribute to match default value behavior in UI.
 	helmRemoteRepoPacker := universalPack(
 		allHclPredicate(
-			ignoreHclPredicate("class", "rclass", "external_dependencies_patterns"),
+			noPassword,
+			ignoreHclPredicate("external_dependencies_patterns"),
 			schemaHasKey(helmRemoteSchema),
 		),
 	)

--- a/pkg/artifactory/resource_artifactory_remote_java_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_java_repository.go
@@ -83,7 +83,14 @@ func resourceArtifactoryRemoteJavaRepository(repoType string, suppressPom bool) 
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(javaRemoteSchema, noPasswordPacker, unpackJavaRemoteRepo, func() interface{} {
+	javaRemoteRepoPacker := universalPack(
+		allHclPredicate(
+			noPassword,
+			schemaHasKey(javaRemoteSchema),
+		),
+	)
+
+	return mkResourceSchema(javaRemoteSchema, javaRemoteRepoPacker, unpackJavaRemoteRepo, func() interface{} {
 		return &JavaRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{
 				Rclass:      "remote",

--- a/pkg/artifactory/resource_artifactory_remote_java_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_java_repository.go
@@ -82,7 +82,8 @@ func resourceArtifactoryRemoteJavaRepository(repoType string, suppressPom bool) 
 		}
 		return repo, repo.Id(), nil
 	}
-	return mkResourceSchema(javaRemoteSchema, defaultPacker, unpackJavaRemoteRepo, func() interface{} {
+
+	return mkResourceSchema(javaRemoteSchema, noPasswordPacker, unpackJavaRemoteRepo, func() interface{} {
 		return &JavaRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{
 				Rclass:      "remote",

--- a/pkg/artifactory/resource_artifactory_remote_java_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_java_repository.go
@@ -83,9 +83,7 @@ func resourceArtifactoryRemoteJavaRepository(repoType string, suppressPom bool) 
 		return repo, repo.Id(), nil
 	}
 
-	javaRemoteRepoPacker := universalPack(javaRemoteSchema, noPassword)
-
-	return mkResourceSchema(javaRemoteSchema, javaRemoteRepoPacker, unpackJavaRemoteRepo, func() interface{} {
+	return mkResourceSchema(javaRemoteSchema, defaultPacker(javaRemoteSchema), unpackJavaRemoteRepo, func() interface{} {
 		return &JavaRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{
 				Rclass:      "remote",

--- a/pkg/artifactory/resource_artifactory_remote_java_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_java_repository.go
@@ -83,12 +83,7 @@ func resourceArtifactoryRemoteJavaRepository(repoType string, suppressPom bool) 
 		return repo, repo.Id(), nil
 	}
 
-	javaRemoteRepoPacker := universalPack(
-		allHclPredicate(
-			noPassword,
-			schemaHasKey(javaRemoteSchema),
-		),
-	)
+	javaRemoteRepoPacker := universalPack(javaRemoteSchema, noPassword)
 
 	return mkResourceSchema(javaRemoteSchema, javaRemoteRepoPacker, unpackJavaRemoteRepo, func() interface{} {
 		return &JavaRemoteRepo{

--- a/pkg/artifactory/resource_artifactory_remote_nuget_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_nuget_repository.go
@@ -57,12 +57,7 @@ func resourceArtifactoryRemoteNugetRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	nugetRemoteRepoPacker := universalPack(
-		allHclPredicate(
-			noPassword,
-			schemaHasKey(nugetRemoteSchema),
-		),
-	)
+	nugetRemoteRepoPacker := universalPack(nugetRemoteSchema, noPassword)
 
 	return mkResourceSchema(nugetRemoteSchema, nugetRemoteRepoPacker, unpackNugetRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()

--- a/pkg/artifactory/resource_artifactory_remote_nuget_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_nuget_repository.go
@@ -57,9 +57,7 @@ func resourceArtifactoryRemoteNugetRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	nugetRemoteRepoPacker := universalPack(nugetRemoteSchema, noPassword)
-
-	return mkResourceSchema(nugetRemoteSchema, nugetRemoteRepoPacker, unpackNugetRemoteRepo, func() interface{} {
+	return mkResourceSchema(nugetRemoteSchema, defaultPacker(nugetRemoteSchema), unpackNugetRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &NugetRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_nuget_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_nuget_repository.go
@@ -57,7 +57,14 @@ func resourceArtifactoryRemoteNugetRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(nugetRemoteSchema, noPasswordPacker, unpackNugetRemoteRepo, func() interface{} {
+	nugetRemoteRepoPacker := universalPack(
+		allHclPredicate(
+			noPassword,
+			schemaHasKey(nugetRemoteSchema),
+		),
+	)
+
+	return mkResourceSchema(nugetRemoteSchema, nugetRemoteRepoPacker, unpackNugetRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &NugetRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_nuget_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_nuget_repository.go
@@ -57,7 +57,7 @@ func resourceArtifactoryRemoteNugetRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(nugetRemoteSchema, defaultPacker, unpackNugetRemoteRepo, func() interface{} {
+	return mkResourceSchema(nugetRemoteSchema, noPasswordPacker, unpackNugetRemoteRepo, func() interface{} {
 		repoLayout, _ := getDefaultRepoLayoutRef("remote", packageType)()
 		return &NugetRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_remote_pypi_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_pypi_repository.go
@@ -41,7 +41,7 @@ func resourceArtifactoryRemotePypiRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(pypiRemoteSchema, defaultPacker, unpackPypiRemoteRepo, func() interface{} {
+	return mkResourceSchema(pypiRemoteSchema, noPasswordPacker, unpackPypiRemoteRepo, func() interface{} {
 		return &PypiRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{
 				Rclass:      "remote",

--- a/pkg/artifactory/resource_artifactory_remote_pypi_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_pypi_repository.go
@@ -41,7 +41,14 @@ func resourceArtifactoryRemotePypiRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(pypiRemoteSchema, noPasswordPacker, unpackPypiRemoteRepo, func() interface{} {
+	pypiRemoteRepoPacker := universalPack(
+		allHclPredicate(
+			noPassword,
+			schemaHasKey(pypiRemoteSchema),
+		),
+	)
+
+	return mkResourceSchema(pypiRemoteSchema, pypiRemoteRepoPacker, unpackPypiRemoteRepo, func() interface{} {
 		return &PypiRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{
 				Rclass:      "remote",

--- a/pkg/artifactory/resource_artifactory_remote_pypi_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_pypi_repository.go
@@ -41,9 +41,7 @@ func resourceArtifactoryRemotePypiRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	pypiRemoteRepoPacker := universalPack(pypiRemoteSchema, noPassword)
-
-	return mkResourceSchema(pypiRemoteSchema, pypiRemoteRepoPacker, unpackPypiRemoteRepo, func() interface{} {
+	return mkResourceSchema(pypiRemoteSchema, defaultPacker(pypiRemoteSchema), unpackPypiRemoteRepo, func() interface{} {
 		return &PypiRemoteRepo{
 			RemoteRepositoryBaseParams: RemoteRepositoryBaseParams{
 				Rclass:      "remote",

--- a/pkg/artifactory/resource_artifactory_remote_pypi_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_pypi_repository.go
@@ -41,12 +41,7 @@ func resourceArtifactoryRemotePypiRepository() *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	pypiRemoteRepoPacker := universalPack(
-		allHclPredicate(
-			noPassword,
-			schemaHasKey(pypiRemoteSchema),
-		),
-	)
+	pypiRemoteRepoPacker := universalPack(pypiRemoteSchema, noPassword)
 
 	return mkResourceSchema(pypiRemoteSchema, pypiRemoteRepoPacker, unpackPypiRemoteRepo, func() interface{} {
 		return &PypiRemoteRepo{

--- a/pkg/artifactory/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository_test.go
@@ -559,8 +559,7 @@ func mkNewRemoteTestCase(repoType string, t *testing.T, extraFields map[string]i
 		"key":      name,
 		"url":      "https://registry.npmjs.org/",
 		"username": "user",
-		// This returns encrypted. Can't be tested
-		//"password":                           "foo",
+		"password": "Password1",
 		"proxy": "",
 
 		//"description":                        "foo", // the server returns this suffixed. Test seperate
@@ -627,8 +626,7 @@ func mkRemoteTestCaseWithAdditionalCheckFunctions(repoType string, t *testing.T,
 		"key":      name,
 		"url":      "https://registry.npmjs.org/",
 		"username": "user",
-		// This returns encrypted. Can't be tested
-		//"password":                           "foo",
+		"password": "Password1",
 		"proxy": "",
 
 		//"description":                        "foo", // the server returns this suffixed. Test seperate

--- a/pkg/artifactory/resource_artifactory_virtual_alpine_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_alpine_repository.go
@@ -34,7 +34,7 @@ func resourceArtifactoryAlpineVirtualRepository() *schema.Resource {
 		return &repo, repo.Key, nil
 	}
 
-	return mkResourceSchema(alpineVirtualSchema, defaultPacker, unpackAlpineVirtualRepository, func() interface{} {
+	return mkResourceSchema(alpineVirtualSchema, defaultPacker(alpineVirtualSchema), unpackAlpineVirtualRepository, func() interface{} {
 		return &AlpineVirtualRepositoryParams{
 			VirtualRepositoryBaseParamsWithRetrievalCachePeriodSecs: VirtualRepositoryBaseParamsWithRetrievalCachePeriodSecs{
 				VirtualRepositoryBaseParams: VirtualRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_virtual_bower_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_bower_repository.go
@@ -56,7 +56,7 @@ func resourceArtifactoryBowerVirtualRepository() *schema.Resource {
 		return &repo, repo.Key, nil
 	}
 
-	return mkResourceSchema(bowerVirtualSchema, defaultPacker, unpackBowerVirtualRepository, func() interface{} {
+	return mkResourceSchema(bowerVirtualSchema, defaultPacker(bowerVirtualSchema), unpackBowerVirtualRepository, func() interface{} {
 		return &BowerVirtualRepositoryParams{
 			VirtualRepositoryBaseParams: VirtualRepositoryBaseParams{
 				Rclass:      "virtual",

--- a/pkg/artifactory/resource_artifactory_virtual_debian_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_debian_repository.go
@@ -66,7 +66,7 @@ func resourceArtifactoryDebianVirtualRepository() *schema.Resource {
 		return &repo, repo.Key, nil
 	}
 
-	return mkResourceSchema(debianVirtualSchema, defaultPacker, unpackDebianVirtualRepository, func() interface{} {
+	return mkResourceSchema(debianVirtualSchema, defaultPacker(debianVirtualSchema), unpackDebianVirtualRepository, func() interface{} {
 		return &DebianVirtualRepositoryParams{
 			VirtualRepositoryBaseParamsWithRetrievalCachePeriodSecs: VirtualRepositoryBaseParamsWithRetrievalCachePeriodSecs{
 				VirtualRepositoryBaseParams: VirtualRepositoryBaseParams{

--- a/pkg/artifactory/resource_artifactory_virtual_generic_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_generic_repository.go
@@ -17,7 +17,9 @@ func resourceArtifactoryVirtualGenericRepository(pkt string) *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	return mkResourceSchema(mergeSchema(baseVirtualRepoSchema, repoLayoutRefSchema("virtual", pkt)), defaultPacker, unpack, constructor)
+	genericSchema := mergeSchema(baseVirtualRepoSchema, repoLayoutRefSchema("virtual", pkt))
+
+	return mkResourceSchema(genericSchema, defaultPacker(genericSchema), unpack, constructor)
 }
 
 func resourceArtifactoryVirtualRepositoryWithRetrievalCachePeriodSecs(pkt string) *schema.Resource {
@@ -42,5 +44,5 @@ func resourceArtifactoryVirtualRepositoryWithRetrievalCachePeriodSecs(pkt string
 		repo := unpackBaseVirtRepoWithRetrievalCachePeriodSecs(data, pkt)
 		return repo, repo.Id(), nil
 	}
-	return mkResourceSchema(repoWithRetrivalCachePeriodSecsVirtualSchema, defaultPacker, unpack, constructor)
+	return mkResourceSchema(repoWithRetrivalCachePeriodSecsVirtualSchema, defaultPacker(repoWithRetrivalCachePeriodSecsVirtualSchema), unpack, constructor)
 }

--- a/pkg/artifactory/resource_artifactory_virtual_go_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_go_repository.go
@@ -48,7 +48,7 @@ func resourceArtifactoryGoVirtualRepository() *schema.Resource {
 		return &repo, repo.Key, nil
 	}
 
-	return mkResourceSchema(goVirtualSchema, defaultPacker, unpackGoVirtualRepository, func() interface{} {
+	return mkResourceSchema(goVirtualSchema, defaultPacker(goVirtualSchema), unpackGoVirtualRepository, func() interface{} {
 		return &GoVirtualRepositoryParams{
 			VirtualRepositoryBaseParams: VirtualRepositoryBaseParams{
 				Rclass:      "virtual",

--- a/pkg/artifactory/resource_artifactory_virtual_helm_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_helm_repository.go
@@ -44,5 +44,5 @@ func resourceArtifactoryHelmVirtualRepository() *schema.Resource {
 		}
 	}
 
-	return mkResourceSchema(helmVirtualSchema, defaultPacker, unpackHelmVirtualRepository, constructor)
+	return mkResourceSchema(helmVirtualSchema, defaultPacker(helmVirtualSchema), unpackHelmVirtualRepository, constructor)
 }

--- a/pkg/artifactory/resource_artifactory_virtual_java_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_java_repository.go
@@ -60,7 +60,7 @@ func resourceArtifactoryJavaVirtualRepository(repoType string) *schema.Resource 
 		return &repo, repo.Key, nil
 	}
 
-	return mkResourceSchema(mavenVirtualSchema, defaultPacker, unpackMavenVirtualRepository, func() interface{} {
+	return mkResourceSchema(mavenVirtualSchema, defaultPacker(mavenVirtualSchema), unpackMavenVirtualRepository, func() interface{} {
 		return &JavaVirtualRepositoryParams{
 			VirtualRepositoryBaseParams: VirtualRepositoryBaseParams{
 				Rclass:      "virtual",

--- a/pkg/artifactory/resource_artifactory_virtual_nuget_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_nuget_repository.go
@@ -33,7 +33,7 @@ func resourceArtifactoryNugetVirtualRepository() *schema.Resource {
 		return &repo, repo.Key, nil
 	}
 
-	return mkResourceSchema(nugetVirtualSchema, defaultPacker, unpackNugetVirtualRepository, func() interface{} {
+	return mkResourceSchema(nugetVirtualSchema, defaultPacker(nugetVirtualSchema), unpackNugetVirtualRepository, func() interface{} {
 		return &NugetVirtualRepositoryParams{
 			VirtualRepositoryBaseParams: VirtualRepositoryBaseParams{
 				Rclass:      "virtual",

--- a/pkg/artifactory/resource_artifactory_virtual_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_repository.go
@@ -72,7 +72,7 @@ var legacyVirtualSchema = map[string]*schema.Schema{
 }
 
 func resourceArtifactoryVirtualRepository() *schema.Resource {
-	skeema := mkResourceSchema(legacyVirtualSchema, inSchema(legacyVirtualSchema), unpackVirtualRepository, func() interface{} {
+	skeema := mkResourceSchema(legacyVirtualSchema, universalPack(legacyVirtualSchema), unpackVirtualRepository, func() interface{} {
 		return &MessyVirtualRepo{
 			VirtualRepositoryBaseParams: VirtualRepositoryBaseParams{
 				Rclass: "virtual",

--- a/pkg/artifactory/resource_artifactory_virtual_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_repository.go
@@ -72,7 +72,7 @@ var legacyVirtualSchema = map[string]*schema.Schema{
 }
 
 func resourceArtifactoryVirtualRepository() *schema.Resource {
-	skeema := mkResourceSchema(legacyVirtualSchema, universalPack(legacyVirtualSchema), unpackVirtualRepository, func() interface{} {
+	skeema := mkResourceSchema(legacyVirtualSchema, defaultPacker(legacyVirtualSchema), unpackVirtualRepository, func() interface{} {
 		return &MessyVirtualRepo{
 			VirtualRepositoryBaseParams: VirtualRepositoryBaseParams{
 				Rclass: "virtual",

--- a/pkg/artifactory/resource_artifactory_virtual_rpm_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_rpm_repository.go
@@ -49,7 +49,7 @@ func resourceArtifactoryRpmVirtualRepository() *schema.Resource {
 		return &repo, repo.Key, nil
 	}
 
-	return mkResourceSchema(rpmVirtualSchema, defaultPacker, unpackRpmVirtualRepository, func() interface{} {
+	return mkResourceSchema(rpmVirtualSchema, defaultPacker(rpmVirtualSchema), unpackRpmVirtualRepository, func() interface{} {
 		return &RpmVirtualRepositoryParams{
 			VirtualRepositoryBaseParams: VirtualRepositoryBaseParams{
 				Rclass:      "virtual",


### PR DESCRIPTION
Fixes #347

- Remove hashing of remote repos ‘password’ attribute
- Remove ‘omitempty’ tag for the same
- Add `noPassword` predicate and `noPasswordPacker` packer so the value from Artifactory API is ignored for TF state.


