### PR TITLE
docs: fix examples for federated repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 4.0.2 (Apr 6, 2022)
+
+BUG FIXES:
+
+* Fix typos in `artifactory_federated_*_repository` resources documentation.
+
 ## 4.0.1 (Apr 4, 2022)
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* Fix typos in `artifactory_federated_*_repository` resources documentation.
+* Fix typos in `artifactory_federated_*_repository` resources documentation. [GH-391]
 
 ## 4.0.1 (Apr 4, 2022)
 

--- a/docs/resources/artifactory_federated_alpine_repository.md
+++ b/docs/resources/artifactory_federated_alpine_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_alpine_repository" "terraform-federated-test-alp
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-alpine-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-alpine-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_bower_repository.md
+++ b/docs/resources/artifactory_federated_bower_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_bower_repository" "terraform-federated-test-bowe
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-bower-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-bower-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_cargo_repository.md
+++ b/docs/resources/artifactory_federated_cargo_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_cargo_repository" "terraform-federated-test-carg
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-cargo-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-cargo-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_chef_repository.md
+++ b/docs/resources/artifactory_federated_chef_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_chef_repository" "terraform-federated-test-chef-
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-chef-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-chef-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_cocoapods_repository.md
+++ b/docs/resources/artifactory_federated_cocoapods_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_cocoapods_repository" "terraform-federated-test-
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-cocoapods-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-cocoapods-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_composer_repository.md
+++ b/docs/resources/artifactory_federated_composer_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_composer_repository" "terraform-federated-test-c
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-composer-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-composer-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_conan_repository.md
+++ b/docs/resources/artifactory_federated_conan_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_conan_repository" "terraform-federated-test-cona
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-conan-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-conan-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_conda_repository.md
+++ b/docs/resources/artifactory_federated_conda_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_conda_repository" "terraform-federated-test-cond
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-conda-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-conda-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_cran_repository.md
+++ b/docs/resources/artifactory_federated_cran_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_cran_repository" "terraform-federated-test-cran-
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-cran-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-cran-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_debian_repository.md
+++ b/docs/resources/artifactory_federated_debian_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_debian_repository" "terraform-federated-test-deb
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-debian-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-debian-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_docker_repository.md
+++ b/docs/resources/artifactory_federated_docker_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_docker_repository" "terraform-federated-test-doc
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-docker-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-docker-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_gems_repository.md
+++ b/docs/resources/artifactory_federated_gems_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_gem_repository" "terraform-federated-test-gem-re
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-gem-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-gem-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_generic_repository.md
+++ b/docs/resources/artifactory_federated_generic_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_generic_repository" "terraform-federated-test-ge
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-generic-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-generic-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_gitlfs_repository.md
+++ b/docs/resources/artifactory_federated_gitlfs_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_gitlfs_repository" "terraform-federated-test-git
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-gitlfs-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-gitlfs-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_go_repository.md
+++ b/docs/resources/artifactory_federated_go_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_go_repository" "terraform-federated-test-go-repo
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-go-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-go-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_gradle_repository.md
+++ b/docs/resources/artifactory_federated_gradle_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_gradle_repository" "terraform-federated-test-gra
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-gradle-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-gradle-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_helm_repository.md
+++ b/docs/resources/artifactory_federated_helm_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_helm_repository" "terraform-federated-test-helm-
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-helm-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-helm-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_ivy_repository.md
+++ b/docs/resources/artifactory_federated_ivy_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_ivy_repository" "terraform-federated-test-ivy-re
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-ivy-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-ivy-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_maven_repository.md
+++ b/docs/resources/artifactory_federated_maven_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_maven_repository" "terraform-federated-test-mave
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-maven-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-maven-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_npm_repository.md
+++ b/docs/resources/artifactory_federated_npm_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_npm_repository" "terraform-federated-test-npm-re
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-npm-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-npm-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_nuget_repository.md
+++ b/docs/resources/artifactory_federated_nuget_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_nuget_repository" "terraform-federated-test-nuge
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-nuget-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-nuget-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_opkg_repository.md
+++ b/docs/resources/artifactory_federated_opkg_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_opkg_repository" "terraform-federated-test-opkg-
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-opkg-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-opkg-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_puppet_repository.md
+++ b/docs/resources/artifactory_federated_puppet_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_puppet_repository" "terraform-federated-test-pup
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-puppet-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-puppet-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_pypi_repository.md
+++ b/docs/resources/artifactory_federated_pypi_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_pypi_repository" "terraform-federated-test-pypi-
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-pypi-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-pypi-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_rpm_repository.md
+++ b/docs/resources/artifactory_federated_rpm_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_rpm_repository" "terraform-federated-test-rpm-re
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-rpm-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-rpm-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_sbt_repository.md
+++ b/docs/resources/artifactory_federated_sbt_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_sbt_repository" "terraform-federated-test-sbt-re
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-sbt-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-sbt-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```

--- a/docs/resources/artifactory_federated_vagrant_repository.md
+++ b/docs/resources/artifactory_federated_vagrant_repository.md
@@ -10,12 +10,12 @@ resource "artifactory_federated_vagrant_repository" "terraform-federated-test-va
 
   member {
     url    = "http://tempurl.org/artifactory/terraform-federated-test-vagrant-repo"
-    enable = true
+    enabled = true
   }
 
   member {
     url    = "http://tempurl2.org/artifactory/terraform-federated-test-vagrant-repo-2"
-    enable = true
+    enabled = true
   }
 }
 ```


### PR DESCRIPTION
Current examples for federated repositories don't work due to typos in the property name.