### PR TITLE
Add JFROG_ACCESS_TOKEN as a optional environemnt variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Requirements:
 
 ## Testing
 
-First, you need a running instance of the JFrog Artifactory. 
-You can ask for an instance to test against it as part of your PR. Alternatively, you can run the file [scripts/run-artifactory.sh](scripts/run-artifactory.sh). 
+First, you need a running instance of the JFrog Artifactory.
+You can ask for an instance to test against it as part of your PR. Alternatively, you can run the file [scripts/run-artifactory.sh](scripts/run-artifactory.sh).
 The script requires a valid license of a [supported type](https://github.com/jfrog/terraform-provider-artifactory#license-requirements), license should be saved in the file called `artifactory.lic` in the same directory as a script.
-With the script you can start one or two Artifactory instances using docker compose.   
-The license is not supplied, but a [30 day trial license can be freely obtained](https://jfrog.com/start-free/#hosted) and will allow local development. Make sure the license saved as a multi line text file. 
+With the script you can start one or two Artifactory instances using docker compose.
+The license is not supplied, but a [30 day trial license can be freely obtained](https://jfrog.com/start-free/#hosted) and will allow local development. Make sure the license saved as a multi line text file.
 
-Currently, acceptance tests **require access key** and don't support basic authentication and API key. To generate access key, please refer to the [official documentation](https://www.jfrog.com/confluence/display/JFROG/Access+Tokens#AccessTokens-GeneratingAdminTokens) 
+Currently, acceptance tests **require an access key** and don't support basic authentication or an API key. To generate an access key, please refer to the [official documentation](https://www.jfrog.com/confluence/display/JFROG/Access+Tokens#AccessTokens-GeneratingAdminTokens)
 Then, you have to set some environment variables as this is how the acceptance tests pick up their config.
 ```sh
 ARTIFACTORY_URL=http://localhost:8082
@@ -84,8 +84,8 @@ ARTIFACTORY_USERNAME=admin
 ARTIFACTORY_ACCESS_TOKEN=<your_access_token>
 TF_ACC=true
 ```
-`ARTIFACTORY_USERNAME` is not used in authentication, but used in several tests, related to replication functionality. 
-It should be hardcoded to `admin`, because it's a default user created in the Artifactory instance from the start. 
+`ARTIFACTORY_USERNAME` is not used in authentication, but used in several tests, related to replication functionality.
+It should be hardcoded to `admin`, because it's a default user created in the Artifactory instance from the start.
 A crucial, and very much hidden, env var to set is `TF_ACC=true` - you can literally set `TF_ACC` to anything you want, so long as it's set. The acceptance tests use terraform testing libraries that, if this flag isn't set, will skip all tests.
 
 You can then run the tests as

--- a/docs/index.md
+++ b/docs/index.md
@@ -63,7 +63,7 @@ The Artifactory provider supports two ways of authentication. The following meth
 
 ### Access Token
 Artifactory access tokens may be used via the Authorization header by providing the `access_token` field to the provider
-block. Getting this value from the environment is supported with the `ARTIFACTORY_ACCESS_TOKEN` variable
+block. Getting this value from the environment is supported with `JFROG_ACCESS_TOKEN` or `ARTIFACTORY_ACCESS_TOKEN` variables
 
 Usage:
 ```hcl
@@ -92,7 +92,7 @@ provider "artifactory" {
 The following arguments are supported:
 
 * `url` - (Optional) URL of Artifactory. This can also be sourced from the `ARTIFACTORY_URL` environment variable.
-* `access_token` - (Optional) This can also be sourced from the `ARTIFACTORY_ACCESS_TOKEN` environment variable.
+* `access_token` - (Optional) This can also be sourced from `JFROG_ACCESS_TOKEN` or `ARTIFACTORY_ACCESS_TOKEN` environment variables.
 * `api_key` - (Optional) API key for api auth. Uses `X-JFrog-Art-Api` header.
   Conflicts with `access_token`. This can also be sourced from the `ARTIFACTORY_API_KEY` environment variable.
 * `check_license` - (Optional) Toggle for pre-flight checking of Artifactory license. Default to `true`.

--- a/pkg/artifactory/provider.go
+++ b/pkg/artifactory/provider.go
@@ -127,7 +127,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
-				DefaultFunc: schema.EnvDefaultFunc("ARTIFACTORY_ACCESS_TOKEN", nil),
+				DefaultFunc: schema.MultiEnvDefaultFunc([]string{"ARTIFACTORY_ACCESS_TOKEN", "JFROG_ACCESS_TOKEN"}, ""),
 				Description: "This is a access token that can be given to you by your admin under `Identity and Access`",
 			},
 			"check_license": {

--- a/sample.tf
+++ b/sample.tf
@@ -9,7 +9,7 @@ terraform {
 }
 
 provider "artifactory" {
-  //  supply ARTIFACTORY_ACCESS_TOKEN / ARTIFACTORY_API_KEY and ARTIFACTORY_URL as env vars
+  //  supply ARTIFACTORY_ACCESS_TOKEN / JFROG_ACCESS_TOKEN / ARTIFACTORY_API_KEY and ARTIFACTORY_URL as env vars
 }
 
 resource "artifactory_local_bower_repository" "bower-local" {


### PR DESCRIPTION
Adds JFROG_ACCESS_TOKEN environment variable per https://github.com/jfrog/terraform-provider-artifactory/issues/414

I didn't see a useful way to add a test case for this change, and one didn't exist on https://github.com/jfrog/terraform-provider-xray