### PR TITLE
Improve code packaging

### DIFF
--- a/pkg/artifactory/datasource_artifactory_file_test.go
+++ b/pkg/artifactory/datasource_artifactory_file_test.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +20,7 @@ func downloadPreCheck(t *testing.T, downloadPath string, localFileModTime *time.
 	return func() {
 		const localFilePath = "../../samples/crash.zip"
 		testAccPreCheck(t)
-		client := getTestResty(t)
+		client := utils.GetTestResty(t)
 		err := uploadTestFile(client, localFilePath, "example-repo-local/crash.zip", "application/zip")
 		if err != nil {
 			panic(err)
@@ -38,7 +38,7 @@ func downloadPreCheck(t *testing.T, downloadPath string, localFileModTime *time.
 func uploadTwoArtifacts(t *testing.T) {
 	const localOlderFilePath = "../../samples/multi1-3.7-20220310.233748-1.jar"
 	const localNewerFilePath = "../../samples/multi1-3.7-20220310.233859-2.jar"
-	client := getTestResty(t)
+	client := utils.GetTestResty(t)
 	err := uploadTestFile(client, localOlderFilePath, "my-maven-local/org/jfrog/test/multi1/3.7-SNAPSHOT/multi1-3.7-20220310.233748-1.jar", "application/java-archive")
 	if err != nil {
 		panic(err)
@@ -81,7 +81,7 @@ func TestDlFile(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          downloadPreCheck(t, downloadPath, &localFileModTime),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(script, downloadPath),
@@ -126,13 +126,13 @@ func TestDownloadFileWithPath_is_aliased(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccDeleteRepo(t, "my-maven-local")
-			testAccCreateRepos(t, "my-maven-local", "local",
+			utils.TestAccDeleteRepo(t, "my-maven-local")
+			utils.TestAccCreateRepos(t, "my-maven-local", "local",
 				"maven", true, true)
 			uploadTwoArtifacts(t)
 		},
 
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(script, downloadPath),
@@ -164,13 +164,13 @@ func TestDownloadFileWithPath_is_aliasedNegative(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			testAccDeleteRepo(t, "my-maven-local")
-			testAccCreateRepos(t, "my-maven-local", "local",
+			utils.TestAccDeleteRepo(t, "my-maven-local")
+			utils.TestAccCreateRepos(t, "my-maven-local", "local",
 				"maven", true, true)
 			uploadTwoArtifacts(t)
 		},
 
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      fmt.Sprintf(script, downloadPath),
@@ -240,7 +240,7 @@ func TestFileDownloadSkipCheck(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          downloadPreCheck(t, downloadPath, &localFileModTime),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(noOverWriteForcedScript, downloadPath),

--- a/pkg/artifactory/datasource_artifactory_fileinfo.go
+++ b/pkg/artifactory/datasource_artifactory_fileinfo.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 
 	"github.com/go-resty/resty/v2"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func dataSourceArtifactoryFileInfo() *schema.Resource {
@@ -84,7 +84,7 @@ func dataSourceFileInfoRead(d *schema.ResourceData, m interface{}) error {
 }
 
 func packFileInfo(fileInfo FileInfo, d *schema.ResourceData) error {
-	setValue := mkLens(d)
+	setValue := utils.MkLens(d)
 
 	d.SetId(fileInfo.DownloadUri)
 

--- a/pkg/artifactory/provider_test.go
+++ b/pkg/artifactory/provider_test.go
@@ -42,7 +42,7 @@ func testAccPreCheck(t *testing.T) {
 	}
 
 	provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-	oldErr := utils.ConfigureProvider(provider)
+	_, oldErr := utils.ConfigureProvider(provider)
 	if oldErr != nil {
 		t.Fatal(oldErr)
 	}

--- a/pkg/artifactory/repositories.go
+++ b/pkg/artifactory/repositories.go
@@ -749,7 +749,7 @@ var baseRemoteRepoSchema = map[string]*schema.Schema{
 		Type:             schema.TypeString,
 		Optional:         true,
 		ValidateDiagFunc: utils.CommaSeperatedList,
-		StateFunc:        formatCommaSeparatedString,
+		StateFunc:        utils.FormatCommaSeparatedString,
 		Description:      `(Optional) The set of mime types that should override the block_mismatching_mime_types setting. Eg: "application/json,application/xml". Default value is empty.`,
 	},
 }
@@ -940,71 +940,71 @@ var baseFederatedRepoSchema = map[string]*schema.Schema{
 }
 
 func unpackBaseRepo(rclassType string, s *schema.ResourceData, packageType string) LocalRepositoryBaseParams {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	return LocalRepositoryBaseParams{
 		Rclass:                 rclassType,
-		Key:                    d.getString("key", false),
-		ProjectKey:             d.getString("project_key", false),
-		ProjectEnvironments:    d.getSet("project_environments"),
+		Key:                    d.GetString("key", false),
+		ProjectKey:             d.GetString("project_key", false),
+		ProjectEnvironments:    d.GetSet("project_environments"),
 		PackageType:            packageType,
-		Description:            d.getString("description", false),
-		Notes:                  d.getString("notes", false),
-		IncludesPattern:        d.getString("includes_pattern", false),
-		ExcludesPattern:        d.getString("excludes_pattern", false),
-		RepoLayoutRef:          d.getString("repo_layout_ref", false),
-		BlackedOut:             d.getBoolRef("blacked_out", false),
-		ArchiveBrowsingEnabled: d.getBoolRef("archive_browsing_enabled", false),
-		PropertySets:           d.getSet("property_sets"),
-		XrayIndex:              d.getBool("xray_index", false),
-		DownloadRedirect:       d.getBoolRef("download_direct", false),
-		PriorityResolution:     d.getBool("priority_resolution", false),
+		Description:            d.GetString("description", false),
+		Notes:                  d.GetString("notes", false),
+		IncludesPattern:        d.GetString("includes_pattern", false),
+		ExcludesPattern:        d.GetString("excludes_pattern", false),
+		RepoLayoutRef:          d.GetString("repo_layout_ref", false),
+		BlackedOut:             d.GetBoolRef("blacked_out", false),
+		ArchiveBrowsingEnabled: d.GetBoolRef("archive_browsing_enabled", false),
+		PropertySets:           d.GetSet("property_sets"),
+		XrayIndex:              d.GetBool("xray_index", false),
+		DownloadRedirect:       d.GetBoolRef("download_direct", false),
+		PriorityResolution:     d.GetBool("priority_resolution", false),
 	}
 }
 
 func unpackBaseRemoteRepo(s *schema.ResourceData, packageType string) RemoteRepositoryBaseParams {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 
 	repo := RemoteRepositoryBaseParams{
 		Rclass:                   "remote",
-		Key:                      d.getString("key", false),
-		ProjectKey:               d.getString("project_key", false),
-		ProjectEnvironments:      d.getSet("project_environments"),
+		Key:                      d.GetString("key", false),
+		ProjectKey:               d.GetString("project_key", false),
+		ProjectEnvironments:      d.GetSet("project_environments"),
 		PackageType:              packageType, // must be set independently
-		Url:                      d.getString("url", false),
-		Username:                 d.getString("username", true),
-		Password:                 d.getString("password", false),
-		Proxy:                    d.getString("proxy", false),
-		Description:              d.getString("description", true),
-		Notes:                    d.getString("notes", true),
-		IncludesPattern:          d.getString("includes_pattern", true),
-		ExcludesPattern:          d.getString("excludes_pattern", true),
-		RepoLayoutRef:            d.getString("repo_layout_ref", true),
-		HardFail:                 d.getBoolRef("hard_fail", true),
-		Offline:                  d.getBoolRef("offline", true),
-		BlackedOut:               d.getBoolRef("blacked_out", true),
-		XrayIndex:                d.getBool("xray_index", true),
-		PropagateQueryParams:     d.getBool("propagate_query_params", true),
-		StoreArtifactsLocally:    d.getBoolRef("store_artifacts_locally", true),
-		SocketTimeoutMillis:      d.getInt("socket_timeout_millis", true),
-		LocalAddress:             d.getString("local_address", true),
-		RetrievalCachePeriodSecs: d.getInt("retrieval_cache_period_seconds", false),
+		Url:                      d.GetString("url", false),
+		Username:                 d.GetString("username", true),
+		Password:                 d.GetString("password", false),
+		Proxy:                    d.GetString("proxy", false),
+		Description:              d.GetString("description", true),
+		Notes:                    d.GetString("notes", true),
+		IncludesPattern:          d.GetString("includes_pattern", true),
+		ExcludesPattern:          d.GetString("excludes_pattern", true),
+		RepoLayoutRef:            d.GetString("repo_layout_ref", true),
+		HardFail:                 d.GetBoolRef("hard_fail", true),
+		Offline:                  d.GetBoolRef("offline", true),
+		BlackedOut:               d.GetBoolRef("blacked_out", true),
+		XrayIndex:                d.GetBool("xray_index", true),
+		PropagateQueryParams:     d.GetBool("propagate_query_params", true),
+		StoreArtifactsLocally:    d.GetBoolRef("store_artifacts_locally", true),
+		SocketTimeoutMillis:      d.GetInt("socket_timeout_millis", true),
+		LocalAddress:             d.GetString("local_address", true),
+		RetrievalCachePeriodSecs: d.GetInt("retrieval_cache_period_seconds", false),
 		// Not returned in the GET
-		//FailedRetrievalCachePeriodSecs:    d.getInt("failed_retrieval_cache_period_secs", true),
-		MissedRetrievalCachePeriodSecs:    d.getInt("missed_cache_period_seconds", false),
-		UnusedArtifactsCleanupEnabled:     d.getBoolRef("unused_artifacts_cleanup_period_enabled", true),
-		UnusedArtifactsCleanupPeriodHours: d.getInt("unused_artifacts_cleanup_period_hours", true),
-		AssumedOfflinePeriodSecs:          d.getInt("assumed_offline_period_secs", true),
-		ShareConfiguration:                d.getBoolRef("share_configuration", true),
-		SynchronizeProperties:             d.getBoolRef("synchronize_properties", true),
-		BlockMismatchingMimeTypes:         d.getBoolRef("block_mismatching_mime_types", true),
-		PropertySets:                      d.getSet("property_sets"),
-		AllowAnyHostAuth:                  d.getBoolRef("allow_any_host_auth", true),
-		EnableCookieManagement:            d.getBoolRef("enable_cookie_management", true),
-		BypassHeadRequests:                d.getBoolRef("bypass_head_requests", true),
-		ClientTlsCertificate:              d.getString("client_tls_certificate", true),
-		PriorityResolution:                d.getBool("priority_resolution", false),
-		ListRemoteFolderItems:             d.getBool("list_remote_folder_items", false),
-		MismatchingMimeTypeOverrideList:   d.getString("mismatching_mime_types_override_list", false),
+		//FailedRetrievalCachePeriodSecs:    d.GetInt("failed_retrieval_cache_period_secs", true),
+		MissedRetrievalCachePeriodSecs:    d.GetInt("missed_cache_period_seconds", false),
+		UnusedArtifactsCleanupEnabled:     d.GetBoolRef("unused_artifacts_cleanup_period_enabled", true),
+		UnusedArtifactsCleanupPeriodHours: d.GetInt("unused_artifacts_cleanup_period_hours", true),
+		AssumedOfflinePeriodSecs:          d.GetInt("assumed_offline_period_secs", true),
+		ShareConfiguration:                d.GetBoolRef("share_configuration", true),
+		SynchronizeProperties:             d.GetBoolRef("synchronize_properties", true),
+		BlockMismatchingMimeTypes:         d.GetBoolRef("block_mismatching_mime_types", true),
+		PropertySets:                      d.GetSet("property_sets"),
+		AllowAnyHostAuth:                  d.GetBoolRef("allow_any_host_auth", true),
+		EnableCookieManagement:            d.GetBoolRef("enable_cookie_management", true),
+		BypassHeadRequests:                d.GetBoolRef("bypass_head_requests", true),
+		ClientTlsCertificate:              d.GetString("client_tls_certificate", true),
+		PriorityResolution:                d.GetBool("priority_resolution", false),
+		ListRemoteFolderItems:             d.GetBool("list_remote_folder_items", false),
+		MismatchingMimeTypeOverrideList:   d.GetString("mismatching_mime_types_override_list", false),
 	}
 	if v, ok := d.GetOk("content_synchronisation"); ok {
 		contentSynchronisationConfig := v.([]interface{})[0].(map[string]interface{})
@@ -1029,10 +1029,10 @@ func unpackBaseRemoteRepo(s *schema.ResourceData, packageType string) RemoteRepo
 }
 
 func unpackVcsRemoteRepo(s *schema.ResourceData) RemoteRepositoryVcsParams {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	repo := RemoteRepositoryVcsParams{
-		VcsGitProvider:    d.getString("vcs_git_provider", false),
-		VcsGitDownloadUrl: d.getString("vcs_git_download_url", false),
+		VcsGitProvider:    d.GetString("vcs_git_provider", false),
+		VcsGitDownloadUrl: d.GetString("vcs_git_download_url", false),
 	}
 	return repo
 }
@@ -1042,50 +1042,50 @@ func unpackVcsRemoteRepo(s *schema.ResourceData) RemoteRepositoryVcsParams {
 // Artifactory REST API will not accept empty string or null to reset value to not set
 // Instead, using a non-existant value works as a workaround
 // To ensure we don't accidentally set the value to a valid value, we use a UUID v4 string
-func handleResetWithNonExistantValue(d *ResourceData, key string) string {
-	value := d.getString(key, false)
+func handleResetWithNonExistantValue(d *utils.ResourceData, key string) string {
+	value := d.GetString(key, false)
 
 	// When value has changed and is empty string, then it has been removed from
 	// the Terraform configuration.
 	if value == "" && d.HasChange(key) {
-		return fmt.Sprintf("non-existant-value-%d", randomInt())
+		return fmt.Sprintf("non-existant-value-%d", utils.RandomInt())
 	}
 
 	return value
 }
 
 func unpackBaseVirtRepo(s *schema.ResourceData, packageType string) VirtualRepositoryBaseParams {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 
 	return VirtualRepositoryBaseParams{
-		Key:                 d.getString("key", false),
+		Key:                 d.GetString("key", false),
 		Rclass:              "virtual",
-		ProjectKey:          d.getString("project_key", false),
-		ProjectEnvironments: d.getSet("project_environments"),
+		ProjectKey:          d.GetString("project_key", false),
+		ProjectEnvironments: d.GetSet("project_environments"),
 		PackageType:         packageType, // must be set independently
-		IncludesPattern:     d.getString("includes_pattern", false),
-		ExcludesPattern:     d.getString("excludes_pattern", false),
-		RepoLayoutRef:       d.getString("repo_layout_ref", false),
-		ArtifactoryRequestsCanRetrieveRemoteArtifacts: d.getBool("artifactory_requests_can_retrieve_remote_artifacts", false),
-		Repositories:          d.getList("repositories"),
-		Description:           d.getString("description", false),
-		Notes:                 d.getString("notes", false),
+		IncludesPattern:     d.GetString("includes_pattern", false),
+		ExcludesPattern:     d.GetString("excludes_pattern", false),
+		RepoLayoutRef:       d.GetString("repo_layout_ref", false),
+		ArtifactoryRequestsCanRetrieveRemoteArtifacts: d.GetBool("artifactory_requests_can_retrieve_remote_artifacts", false),
+		Repositories:          d.GetList("repositories"),
+		Description:           d.GetString("description", false),
+		Notes:                 d.GetString("notes", false),
 		DefaultDeploymentRepo: handleResetWithNonExistantValue(d, "default_deployment_repo"),
 	}
 }
 
 func unpackBaseVirtRepoWithRetrievalCachePeriodSecs(s *schema.ResourceData, packageType string) VirtualRepositoryBaseParamsWithRetrievalCachePeriodSecs {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 
 	return VirtualRepositoryBaseParamsWithRetrievalCachePeriodSecs{
 		VirtualRepositoryBaseParams:     unpackBaseVirtRepo(s, packageType),
-		VirtualRetrievalCachePeriodSecs: d.getInt("retrieval_cache_period_seconds", false),
+		VirtualRetrievalCachePeriodSecs: d.GetInt("retrieval_cache_period_seconds", false),
 	}
 }
 
 // universalUnpack - todo implement me
 func universalUnpack(payload reflect.Type, s *schema.ResourceData) (interface{}, string, error) {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	var t = reflect.TypeOf(payload)
 	var v = reflect.ValueOf(payload)
 	if t.Kind() == reflect.Ptr {
@@ -1106,12 +1106,12 @@ func universalUnpack(payload reflect.Type, s *schema.ResourceData) (interface{},
 		}
 	}
 	result := KeyPairPayLoad{
-		PairName:    d.getString("pair_name", false),
-		PairType:    d.getString("pair_type", false),
-		Alias:       d.getString("alias", false),
-		PrivateKey:  strings.ReplaceAll(d.getString("private_key", false), "\t", ""),
-		PublicKey:   strings.ReplaceAll(d.getString("public_key", false), "\t", ""),
-		Unavailable: d.getBool("unavailable", false),
+		PairName:    d.GetString("pair_name", false),
+		PairType:    d.GetString("pair_type", false),
+		Alias:       d.GetString("alias", false),
+		PrivateKey:  strings.ReplaceAll(d.GetString("private_key", false), "\t", ""),
+		PublicKey:   strings.ReplaceAll(d.GetString("public_key", false), "\t", ""),
+		Unavailable: d.GetBool("unavailable", false),
 	}
 	return &result, result.PairName, nil
 }
@@ -1150,7 +1150,7 @@ func findInspector(kind reflect.Kind) AutoMapper {
 	case reflect.Slice:
 		return func(field reflect.StructField, thing reflect.Value) map[string]interface{} {
 			return map[string]interface{}{
-				fieldToHcl(field): castToInterfaceArr(thing.Interface().([]string)),
+				fieldToHcl(field): utils.CastToInterfaceArr(thing.Interface().([]string)),
 			}
 		}
 	}
@@ -1181,7 +1181,7 @@ func fieldToHcl(field reflect.StructField) string {
 	return result
 }
 
-func lookup(payload interface{}, predicate HclPredicate) map[string]interface{} {
+func lookup(payload interface{}, predicate utils.HclPredicate) map[string]interface{} {
 
 	if predicate == nil {
 		predicate = allowAllPredicate
@@ -1216,7 +1216,7 @@ func lookup(payload interface{}, predicate HclPredicate) map[string]interface{} 
 	return values
 }
 
-func anyHclPredicate(predicates ...HclPredicate) HclPredicate {
+func anyuHclPredicate(predicates ...utils.HclPredicate) utils.HclPredicate {
 	return func(hcl string) bool {
 		for _, predicate := range predicates {
 			if predicate(hcl) {
@@ -1227,7 +1227,7 @@ func anyHclPredicate(predicates ...HclPredicate) HclPredicate {
 	}
 }
 
-func allHclPredicate(predicates ...HclPredicate) HclPredicate {
+func allHclPredicate(predicates ...utils.HclPredicate) utils.HclPredicate {
 	return func(hcl string) bool {
 		for _, predicate := range predicates {
 			if !predicate(hcl) {
@@ -1245,7 +1245,7 @@ var allowAllPredicate = func(hcl string) bool {
 	return true
 }
 
-func ignoreHclPredicate(names ...string) HclPredicate {
+func ignoreHclPredicate(names ...string) utils.HclPredicate {
 	set := map[string]interface{}{}
 	for _, name := range names {
 		set[name] = nil
@@ -1274,15 +1274,15 @@ func composePacker(packers ...PackFunc) PackFunc {
 }
 
 func defaultPacker(skeema map[string]*schema.Schema) PackFunc {
-	return universalPack(allHclPredicate(schemaHasKey(skeema), noPassword))
+	return universalPack(allHclPredicate(utils.SchemaHasKey(skeema), noPassword))
 }
 
 // universalPack consider making this a function that takes a predicate of what to include and returns
 // a function that does the job. This would allow for the legacy code to specify which keys to keep and not
-func universalPack(predicate HclPredicate) PackFunc {
+func universalPack(predicate utils.HclPredicate) PackFunc {
 
 	return func(payload interface{}, d *schema.ResourceData) error {
-		setValue := mkLens(d)
+		setValue := utils.MkLens(d)
 
 		var errors []error
 

--- a/pkg/artifactory/repositories.go
+++ b/pkg/artifactory/repositories.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 const repositoriesEndpoint = "artifactory/api/repositories/"
@@ -402,7 +403,7 @@ var baseLocalRepoSchema = map[string]*schema.Schema{
 	"project_key": {
 		Type:             schema.TypeString,
 		Optional:         true,
-		ValidateDiagFunc: projectKeyValidator,
+		ValidateDiagFunc: utils.ProjectKeyValidator,
 		Description:      "Project key for assigning this repository to. When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.",
 	},
 	"project_environments": {
@@ -442,7 +443,7 @@ var baseLocalRepoSchema = map[string]*schema.Schema{
 	"repo_layout_ref": {
 		Type:             schema.TypeString,
 		Optional:         true,
-		ValidateDiagFunc: repoLayoutRefSchemaOverrideValidator,
+		ValidateDiagFunc: utils.RepoLayoutRefSchemaOverrideValidator,
 		Description:      "Sets the layout that the repository should use for storing and identifying modules. A recommended layout that corresponds to the package type defined is suggested, and index packages uploaded and calculate metadata accordingly.",
 	},
 	"blacked_out": {
@@ -492,7 +493,7 @@ var baseRemoteRepoSchema = map[string]*schema.Schema{
 	"project_key": {
 		Type:             schema.TypeString,
 		Optional:         true,
-		ValidateDiagFunc: projectKeyValidator,
+		ValidateDiagFunc: utils.ProjectKeyValidator,
 		Description:      "Project key for assigning this repository to. Must be 3 - 10 lowercase alphanumeric characters. When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.",
 	},
 	"project_environments": {
@@ -556,7 +557,7 @@ var baseRemoteRepoSchema = map[string]*schema.Schema{
 	"repo_layout_ref": {
 		Type:             schema.TypeString,
 		Optional:         true,
-		ValidateDiagFunc: repoLayoutRefSchemaOverrideValidator,
+		ValidateDiagFunc: utils.RepoLayoutRefSchemaOverrideValidator,
 		Description:      "Sets the layout that the repository should use for storing and identifying modules. A recommended layout that corresponds to the package type defined is suggested, and index packages uploaded and calculate metadata accordingly.",
 	},
 	"remote_repo_layout_ref": {
@@ -747,7 +748,7 @@ var baseRemoteRepoSchema = map[string]*schema.Schema{
 	"mismatching_mime_types_override_list": {
 		Type:             schema.TypeString,
 		Optional:         true,
-		ValidateDiagFunc: commaSeperatedList,
+		ValidateDiagFunc: utils.CommaSeperatedList,
 		StateFunc:        formatCommaSeparatedString,
 		Description:      `(Optional) The set of mime types that should override the block_mismatching_mime_types setting. Eg: "application/json,application/xml". Default value is empty.`,
 	},
@@ -779,7 +780,7 @@ var baseVirtualRepoSchema = map[string]*schema.Schema{
 	"project_key": {
 		Type:             schema.TypeString,
 		Optional:         true,
-		ValidateDiagFunc: projectKeyValidator,
+		ValidateDiagFunc: utils.ProjectKeyValidator,
 		Description:      "Project key for assigning this repository to. Must be 3 - 10 lowercase alphanumeric characters. When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.",
 	},
 	"project_environments": {
@@ -823,7 +824,7 @@ var baseVirtualRepoSchema = map[string]*schema.Schema{
 	"repo_layout_ref": {
 		Type:             schema.TypeString,
 		Optional:         true,
-		ValidateDiagFunc: repoLayoutRefSchemaOverrideValidator,
+		ValidateDiagFunc: utils.RepoLayoutRefSchemaOverrideValidator,
 		Description:      "Sets the layout that the repository should use for storing and identifying modules. A recommended layout that corresponds to the package type defined is suggested, and index packages uploaded and calculate metadata accordingly.",
 	},
 	"repositories": {
@@ -863,7 +864,7 @@ var baseFederatedRepoSchema = map[string]*schema.Schema{
 	"project_key": {
 		Type:             schema.TypeString,
 		Optional:         true,
-		ValidateDiagFunc: projectKeyValidator,
+		ValidateDiagFunc: utils.ProjectKeyValidator,
 		Description:      "Project key for assigning this repository to. When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.",
 	},
 	"project_environments": {
@@ -902,7 +903,7 @@ var baseFederatedRepoSchema = map[string]*schema.Schema{
 	"repo_layout_ref": {
 		Type:             schema.TypeString,
 		Optional:         true,
-		ValidateDiagFunc: repoLayoutRefSchemaOverrideValidator,
+		ValidateDiagFunc: utils.RepoLayoutRefSchemaOverrideValidator,
 		Description:      "Sets the layout that the repository should use for storing and identifying modules. A recommended layout that corresponds to the package type defined is suggested, and index packages uploaded and calculate metadata accordingly.",
 	},
 	"blacked_out": {

--- a/pkg/artifactory/resource_artifactory_access_token.go
+++ b/pkg/artifactory/resource_artifactory_access_token.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/google/go-querystring/query"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 // AccessTokenRevokeOptions jfrog client go has no v1 code and moving to v2 would be a lot of work.
@@ -164,7 +165,7 @@ func resourceAccessTokenCreate(d *schema.ResourceData, m interface{}) error {
 	grantType := "client_credentials" // client_credentials is the only supported type
 
 	tokenOptions := AccessTokenOptions{}
-	resourceData := &ResourceData{d}
+	resourceData := &utils.ResourceData{d}
 
 	date, expiresIn, err := getDate(d)
 	if err != nil {
@@ -183,7 +184,7 @@ func resourceAccessTokenCreate(d *schema.ResourceData, m interface{}) error {
 	tokenOptions.Audience = audience
 	tokenOptions.GrantType = grantType
 	tokenOptions.Refreshable = strconv.FormatBool(refreshable)
-	tokenOptions.Username = resourceData.getString("username", false)
+	tokenOptions.Username = resourceData.GetString("username", false)
 
 	username := resourceData.Get("username").(string)
 	userExists, _ := checkUserExists(client, username)

--- a/pkg/artifactory/resource_artifactory_access_token_test.go
+++ b/pkg/artifactory/resource_artifactory_access_token_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccAccessTokenAudienceBad(t *testing.T) {
@@ -32,7 +33,7 @@ func TestAccAccessTokenAudienceBad(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      audienceBad,
@@ -62,7 +63,7 @@ func TestAccAccessTokenAudienceGood(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: audienceGood,
@@ -99,7 +100,7 @@ func TestAccAccessTokenExistingUser(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: existingUser,
@@ -141,7 +142,7 @@ func TestAccAccessTokenFixedDateGood(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fixedDateGood(),
@@ -177,7 +178,7 @@ func TestAccAccessTokenFixedDateBad(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      fixedDateBad,
@@ -212,7 +213,7 @@ func TestAccAccessTokenAdminToken(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      adminToken,
@@ -242,7 +243,7 @@ func TestAccAccessTokenRefreshableToken(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: refreshableToken,
@@ -273,7 +274,7 @@ func TestAccAccessTokenMissingUserBad(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      missingUserBad,
@@ -297,7 +298,7 @@ func TestAccAccessTokenMissingUserGood(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: missingUserGood,
@@ -338,7 +339,7 @@ func TestAccAccessTokenMissingGroup(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      missingGroup,
@@ -370,7 +371,7 @@ func TestAccAccessTokenWildcardGroupGood(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: wildcardGroupGood,
@@ -408,7 +409,7 @@ func TestAccAccessTokenNonExpiringToken(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckAccessTokenDestroy("artifactory_access_token.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: nonExpiringToken,
@@ -445,12 +446,12 @@ func testAccCheckAccessTokenDestroy(id string) func(*terraform.State) error {
 		// We want to check that the token cannot authenticate
 		url := os.Getenv("ARTIFACTORY_URL")
 
-		resty, err := buildResty(url)
+		resty, err := utils.BuildResty(url, "")
 		if err != nil {
 			return err
 		}
 		accessToken := rs.Primary.Attributes["access_token"]
-		resty, err = addAuthToResty(resty, "", accessToken)
+		resty, err = utils.AddAuthToResty(resty, "", accessToken)
 		if err != nil {
 			return err
 		}

--- a/pkg/artifactory/resource_artifactory_anonymous_user.go
+++ b/pkg/artifactory/resource_artifactory_anonymous_user.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryAnonymousUser() *schema.Resource {
@@ -27,7 +28,7 @@ func resourceArtifactoryAnonymousUser() *schema.Resource {
 
 	packAnonymousUser := func(user AnonymousUser, d *schema.ResourceData) diag.Diagnostics {
 
-		setValue := mkLens(d)
+		setValue := utils.MkLens(d)
 
 		errors := setValue("name", user.Name)
 
@@ -39,7 +40,7 @@ func resourceArtifactoryAnonymousUser() *schema.Resource {
 	}
 
 	resourceAnonymousUserRead := func(ctx context.Context, rd *schema.ResourceData, m interface{}) diag.Diagnostics {
-		d := &ResourceData{rd}
+		d := &utils.ResourceData{rd}
 
 		userName := d.Id()
 		user := &AnonymousUser{}

--- a/pkg/artifactory/resource_artifactory_anonymous_user_test.go
+++ b/pkg/artifactory/resource_artifactory_anonymous_user_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccAnonymousUserImportable(t *testing.T) {
@@ -19,7 +20,7 @@ func TestAccAnonymousUserImportable(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:            anonymousUserConfig,
@@ -60,7 +61,7 @@ func TestAccAnonymousUserNotCreateable(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      anonymousUserConfig,

--- a/pkg/artifactory/resource_artifactory_api_key.go
+++ b/pkg/artifactory/resource_artifactory_api_key.go
@@ -5,8 +5,8 @@ import (
 	"strconv"
 
 	"github.com/go-resty/resty/v2"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type ApiKey struct {
@@ -37,7 +37,7 @@ func resourceArtifactoryApiKey() *schema.Resource {
 
 func packApiKey(apiKey string, d *schema.ResourceData) error {
 
-	setValue := mkLens(d)
+	setValue := utils.MkLens(d)
 
 	errors := setValue("api_key", apiKey)
 

--- a/pkg/artifactory/resource_artifactory_api_key_test.go
+++ b/pkg/artifactory/resource_artifactory_api_key_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccApiKey(t *testing.T) {
@@ -18,7 +19,7 @@ func TestAccApiKey(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckApiKeyDestroy("artifactory_api_key.foobar"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: apiKey,
@@ -32,7 +33,8 @@ func TestAccApiKey(t *testing.T) {
 
 func testAccCheckApiKeyDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		client := provider.Meta().(*resty.Client)
 		rs, ok := s.RootModule().Resources[id]
 

--- a/pkg/artifactory/resource_artifactory_api_key_test.go
+++ b/pkg/artifactory/resource_artifactory_api_key_test.go
@@ -34,13 +34,17 @@ func TestAccApiKey(t *testing.T) {
 func testAccCheckApiKeyDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		client := provider.Meta().(*resty.Client)
 		rs, ok := s.RootModule().Resources[id]
-
 		if !ok {
 			return fmt.Errorf("err: Resource id[%s] not found", id)
 		}
+
 		data := make(map[string]string)
 
 		_, err := client.R().SetResult(&data).Get(apiKeyEndpoint)

--- a/pkg/artifactory/resource_artifactory_backup.go
+++ b/pkg/artifactory/resource_artifactory_backup.go
@@ -129,7 +129,7 @@ func resourceArtifactoryBackup() *schema.Resource {
 			return diag.FromErr(err)
 		}
 
-		err = sendConfigurationPatch(content, m)
+		err = utils.SendConfigurationPatch(content, m)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -163,7 +163,7 @@ func resourceArtifactoryBackup() *schema.Resource {
 		var clearAllBackupConfigs = `
 backups: ~
 `
-		err = sendConfigurationPatch([]byte(clearAllBackupConfigs), m)
+		err = utils.SendConfigurationPatch([]byte(clearAllBackupConfigs), m)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -173,7 +173,7 @@ backups: ~
 			return diag.FromErr(err)
 		}
 
-		err = sendConfigurationPatch([]byte(restoreRestOfBackups), m)
+		err = utils.SendConfigurationPatch([]byte(restoreRestOfBackups), m)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -196,16 +196,16 @@ backups: ~
 }
 
 func unpackBackup(s *schema.ResourceData) Backup {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	backup := Backup{
-		Key:                    d.getString("key", false),
-		Enabled:                d.getBool("enabled", false),
-		CronExp:                d.getString("cron_exp", false),
-		RetentionPeriodHours:   d.getInt("retention_period_hours", false),
-		CreateArchive:          d.getBool("create_archive", false),
-		ExcludeNewRepositories: d.getBool("exclude_new_repositories", false),
-		SendMailOnError:        d.getBool("send_mail_on_error", false),
-		ExcludedRepositories:   d.getList("excluded_repositories"),
+		Key:                    d.GetString("key", false),
+		Enabled:                d.GetBool("enabled", false),
+		CronExp:                d.GetString("cron_exp", false),
+		RetentionPeriodHours:   d.GetInt("retention_period_hours", false),
+		CreateArchive:          d.GetBool("create_archive", false),
+		ExcludeNewRepositories: d.GetBool("exclude_new_repositories", false),
+		SendMailOnError:        d.GetBool("send_mail_on_error", false),
+		ExcludedRepositories:   d.GetList("excluded_repositories"),
 	}
 	return backup
 }

--- a/pkg/artifactory/resource_artifactory_backup.go
+++ b/pkg/artifactory/resource_artifactory_backup.go
@@ -2,12 +2,13 @@ package artifactory
 
 import (
 	"context"
-	"gopkg.in/yaml.v2"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
+	"gopkg.in/yaml.v2"
 )
 
 type Backup struct {
@@ -43,7 +44,7 @@ func resourceArtifactoryBackup() *schema.Resource {
 		"cron_exp": {
 			Type:             schema.TypeString,
 			Required:         true,
-			ValidateDiagFunc: validation.ToDiagFunc(validateCron),
+			ValidateDiagFunc: validation.ToDiagFunc(utils.ValidateCron),
 			Description:      `(Required) Cron expression to control the backup frequency.`,
 		},
 		"retention_period_hours": {

--- a/pkg/artifactory/resource_artifactory_backup_test.go
+++ b/pkg/artifactory/resource_artifactory_backup_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccBackup_full(t *testing.T) {
@@ -34,7 +35,7 @@ resource "artifactory_backup" "backuptest" {
 }`
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccBackupDestroy("backuptest"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -59,7 +60,8 @@ resource "artifactory_backup" "backuptest" {
 
 func testAccBackupDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		client := provider.Meta().(*resty.Client)
 
 		_, ok := s.RootModule().Resources["artifactory_backup."+id]

--- a/pkg/artifactory/resource_artifactory_backup_test.go
+++ b/pkg/artifactory/resource_artifactory_backup_test.go
@@ -61,7 +61,11 @@ resource "artifactory_backup" "backuptest" {
 func testAccBackupDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		client := provider.Meta().(*resty.Client)
 
 		_, ok := s.RootModule().Resources["artifactory_backup."+id]

--- a/pkg/artifactory/resource_artifactory_certificate.go
+++ b/pkg/artifactory/resource_artifactory_certificate.go
@@ -12,9 +12,9 @@ import (
 	"strings"
 
 	"github.com/go-resty/resty/v2"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 const endpoint = "artifactory/api/system/security/certificates/"
@@ -195,7 +195,7 @@ func resourceCertificateRead(d *schema.ResourceData, m interface{}) error {
 	}
 
 	if cert != nil {
-		setValue := mkLens(d)
+		setValue := utils.MkLens(d)
 
 		setValue("alias", (*cert).CertificateAlias)
 		setValue("fingerprint", (*cert).FingerPrint)

--- a/pkg/artifactory/resource_artifactory_certificate_test.go
+++ b/pkg/artifactory/resource_artifactory_certificate_test.go
@@ -152,7 +152,11 @@ func testAccCheckCertificateDestroy(id string) func(*terraform.State) error {
 			return fmt.Errorf("err: Resource id[%s] not found", id)
 		}
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		cert, err := findCertificate(id, provider.Meta())
 		if err != nil {
 			return err

--- a/pkg/artifactory/resource_artifactory_certificate_test.go
+++ b/pkg/artifactory/resource_artifactory_certificate_test.go
@@ -20,7 +20,7 @@ func TestHasFileAndContentFails(t *testing.T) {
 		}
 	`
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      conflictsResource,
@@ -39,7 +39,7 @@ func TestAccCertWithFileMissing(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckCertificateDestroy("artifactory_certificate.fail"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      certWithMissingFile,
@@ -62,7 +62,7 @@ func TestAccCertWithFile(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckCertificateDestroy(fqrn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(certWithFile, name, name),
@@ -127,7 +127,7 @@ func TestAccCertificate_full(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckCertificateDestroy(fqrn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: cleansed,
@@ -151,7 +151,8 @@ func testAccCheckCertificateDestroy(id string) func(*terraform.State) error {
 		if !ok {
 			return fmt.Errorf("err: Resource id[%s] not found", id)
 		}
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		cert, err := findCertificate(id, provider.Meta())
 		if err != nil {
 			return err

--- a/pkg/artifactory/resource_artifactory_certificate_test.go
+++ b/pkg/artifactory/resource_artifactory_certificate_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestHasFileAndContentFails(t *testing.T) {
@@ -52,10 +53,10 @@ func TestAccCertWithFile(t *testing.T) {
 	const certWithFile = `
 		resource "artifactory_certificate" "%s" {
 			alias   = "%s"
-			file = "../../samples/cert.pem" 
+			file = "../../samples/cert.pem"
 		}
 	`
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("foobar%d", id)
 	fqrn := fmt.Sprintf("artifactory_certificate.%s", name)
 	resource.Test(t, resource.TestCase{
@@ -117,7 +118,7 @@ func TestAccCertificate_full(t *testing.T) {
 		EOF
 		}
 	`
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("foobar%d", id)
 	fqrn := fmt.Sprintf("artifactory_certificate.%s", name)
 	subbed := fmt.Sprintf(certificateFull, name, name)

--- a/pkg/artifactory/resource_artifactory_federated_generic_repository.go
+++ b/pkg/artifactory/resource_artifactory_federated_generic_repository.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryFederatedGenericRepository(repoType string) *schema.Resource {
 
-	var federatedSchema = mergeSchema(baseFederatedRepoSchema, map[string]*schema.Schema{
+	var federatedSchema = utils.MergeSchema(baseFederatedRepoSchema, map[string]*schema.Schema{
 		"member": {
 			Type:     schema.TypeSet,
 			Required: true,
@@ -48,7 +49,7 @@ func resourceArtifactoryFederatedGenericRepository(repoType string) *schema.Reso
 	}
 
 	var unpackMembers = func(data *schema.ResourceData) []Member {
-		d := &ResourceData{data}
+		d := &utils.ResourceData{data}
 
 		var members []Member
 
@@ -81,7 +82,7 @@ func resourceArtifactoryFederatedGenericRepository(repoType string) *schema.Reso
 	}
 
 	var packMembers = func(repo interface{}, d *schema.ResourceData) error {
-		setValue := mkLens(d)
+		setValue := utils.MkLens(d)
 
 		var federatedMembers []interface{}
 

--- a/pkg/artifactory/resource_artifactory_federated_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_federated_repository_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func skipFederatedRepo() (bool, string) {
@@ -38,7 +39,7 @@ func TestAccFederatedRepoWithMembers(t *testing.T) {
 		"member1Url":   federatedMember1Url,
 		"member2Url":   federatedMember2Url,
 	}
-	federatedRepositoryConfig := executeTemplate("TestAccFederatedRepositoryConfigWithMembers", `
+	federatedRepositoryConfig := utils.ExecuteTemplate("TestAccFederatedRepositoryConfigWithMembers", `
 		resource "{{ .resourceType }}" "{{ .name }}" {
 			key         = "{{ .name }}"
 			description = "Test federated repo for {{ .name }}"
@@ -83,7 +84,7 @@ func federatedTestCase(repoType string, t *testing.T) (*testing.T, resource.Test
 	name := fmt.Sprintf("terraform-federated-%s-%d", repoType, rand.Int())
 	resourceType := fmt.Sprintf("artifactory_federated_%s_repository", repoType)
 	resourceName := fmt.Sprintf("%s.%s", resourceType, name)
-	xrayIndex := randBool()
+	xrayIndex := utils.RandBool()
 	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", os.Getenv("ARTIFACTORY_URL"), name)
 
 	params := map[string]interface{}{
@@ -92,7 +93,7 @@ func federatedTestCase(repoType string, t *testing.T) (*testing.T, resource.Test
 		"xrayIndex":    xrayIndex,
 		"memberUrl":    federatedMemberUrl,
 	}
-	federatedRepositoryConfig := executeTemplate("TestAccFederatedRepositoryConfig", `
+	federatedRepositoryConfig := utils.ExecuteTemplate("TestAccFederatedRepositoryConfig", `
 		resource "{{ .resourceType }}" "{{ .name }}" {
 			key         = "{{ .name }}"
 			description = "Test federated repo for {{ .name }}"
@@ -140,11 +141,11 @@ func TestAccFederatedRepoAllTypes(t *testing.T) {
 
 func TestAccFederatedRepoWithProjectAttributesGH318(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	projectKey := fmt.Sprintf("t%d", randomInt())
-	projectEnv := randSelect("DEV", "PROD").(string)
+	projectKey := fmt.Sprintf("t%d", utils.RandomInt())
+	projectEnv := utils.RandSelect("DEV", "PROD").(string)
 	repoName := fmt.Sprintf("%s-generic-federated", projectKey)
 
-	_, fqrn, name := mkNames(repoName, "artifactory_federated_generic_repository")
+	_, fqrn, name := utils.MkNames(repoName, "artifactory_federated_generic_repository")
 	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", os.Getenv("ARTIFACTORY_URL"), name)
 
 	params := map[string]interface{}{
@@ -153,7 +154,7 @@ func TestAccFederatedRepoWithProjectAttributesGH318(t *testing.T) {
 		"projectEnv": projectEnv,
 		"memberUrl":  federatedMemberUrl,
 	}
-	federatedRepositoryConfig := executeTemplate("TestAccFederatedRepositoryConfig", `
+	federatedRepositoryConfig := utils.ExecuteTemplate("TestAccFederatedRepositoryConfig", `
 		resource "artifactory_federated_generic_repository" "{{ .name }}" {
 			key                  = "{{ .name }}"
 			project_key          = "{{ .projectKey }}"
@@ -194,10 +195,10 @@ func TestAccFederatedRepoWithProjectAttributesGH318(t *testing.T) {
 
 func TestAccFederatedRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 	rand.Seed(time.Now().UnixNano())
-	projectKey := fmt.Sprintf("t%d", randomInt())
+	projectKey := fmt.Sprintf("t%d", utils.RandomInt())
 	repoName := fmt.Sprintf("%s-generic-federated", projectKey)
 
-	_, fqrn, name := mkNames(repoName, "artifactory_federated_generic_repository")
+	_, fqrn, name := utils.MkNames(repoName, "artifactory_federated_generic_repository")
 	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", os.Getenv("ARTIFACTORY_URL"), name)
 
 	params := map[string]interface{}{
@@ -205,7 +206,7 @@ func TestAccFederatedRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 		"projectKey": projectKey,
 		"memberUrl":  federatedMemberUrl,
 	}
-	federatedRepositoryConfig := executeTemplate("TestAccFederatedRepositoryConfig", `
+	federatedRepositoryConfig := utils.ExecuteTemplate("TestAccFederatedRepositoryConfig", `
 		resource "artifactory_federated_generic_repository" "{{ .name }}" {
 			key         = "{{ .name }}"
 		 	project_key = "invalid-project-key"

--- a/pkg/artifactory/resource_artifactory_federated_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_federated_repository_test.go
@@ -57,10 +57,12 @@ func TestAccFederatedRepoWithMembers(t *testing.T) {
 		}
 	`, params)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(resourceName, testCheckRepo),
+		CheckDestroy:      utils.VerifyDeleted(resourceName, provider, utils.TestCheckRepo),
 		Steps: []resource.TestStep{
 			{
 				Config: federatedRepositoryConfig,
@@ -107,10 +109,12 @@ func federatedTestCase(repoType string, t *testing.T) (*testing.T, resource.Test
 		}
 	`, params)
 
+	provider := Provider()
+
 	return t, resource.TestCase{
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(resourceName, testCheckRepo),
+		CheckDestroy:      utils.VerifyDeleted(resourceName, provider, utils.TestCheckRepo),
 		Steps: []resource.TestStep{
 			{
 				Config: federatedRepositoryConfig,
@@ -167,15 +171,17 @@ func TestAccFederatedRepoWithProjectAttributesGH318(t *testing.T) {
 		}
 	`, params)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		PreCheck: func() {
 			testAccPreCheck(t)
-			createProject(t, projectKey)
+			utils.CreateProject(t, projectKey)
 		},
-		CheckDestroy: verifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
-			deleteProject(t, projectKey)
-			return testCheckRepo(id, request)
+		CheckDestroy: utils.VerifyDeleted(fqrn, provider, func(id string, request *resty.Request) (*resty.Response, error) {
+			utils.DeleteProject(t, projectKey)
+			return utils.TestCheckRepo(id, request)
 		}),
 		Steps: []resource.TestStep{
 			{
@@ -218,16 +224,18 @@ func TestAccFederatedRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 		}
 	`, params)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			createProject(t, projectKey)
+			utils.CreateProject(t, projectKey)
 		},
-		CheckDestroy: verifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
-			deleteProject(t, projectKey)
-			return testCheckRepo(id, request)
+		CheckDestroy: utils.VerifyDeleted(fqrn, provider, func(id string, request *resty.Request) (*resty.Response, error) {
+			utils.DeleteProject(t, projectKey)
+			return utils.TestCheckRepo(id, request)
 		}),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config:      federatedRepositoryConfig,

--- a/pkg/artifactory/resource_artifactory_general_security.go
+++ b/pkg/artifactory/resource_artifactory_general_security.go
@@ -4,10 +4,9 @@ import (
 	"context"
 
 	"github.com/go-resty/resty/v2"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -72,7 +71,7 @@ func resourceGeneralSecurityUpdate(ctx context.Context, d *schema.ResourceData, 
 		return diag.Errorf("failed to marshal general security settings during Update")
 	}
 
-	err = sendConfigurationPatch(content, m)
+	err = utils.SendConfigurationPatch(content, m)
 	if err != nil {
 		return diag.Errorf("failed to send PATCH request to Artifactory during Update")
 	}
@@ -88,7 +87,7 @@ security:
   anonAccessEnabled: false
 `
 
-	err := sendConfigurationPatch([]byte(content), m)
+	err := utils.SendConfigurationPatch([]byte(content), m)
 	if err != nil {
 		return diag.Errorf("failed to send PATCH request to Artifactory during Delete")
 	}
@@ -97,11 +96,11 @@ security:
 }
 
 func unpackGeneralSecurity(s *schema.ResourceData) *GeneralSecurity {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	security := *new(GeneralSecurity)
 
 	settings := GeneralSettings{
-		AnonAccessEnabled: d.getBool("enable_anonymous_access", false),
+		AnonAccessEnabled: d.GetBool("enable_anonymous_access", false),
 	}
 
 	security.GeneralSettings = settings
@@ -109,7 +108,7 @@ func unpackGeneralSecurity(s *schema.ResourceData) *GeneralSecurity {
 }
 
 func packGeneralSecurity(s *GeneralSecurity, d *schema.ResourceData) diag.Diagnostics {
-	setValue := mkLens(d)
+	setValue := utils.MkLens(d)
 
 	errors := setValue("enable_anonymous_access", s.GeneralSettings.AnonAccessEnabled)
 

--- a/pkg/artifactory/resource_artifactory_general_security_test.go
+++ b/pkg/artifactory/resource_artifactory_general_security_test.go
@@ -35,7 +35,11 @@ func TestAccGeneralSecurity_full(t *testing.T) {
 func testAccGeneralSecurityDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		client := provider.Meta().(*resty.Client)
 
 		_, ok := s.RootModule().Resources[id]

--- a/pkg/artifactory/resource_artifactory_general_security_test.go
+++ b/pkg/artifactory/resource_artifactory_general_security_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 const GeneralSecurityTemplateFull = `
@@ -18,7 +19,7 @@ resource "artifactory_general_security" "security" {
 func TestAccGeneralSecurity_full(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccGeneralSecurityDestroy("artifactory_general_security.security"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -33,7 +34,8 @@ func TestAccGeneralSecurity_full(t *testing.T) {
 
 func testAccGeneralSecurityDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		client := provider.Meta().(*resty.Client)
 
 		_, ok := s.RootModule().Resources[id]

--- a/pkg/artifactory/resource_artifactory_group.go
+++ b/pkg/artifactory/resource_artifactory_group.go
@@ -88,19 +88,19 @@ func resourceArtifactoryGroup() *schema.Resource {
 }
 
 func groupParams(s *schema.ResourceData) (Group, bool, error) {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 
 	group := Group{
-		Name:            d.getString("name", false),
-		Description:     d.getString("description", false),
-		AutoJoin:        d.getBool("auto_join", false),
-		AdminPrivileges: d.getBool("admin_privileges", false),
-		Realm:           d.getString("realm", false),
-		RealmAttributes: d.getString("realm_attributes", false),
-		UsersNames:      d.getSet("users_names"),
-		WatchManager:    d.getBool("watch_manager", false),
-		PolicyManager:   d.getBool("policy_manager", false),
-		ReportsManager:  d.getBool("reports_manager", false),
+		Name:            d.GetString("name", false),
+		Description:     d.GetString("description", false),
+		AutoJoin:        d.GetBool("auto_join", false),
+		AdminPrivileges: d.GetBool("admin_privileges", false),
+		Realm:           d.GetString("realm", false),
+		RealmAttributes: d.GetString("realm_attributes", false),
+		UsersNames:      d.GetSet("users_names"),
+		WatchManager:    d.GetBool("watch_manager", false),
+		PolicyManager:   d.GetBool("policy_manager", false),
+		ReportsManager:  d.GetBool("reports_manager", false),
 	}
 
 	// Validator
@@ -114,7 +114,7 @@ func groupParams(s *schema.ResourceData) (Group, bool, error) {
 	// so it also changes the update from put to post to prevent detaching all existing users
 	// without an explict instruction
 
-	includeUsers := len(group.UsersNames) > 0 || d.getBool("detach_all_users", false)
+	includeUsers := len(group.UsersNames) > 0 || d.GetBool("detach_all_users", false)
 	return group, includeUsers, nil
 }
 
@@ -168,7 +168,7 @@ func resourceGroupRead(d *schema.ResourceData, m interface{}) error {
 		return err
 	}
 
-	setValue := mkLens(d)
+	setValue := utils.MkLens(d)
 	setValue("name", group.Name)
 	setValue("description", group.Description)
 	setValue("auto_join", group.AutoJoin)
@@ -178,7 +178,7 @@ func resourceGroupRead(d *schema.ResourceData, m interface{}) error {
 	setValue("watch_manager", group.WatchManager)
 	setValue("policy_manager", group.PolicyManager)
 	setValue("reports_manager", group.ReportsManager)
-	errors := setValue("users_names", schema.NewSet(schema.HashString, castToInterfaceArr(group.UsersNames)))
+	errors := setValue("users_names", schema.NewSet(schema.HashString, utils.CastToInterfaceArr(group.UsersNames)))
 	if errors != nil && len(errors) > 0 {
 		return fmt.Errorf("failed saving state for groups %q", errors)
 	}

--- a/pkg/artifactory/resource_artifactory_group.go
+++ b/pkg/artifactory/resource_artifactory_group.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 
 	"github.com/go-resty/resty/v2"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 const groupsEndpoint = "artifactory/api/security/groups/"
@@ -50,7 +50,7 @@ func resourceArtifactoryGroup() *schema.Resource {
 				Type:         schema.TypeString,
 				Optional:     true,
 				Computed:     true,
-				ValidateFunc: validateLowerCase,
+				ValidateFunc: utils.ValidateLowerCase,
 			},
 			"realm_attributes": {
 				Type:     schema.TypeString,

--- a/pkg/artifactory/resource_artifactory_group_test.go
+++ b/pkg/artifactory/resource_artifactory_group_test.go
@@ -9,16 +9,17 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccGroup_basic(t *testing.T) {
-	_, rfqn, groupName := mkNames("test-group-full", "artifactory_group")
+	_, rfqn, groupName := utils.MkNames("test-group-full", "artifactory_group")
 	temp := `
 		resource "artifactory_group" "{{ .groupName }}" {
 			name  = "{{ .groupName }}"
 		}
 	`
-	config := executeTemplate(groupName, temp, map[string]string{"groupName": groupName})
+	config := utils.ExecuteTemplate(groupName, temp, map[string]string{"groupName": groupName})
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -36,7 +37,7 @@ func TestAccGroup_basic(t *testing.T) {
 }
 
 func TestAccGroup_full(t *testing.T) {
-	_, rfqn, groupName := mkNames("test-group-full", "artifactory_group")
+	_, rfqn, groupName := utils.MkNames("test-group-full", "artifactory_group")
 
 	templates := []string{
 		`
@@ -120,7 +121,7 @@ func TestAccGroup_full(t *testing.T) {
 
 	configs := []string{}
 	for step, template := range templates {
-		configs = append(configs, executeTemplate(fmt.Sprint(step), template, map[string]string{"groupName": groupName}))
+		configs = append(configs, utils.ExecuteTemplate(fmt.Sprint(step), template, map[string]string{"groupName": groupName}))
 
 	}
 
@@ -199,7 +200,7 @@ func TestAccGroup_full(t *testing.T) {
 }
 
 func TestAccGroup_unmanagedmembers(t *testing.T) {
-	_, rfqn, groupName := mkNames("test-group-unmanagedmembers", "artifactory_group")
+	_, rfqn, groupName := utils.MkNames("test-group-unmanagedmembers", "artifactory_group")
 
 	templates := []string{
 		`
@@ -237,7 +238,7 @@ func TestAccGroup_unmanagedmembers(t *testing.T) {
 	}
 	configs := []string{}
 	for step, template := range templates {
-		configs = append(configs, executeTemplate(fmt.Sprint(step), template, map[string]string{"groupName": groupName}))
+		configs = append(configs, utils.ExecuteTemplate(fmt.Sprint(step), template, map[string]string{"groupName": groupName}))
 
 	}
 	resource.Test(t, resource.TestCase{

--- a/pkg/artifactory/resource_artifactory_group_test.go
+++ b/pkg/artifactory/resource_artifactory_group_test.go
@@ -280,7 +280,11 @@ func TestAccGroup_unmanagedmembers(t *testing.T) {
 func testAccCheckGroupDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		client := provider.Meta().(*resty.Client)
 
 		rs, ok := s.RootModule().Resources[id]
@@ -303,7 +307,11 @@ func testAccCheckGroupDestroy(id string) func(*terraform.State) error {
 func testAccDirectCheckGroupMembership(id string, expectedCount int) func(*terraform.State) error {
 	return func(s *terraform.State) error {
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		client := provider.Meta().(*resty.Client)
 
 		rs, ok := s.RootModule().Resources[id]

--- a/pkg/artifactory/resource_artifactory_group_test.go
+++ b/pkg/artifactory/resource_artifactory_group_test.go
@@ -24,7 +24,7 @@ func TestAccGroup_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckGroupDestroy(rfqn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -128,7 +128,7 @@ func TestAccGroup_full(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckGroupDestroy(rfqn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: configs[0],
@@ -244,7 +244,7 @@ func TestAccGroup_unmanagedmembers(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckGroupDestroy(rfqn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: configs[0],
@@ -279,7 +279,8 @@ func TestAccGroup_unmanagedmembers(t *testing.T) {
 
 func testAccCheckGroupDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		client := provider.Meta().(*resty.Client)
 
 		rs, ok := s.RootModule().Resources[id]
@@ -301,7 +302,8 @@ func testAccCheckGroupDestroy(id string) func(*terraform.State) error {
 
 func testAccDirectCheckGroupMembership(id string, expectedCount int) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		client := provider.Meta().(*resty.Client)
 
 		rs, ok := s.RootModule().Resources[id]

--- a/pkg/artifactory/resource_artifactory_keypair.go
+++ b/pkg/artifactory/resource_artifactory_keypair.go
@@ -12,6 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 const keypairEndPoint = "artifactory/api/security/keypair/"
@@ -177,21 +178,21 @@ func ignoreEmpty(_, old, new string, _ *schema.ResourceData) bool {
 }
 
 func unpackKeyPair(s *schema.ResourceData) (interface{}, string, error) {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	result := KeyPairPayLoad{
-		PairName:    d.getString("pair_name", false),
-		PairType:    d.getString("pair_type", false),
-		Alias:       d.getString("alias", false),
-		PrivateKey:  strings.ReplaceAll(d.getString("private_key", false), "\t", ""),
-		PublicKey:   strings.ReplaceAll(d.getString("public_key", false), "\t", ""),
-		Unavailable: d.getBool("unavailable", false),
+		PairName:    d.GetString("pair_name", false),
+		PairType:    d.GetString("pair_type", false),
+		Alias:       d.GetString("alias", false),
+		PrivateKey:  strings.ReplaceAll(d.GetString("private_key", false), "\t", ""),
+		PublicKey:   strings.ReplaceAll(d.GetString("public_key", false), "\t", ""),
+		Unavailable: d.GetBool("unavailable", false),
 	}
 	return &result, result.PairName, nil
 }
 
 var keyPairPacker = universalPack(
 	allHclPredicate(
-		ignoreHclPredicate("private_key"), schemaHasKey(keyPairSchema),
+		ignoreHclPredicate("private_key"), utils.SchemaHasKey(keyPairSchema),
 	),
 )
 

--- a/pkg/artifactory/resource_artifactory_keypair_test.go
+++ b/pkg/artifactory/resource_artifactory_keypair_test.go
@@ -30,10 +30,13 @@ func TestAccKeyPairFailPrivateCertCheck(t *testing.T) {
 		EOF
 		}
 	`, name, name, id)
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, verifyKeyPair),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, verifyKeyPair),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config:      keyBasic,
@@ -82,10 +85,13 @@ func TestAccKeyPairFailPubCertCheck(t *testing.T) {
 			public_key = "not a key"
 		}
 	`, name, name, id)
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, verifyKeyPair),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, verifyKeyPair),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config:      keyBasic,
@@ -150,10 +156,13 @@ func TestAccKeyPairRSA(t *testing.T) {
 			}
 		}
 	`, name, name, id)
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, verifyKeyPair),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, verifyKeyPair),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: keyBasic,
@@ -273,10 +282,13 @@ func TestAccKeyPairGPG(t *testing.T) {
 		EOF
 		}
 	`, name, name, id)
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, verifyKeyPair),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, verifyKeyPair),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: keyBasic,

--- a/pkg/artifactory/resource_artifactory_keypair_test.go
+++ b/pkg/artifactory/resource_artifactory_keypair_test.go
@@ -6,10 +6,11 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccKeyPairFailPrivateCertCheck(t *testing.T) {
-	id, fqrn, name := mkNames("mykp", "artifactory_keypair")
+	id, fqrn, name := utils.MkNames("mykp", "artifactory_keypair")
 	keyBasic := fmt.Sprintf(`
 		resource "artifactory_keypair" "%s" {
 			pair_name  = "%s"
@@ -43,7 +44,7 @@ func TestAccKeyPairFailPrivateCertCheck(t *testing.T) {
 }
 
 func TestAccKeyPairFailPubCertCheck(t *testing.T) {
-	id, fqrn, name := mkNames("mykp", "artifactory_keypair")
+	id, fqrn, name := utils.MkNames("mykp", "artifactory_keypair")
 	keyBasic := fmt.Sprintf(`
 		resource "artifactory_keypair" "%s" {
 			pair_name  = "%s"
@@ -95,7 +96,7 @@ func TestAccKeyPairFailPubCertCheck(t *testing.T) {
 }
 
 func TestAccKeyPairRSA(t *testing.T) {
-	id, fqrn, name := mkNames("mykp", "artifactory_keypair")
+	id, fqrn, name := utils.MkNames("mykp", "artifactory_keypair")
 	keyBasic := fmt.Sprintf(`
 		resource "artifactory_keypair" "%s" {
 			pair_name  = "%s"
@@ -170,7 +171,7 @@ func TestAccKeyPairRSA(t *testing.T) {
 }
 
 func TestAccKeyPairGPG(t *testing.T) {
-	id, fqrn, name := mkNames("mykp", "artifactory_keypair")
+	id, fqrn, name := utils.MkNames("mykp", "artifactory_keypair")
 	keyBasic := fmt.Sprintf(`
 		resource "artifactory_keypair" "%s" {
 			pair_name  = "%s"

--- a/pkg/artifactory/resource_artifactory_ldap_group_setting.go
+++ b/pkg/artifactory/resource_artifactory_ldap_group_setting.go
@@ -140,7 +140,7 @@ Hierarchy: The user's DN is indicative of the groups the user belongs to by usin
 			return diag.Errorf("failed to marshal ldap group settings during Update")
 		}
 
-		err = sendConfigurationPatch(content, m)
+		err = utils.SendConfigurationPatch(content, m)
 		if err != nil {
 			return diag.Errorf("failed to send PATCH request to Artifactory during Update")
 		}
@@ -183,7 +183,7 @@ Hierarchy: The user's DN is indicative of the groups the user belongs to by usin
 security:
   ldapGroupSettings: ~
 `
-		err = sendConfigurationPatch([]byte(clearAllLdapGroupSettingsConfigs), m)
+		err = utils.SendConfigurationPatch([]byte(clearAllLdapGroupSettingsConfigs), m)
 		if err != nil {
 			return diag.Errorf("failed to send PATCH request to Artifactory during Delete for clearing all Ldap Group Settings")
 		}
@@ -193,7 +193,7 @@ security:
 			return diag.Errorf("failed to marshal ldap group settings during Update")
 		}
 
-		err = sendConfigurationPatch([]byte(restoreRestOfLdapGroupSettingsConfigs), m)
+		err = utils.SendConfigurationPatch([]byte(restoreRestOfLdapGroupSettingsConfigs), m)
 		if err != nil {
 			return diag.Errorf("failed to send PATCH request to Artifactory during restoration of Ldap Group Settings")
 		}
@@ -216,17 +216,17 @@ security:
 }
 
 func unpackLdapGroupSetting(s *schema.ResourceData) LdapGroupSetting {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	ldapGroupSetting := LdapGroupSetting{
-		Name:                 d.getString("name", false),
-		EnabledLdap:          d.getString("ldap_setting_key", false),
-		GroupBaseDn:          d.getString("group_base_dn", false),
-		GroupNameAttribute:   d.getString("group_name_attribute", false),
-		GroupMemberAttribute: d.getString("group_member_attribute", false),
-		SubTree:              d.getBool("sub_tree", false),
-		Filter:               d.getString("filter", false),
-		DescriptionAttribute: d.getString("description_attribute", false),
-		Strategy:             d.getString("strategy", false),
+		Name:                 d.GetString("name", false),
+		EnabledLdap:          d.GetString("ldap_setting_key", false),
+		GroupBaseDn:          d.GetString("group_base_dn", false),
+		GroupNameAttribute:   d.GetString("group_name_attribute", false),
+		GroupMemberAttribute: d.GetString("group_member_attribute", false),
+		SubTree:              d.GetBool("sub_tree", false),
+		Filter:               d.GetString("filter", false),
+		DescriptionAttribute: d.GetString("description_attribute", false),
+		Strategy:             d.GetString("strategy", false),
 	}
 	return ldapGroupSetting
 }

--- a/pkg/artifactory/resource_artifactory_ldap_group_setting.go
+++ b/pkg/artifactory/resource_artifactory_ldap_group_setting.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type LdapGroupSetting struct {
@@ -55,7 +56,7 @@ func resourceArtifactoryLdapGroupSetting() *schema.Resource {
 			Type:             schema.TypeString,
 			Optional:         true,
 			Default:          "",
-			ValidateDiagFunc: validation.ToDiagFunc(validateLdapDn),
+			ValidateDiagFunc: validation.ToDiagFunc(utils.ValidateLdapDn),
 			Description:      `(Optional) A search base for group entry DNs, relative to the DN on the LDAP server’s URL (and not relative to the LDAP Setting’s “Search Base”). Used when importing groups.`,
 		},
 		"group_name_attribute": {
@@ -79,7 +80,7 @@ func resourceArtifactoryLdapGroupSetting() *schema.Resource {
 		"filter": {
 			Type:             schema.TypeString,
 			Required:         true,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.StringIsNotEmpty, validateLdapFilter)),
+			ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.StringIsNotEmpty, utils.ValidateLdapFilter)),
 			Description:      `(Required) The LDAP filter used to search for group entries. Used for importing groups.`,
 		},
 		"description_attribute": {

--- a/pkg/artifactory/resource_artifactory_ldap_group_setting_test.go
+++ b/pkg/artifactory/resource_artifactory_ldap_group_setting_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccLdapGroupSetting_full(t *testing.T) {
@@ -39,7 +40,7 @@ resource "artifactory_ldap_group_setting" "ldapgrouptest" {
 
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccLdapGroupSettingDestroy("ldapgrouptest"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -68,7 +69,8 @@ resource "artifactory_ldap_group_setting" "ldapgrouptest" {
 
 func testAccLdapGroupSettingDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		client := provider.Meta().(*resty.Client)
 
 		_, ok := s.RootModule().Resources["artifactory_ldap_group_setting."+id]

--- a/pkg/artifactory/resource_artifactory_ldap_group_setting_test.go
+++ b/pkg/artifactory/resource_artifactory_ldap_group_setting_test.go
@@ -70,7 +70,11 @@ resource "artifactory_ldap_group_setting" "ldapgrouptest" {
 func testAccLdapGroupSettingDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		client := provider.Meta().(*resty.Client)
 
 		_, ok := s.RootModule().Resources["artifactory_ldap_group_setting."+id]

--- a/pkg/artifactory/resource_artifactory_ldap_setting.go
+++ b/pkg/artifactory/resource_artifactory_ldap_setting.go
@@ -164,7 +164,7 @@ func resourceArtifactoryLdapSetting() *schema.Resource {
 
 		packer := universalPack(
 			allHclPredicate(
-				ignoreHclPredicate("class", "rclass", "manager_password"), schemaHasKey(ldapSettingsSchema),
+				ignoreHclPredicate("class", "rclass", "manager_password"), utils.SchemaHasKey(ldapSettingsSchema),
 			),
 		)
 
@@ -190,7 +190,7 @@ func resourceArtifactoryLdapSetting() *schema.Resource {
 			return diag.Errorf("failed to marshal ldap settings during Update")
 		}
 
-		err = sendConfigurationPatch(content, m)
+		err = utils.SendConfigurationPatch(content, m)
 		if err != nil {
 			return diag.Errorf("failed to send PATCH request to Artifactory during Update")
 		}
@@ -233,7 +233,7 @@ func resourceArtifactoryLdapSetting() *schema.Resource {
 security:
   ldapSettings: ~
 `
-		err = sendConfigurationPatch([]byte(clearAllLdapSettingsConfigs), m)
+		err = utils.SendConfigurationPatch([]byte(clearAllLdapSettingsConfigs), m)
 		if err != nil {
 			return diag.Errorf("failed to send PATCH request to Artifactory during Delete for clearing all Ldap Settings")
 		}
@@ -243,7 +243,7 @@ security:
 			return diag.Errorf("failed to marshal ldap settings during Update")
 		}
 
-		err = sendConfigurationPatch([]byte(restoreRestOfLdapSettingsConfigs), m)
+		err = utils.SendConfigurationPatch([]byte(restoreRestOfLdapSettingsConfigs), m)
 		if err != nil {
 			return diag.Errorf("failed to send PATCH request to Artifactory during restoration of Ldap Settings")
 		}
@@ -266,23 +266,23 @@ security:
 }
 
 func unpackLdapSetting(s *schema.ResourceData) LdapSetting {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	ldapSetting := LdapSetting{
-		Key:                      d.getString("key", false),
-		Enabled:                  d.getBool("enabled", false),
-		LdapUrl:                  d.getString("ldap_url", false),
-		AutoCreateUser:           d.getBool("auto_create_user", false),
-		LdapPoisoningProtection:  d.getBool("ldap_poisoning_protection", false),
-		PagingSupportEnabled:     d.getBool("paging_support_enabled", false),
-		AllowUserToAccessProfile: d.getBool("allow_user_to_access_profile", false),
-		UserDnPattern:            d.getString("user_dn_pattern", false),
-		EmailAttribute:           d.getString("email_attribute", false),
+		Key:                      d.GetString("key", false),
+		Enabled:                  d.GetBool("enabled", false),
+		LdapUrl:                  d.GetString("ldap_url", false),
+		AutoCreateUser:           d.GetBool("auto_create_user", false),
+		LdapPoisoningProtection:  d.GetBool("ldap_poisoning_protection", false),
+		PagingSupportEnabled:     d.GetBool("paging_support_enabled", false),
+		AllowUserToAccessProfile: d.GetBool("allow_user_to_access_profile", false),
+		UserDnPattern:            d.GetString("user_dn_pattern", false),
+		EmailAttribute:           d.GetString("email_attribute", false),
 		Search: LdapSearchType{
-			SearchSubTree:   d.getBool("search_sub_tree", false),
-			SearchBase:      d.getString("search_base", false),
-			SearchFilter:    d.getString("search_filter", false),
-			ManagerDn:       d.getString("manager_dn", false),
-			ManagerPassword: d.getString("manager_password", true),
+			SearchSubTree:   d.GetBool("search_sub_tree", false),
+			SearchBase:      d.GetString("search_base", false),
+			SearchFilter:    d.GetString("search_filter", false),
+			ManagerDn:       d.GetString("manager_dn", false),
+			ManagerPassword: d.GetString("manager_password", true),
 		},
 	}
 	return ldapSetting

--- a/pkg/artifactory/resource_artifactory_ldap_setting.go
+++ b/pkg/artifactory/resource_artifactory_ldap_setting.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type LdapSetting struct {
@@ -69,7 +70,7 @@ func resourceArtifactoryLdapSetting() *schema.Resource {
 		"user_dn_pattern": {
 			Type:             schema.TypeString,
 			Optional:         true,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.StringIsNotEmpty, validateLdapDn)),
+			ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.StringIsNotEmpty, utils.ValidateLdapDn)),
 			Description:      "(Optional) A DN pattern that can be used to log users directly in to LDAP. This pattern is used to create a DN string for 'direct' user authentication where the pattern is relative to the base DN in the LDAP URL. The pattern argument {0} is replaced with the username. This only works if anonymous binding is allowed and a direct user DN can be used, which is not the default case for Active Directory (use User DN search filter instead). Example: uid={0},ou=People. Default value is blank/empty.",
 		},
 		"auto_create_user": {
@@ -113,14 +114,14 @@ func resourceArtifactoryLdapSetting() *schema.Resource {
 		"search_filter": {
 			Type:             schema.TypeString,
 			Optional:         true,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.StringIsNotEmpty, validateLdapFilter)),
+			ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.StringIsNotEmpty, utils.ValidateLdapFilter)),
 			Description:      "(Optional) A filter expression used to search for the user DN used in LDAP authentication. This is an LDAP search filter (as defined in 'RFC 2254') with optional arguments. In this case, the username is the only argument, and is denoted by '{0}'. Possible examples are: (uid={0}) - This searches for a username match on the attribute. Authentication to LDAP is performed from the DN found if successful.",
 		},
 		"search_base": {
 			Type:             schema.TypeString,
 			Optional:         true,
 			Default:          "",
-			ValidateDiagFunc: validation.ToDiagFunc(validateLdapDn),
+			ValidateDiagFunc: validation.ToDiagFunc(utils.ValidateLdapDn),
 			Description:      "(Optional) A context name to search in relative to the base DN of the LDAP URL. For example, 'ou=users' With the LDAP Group Add-on enabled, it is possible to enter multiple search base entries separated by a pipe ('|') character.",
 		},
 		"search_sub_tree": {
@@ -133,7 +134,7 @@ func resourceArtifactoryLdapSetting() *schema.Resource {
 			Type:             schema.TypeString,
 			Optional:         true,
 			Default:          "",
-			ValidateDiagFunc: validation.ToDiagFunc(validateLdapDn),
+			ValidateDiagFunc: validation.ToDiagFunc(utils.ValidateLdapDn),
 			Description:      `(Optional) The full DN of the user that binds to the LDAP server to perform user searches. Only used with "search" authentication.`,
 		},
 		"manager_password": {

--- a/pkg/artifactory/resource_artifactory_ldap_setting_test.go
+++ b/pkg/artifactory/resource_artifactory_ldap_setting_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccLdapSetting_full(t *testing.T) {
@@ -40,7 +41,7 @@ resource "artifactory_ldap_setting" "ldaptest" {
 }`
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccLdapSettingDestroy("ldaptest"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -104,7 +105,7 @@ resource "artifactory_ldap_setting" "ldaptestemailattr" {
 
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccLdapSettingDestroy("ldaptestemailattr"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -175,7 +176,7 @@ resource "artifactory_ldap_setting" "ldaptestuserdnsearchfilter" {
 
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccLdapSettingDestroy("ldaptestuserdnsearchfilter"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -212,7 +213,8 @@ resource "artifactory_ldap_setting" "ldaptestuserdnsearchfilter" {
 
 func testAccLdapSettingDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		client := provider.Meta().(*resty.Client)
 
 		_, ok := s.RootModule().Resources["artifactory_ldap_setting."+id]

--- a/pkg/artifactory/resource_artifactory_ldap_setting_test.go
+++ b/pkg/artifactory/resource_artifactory_ldap_setting_test.go
@@ -214,7 +214,11 @@ resource "artifactory_ldap_setting" "ldaptestuserdnsearchfilter" {
 func testAccLdapSettingDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		client := provider.Meta().(*resty.Client)
 
 		_, ok := s.RootModule().Resources["artifactory_ldap_setting."+id]

--- a/pkg/artifactory/resource_artifactory_local_alpine_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_alpine_repository.go
@@ -2,12 +2,13 @@ package artifactory
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryLocalAlpineRepository() *schema.Resource {
 	const packageType = "alpine"
 
-	var alpineLocalSchema = mergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
+	var alpineLocalSchema = utils.MergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
 		"primary_keypair_ref": {
 			Type:     schema.TypeString,
 			Optional: true,
@@ -22,10 +23,10 @@ func resourceArtifactoryLocalAlpineRepository() *schema.Resource {
 	}
 
 	var unPackLocalAlpineRepository = func(data *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{ResourceData: data}
+		d := &utils.ResourceData{ResourceData: data}
 		repo := AlpineLocalRepo{
 			LocalRepositoryBaseParams: unpackBaseRepo("local", data, packageType),
-			PrimaryKeyPairRef:         d.getString("primary_keypair_ref", false),
+			PrimaryKeyPairRef:         d.GetString("primary_keypair_ref", false),
 		}
 
 		return repo, repo.Id(), nil

--- a/pkg/artifactory/resource_artifactory_local_cargo_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_cargo_repository.go
@@ -2,12 +2,13 @@ package artifactory
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryLocalCargoRepository() *schema.Resource {
 	const packageType = "cargo"
 
-	var cargoLocalSchema = mergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
+	var cargoLocalSchema = utils.MergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
 		"anonymous_access": {
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -22,10 +23,10 @@ func resourceArtifactoryLocalCargoRepository() *schema.Resource {
 	}
 
 	var unPackLocalCargoRepository = func(data *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{ResourceData: data}
+		d := &utils.ResourceData{ResourceData: data}
 		repo := CargoLocalRepo{
 			LocalRepositoryBaseParams: unpackBaseRepo("local", data, packageType),
-			AnonymousAccess:           d.getBool("anonymous_access", false),
+			AnonymousAccess:           d.GetBool("anonymous_access", false),
 		}
 
 		return repo, repo.Id(), nil

--- a/pkg/artifactory/resource_artifactory_local_debian_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_debian_repository.go
@@ -2,12 +2,13 @@ package artifactory
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryLocalDebianRepository() *schema.Resource {
 	const packageType = "debian"
 
-	var debianLocalSchema = mergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
+	var debianLocalSchema = utils.MergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
 		"primary_keypair_ref": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -35,13 +36,13 @@ func resourceArtifactoryLocalDebianRepository() *schema.Resource {
 	}
 
 	var unPackLocalDebianRepository = func(data *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{ResourceData: data}
+		d := &utils.ResourceData{ResourceData: data}
 		repo := DebianLocalRepositoryParams{
 			LocalRepositoryBaseParams: unpackBaseRepo("local", data, packageType),
-			PrimaryKeyPairRef:         d.getString("primary_keypair_ref", false),
-			SecondaryKeyPairRef:       d.getString("secondary_keypair_ref", false),
-			TrivialLayout:             d.getBool("trivial_layout", false),
-			IndexCompressionFormats:   d.getSet("index_compression_formats"),
+			PrimaryKeyPairRef:         d.GetString("primary_keypair_ref", false),
+			SecondaryKeyPairRef:       d.GetString("secondary_keypair_ref", false),
+			TrivialLayout:             d.GetBool("trivial_layout", false),
+			IndexCompressionFormats:   d.GetSet("index_compression_formats"),
 		}
 		return repo, repo.Id(), nil
 	}

--- a/pkg/artifactory/resource_artifactory_local_docker_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_docker_repository.go
@@ -3,13 +3,14 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryLocalDockerV2Repository() *schema.Resource {
 
 	const packageType = "docker"
 
-	var dockerV2LocalSchema = mergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
+	var dockerV2LocalSchema = utils.MergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
 		"max_unique_tags": {
 			Type:     schema.TypeInt,
 			Optional: true,
@@ -42,13 +43,13 @@ func resourceArtifactoryLocalDockerV2Repository() *schema.Resource {
 	packer := defaultPacker(dockerV2LocalSchema)
 
 	var unPackLocalDockerV2Repository = func(data *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{ResourceData: data}
+		d := &utils.ResourceData{ResourceData: data}
 		repo := DockerLocalRepositoryParams{
 			LocalRepositoryBaseParams: unpackBaseRepo("local", data, packageType),
-			MaxUniqueTags:             d.getInt("max_unique_tags", false),
+			MaxUniqueTags:             d.GetInt("max_unique_tags", false),
 			DockerApiVersion:          "V2",
-			TagRetention:              d.getInt("tag_retention", false),
-			BlockPushingSchema1:       d.getBool("block_pushing_schema1", false),
+			TagRetention:              d.GetInt("tag_retention", false),
+			BlockPushingSchema1:       d.GetBool("block_pushing_schema1", false),
 		}
 
 		return repo, repo.Id(), nil
@@ -72,7 +73,7 @@ func resourceArtifactoryLocalDockerV1Repository() *schema.Resource {
 
 	const packageType = "docker"
 
-	var dockerV1LocalSchema = mergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
+	var dockerV1LocalSchema = utils.MergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
 		"max_unique_tags": {
 			Type:     schema.TypeInt,
 			Optional: true,
@@ -93,7 +94,7 @@ func resourceArtifactoryLocalDockerV1Repository() *schema.Resource {
 	}, repoLayoutRefSchema("local", packageType))
 
 	// this is necessary because of the pointers
-	skeema := mergeSchema(map[string]*schema.Schema{}, dockerV1LocalSchema)
+	skeema := utils.MergeSchema(map[string]*schema.Schema{}, dockerV1LocalSchema)
 
 	var unPackLocalDockerV1Repository = func(data *schema.ResourceData) (interface{}, string, error) {
 		repo := DockerLocalRepositoryParams{

--- a/pkg/artifactory/resource_artifactory_local_generic_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_generic_repository.go
@@ -2,6 +2,7 @@ package artifactory
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryLocalGenericRepository(pkt string) *schema.Resource {
@@ -15,6 +16,6 @@ func resourceArtifactoryLocalGenericRepository(pkt string) *schema.Resource {
 		repo := unpackBaseRepo("local", data, pkt)
 		return repo, repo.Id(), nil
 	}
-	mergedLocalRepoSchema := mergeSchema(baseLocalRepoSchema, repoLayoutRefSchema("local", pkt))
+	mergedLocalRepoSchema := utils.MergeSchema(baseLocalRepoSchema, repoLayoutRefSchema("local", pkt))
 	return mkResourceSchema(mergedLocalRepoSchema, defaultPacker(mergedLocalRepoSchema), unpack, constructor)
 }

--- a/pkg/artifactory/resource_artifactory_local_java_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_java_repository.go
@@ -3,11 +3,12 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryLocalJavaRepository(repoType string, suppressPom bool) *schema.Resource {
 
-	var javaLocalSchema = mergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
+	var javaLocalSchema = utils.MergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
 		"checksum_policy_type": {
 			Type:             schema.TypeString,
 			Optional:         true,
@@ -70,15 +71,15 @@ func resourceArtifactoryLocalJavaRepository(repoType string, suppressPom bool) *
 	}
 
 	var unPackLocalJavaRepository = func(data *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{ResourceData: data}
+		d := &utils.ResourceData{ResourceData: data}
 		repo := JavaLocalRepositoryParams{
 			LocalRepositoryBaseParams:    unpackBaseRepo("local", data, repoType),
-			ChecksumPolicyType:           d.getString("checksum_policy_type", false),
-			SnapshotVersionBehavior:      d.getString("snapshot_version_behavior", false),
-			MaxUniqueSnapshots:           d.getInt("max_unique_snapshots", false),
-			HandleReleases:               d.getBool("handle_releases", false),
-			HandleSnapshots:              d.getBool("handle_snapshots", false),
-			SuppressPomConsistencyChecks: d.getBool("suppress_pom_consistency_checks", false),
+			ChecksumPolicyType:           d.GetString("checksum_policy_type", false),
+			SnapshotVersionBehavior:      d.GetString("snapshot_version_behavior", false),
+			MaxUniqueSnapshots:           d.GetInt("max_unique_snapshots", false),
+			HandleReleases:               d.GetBool("handle_releases", false),
+			HandleSnapshots:              d.GetBool("handle_snapshots", false),
+			SuppressPomConsistencyChecks: d.GetBool("suppress_pom_consistency_checks", false),
 		}
 
 		return repo, repo.Id(), nil

--- a/pkg/artifactory/resource_artifactory_local_nuget_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_nuget_repository.go
@@ -2,13 +2,14 @@ package artifactory
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryLocalNugetRepository() *schema.Resource {
 
 	const packageType = "nuget"
 
-	var nugetLocalSchema = mergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
+	var nugetLocalSchema = utils.MergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
 		"max_unique_snapshots": {
 			Type:     schema.TypeInt,
 			Optional: true,
@@ -32,11 +33,11 @@ func resourceArtifactoryLocalNugetRepository() *schema.Resource {
 	}
 
 	var unPackLocalNugetRepository = func(data *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{ResourceData: data}
+		d := &utils.ResourceData{ResourceData: data}
 		repo := NugetLocalRepositoryParams{
 			LocalRepositoryBaseParams: unpackBaseRepo("local", data, packageType),
-			MaxUniqueSnapshots:        d.getInt("max_unique_snapshots", false),
-			ForceNugetAuthentication:  d.getBool("force_nuget_authentication", false),
+			MaxUniqueSnapshots:        d.GetInt("max_unique_snapshots", false),
+			ForceNugetAuthentication:  d.GetBool("force_nuget_authentication", false),
 		}
 
 		return repo, repo.Id(), nil

--- a/pkg/artifactory/resource_artifactory_local_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_local_repository_test.go
@@ -10,12 +10,13 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccLocalAlpineRepository(t *testing.T) {
-	_, fqrn, name := mkNames("terraform-local-test-repo-basic", "artifactory_local_alpine_repository")
-	kpId, kpFqrn, kpName := mkNames("some-keypair", "artifactory_keypair")
-	localRepositoryBasic := executeTemplate("keypair", `
+	_, fqrn, name := utils.MkNames("terraform-local-test-repo-basic", "artifactory_local_alpine_repository")
+	kpId, kpFqrn, kpName := utils.MkNames("some-keypair", "artifactory_keypair")
+	localRepositoryBasic := utils.ExecuteTemplate("keypair", `
 		resource "artifactory_keypair" "{{ .kp_name }}" {
 			pair_name  = "{{ .kp_name }}"
 			pair_type = "RSA"
@@ -99,10 +100,10 @@ func TestAccLocalAlpineRepository(t *testing.T) {
 }
 
 func TestAccLocalDebianRepository(t *testing.T) {
-	_, fqrn, name := mkNames("local-debian-repo", "artifactory_local_debian_repository")
-	kpId, kpFqrn, kpName := mkNames("some-keypair1", "artifactory_keypair")
-	kpId2, kpFqrn2, kpName2 := mkNames("some-keypair2", "artifactory_keypair")
-	localRepositoryBasic := executeTemplate("keypair", `
+	_, fqrn, name := utils.MkNames("local-debian-repo", "artifactory_local_debian_repository")
+	kpId, kpFqrn, kpName := utils.MkNames("some-keypair1", "artifactory_keypair")
+	kpId2, kpFqrn2, kpName2 := utils.MkNames("some-keypair2", "artifactory_keypair")
+	localRepositoryBasic := utils.ExecuteTemplate("keypair", `
 		resource "artifactory_keypair" "{{ .kp_name }}" {
 			pair_name  = "{{ .kp_name }}"
 			pair_type = "GPG"
@@ -241,10 +242,10 @@ func TestAccLocalDebianRepository(t *testing.T) {
 }
 
 func TestAccLocalRpmRepository(t *testing.T) {
-	_, fqrn, name := mkNames("local-rpm-repo", "artifactory_local_rpm_repository")
-	kpId, kpFqrn, kpName := mkNames("some-keypair1", "artifactory_keypair")
-	kpId2, kpFqrn2, kpName2 := mkNames("some-keypair2", "artifactory_keypair")
-	localRepositoryBasic := executeTemplate("keypair", `
+	_, fqrn, name := utils.MkNames("local-rpm-repo", "artifactory_local_rpm_repository")
+	kpId, kpFqrn, kpName := utils.MkNames("some-keypair1", "artifactory_keypair")
+	kpId2, kpFqrn2, kpName2 := utils.MkNames("some-keypair2", "artifactory_keypair")
+	localRepositoryBasic := utils.ExecuteTemplate("keypair", `
 		resource "artifactory_keypair" "{{ .kp_name }}" {
 			pair_name  = "{{ .kp_name }}"
 			pair_type = "GPG"
@@ -384,11 +385,11 @@ func TestAccLocalRpmRepository(t *testing.T) {
 
 func TestAccLocalDockerV1Repository(t *testing.T) {
 
-	_, fqrn, name := mkNames("dockerv1-local", "artifactory_local_docker_v1_repository")
+	_, fqrn, name := utils.MkNames("dockerv1-local", "artifactory_local_docker_v1_repository")
 	params := map[string]interface{}{
 		"name": name,
 	}
-	localRepositoryBasic := executeTemplate("TestAccLocalDockerv2Repository", `
+	localRepositoryBasic := utils.ExecuteTemplate("TestAccLocalDockerv2Repository", `
 		resource "artifactory_local_docker_v1_repository" "{{ .name }}" {
 			key 	     = "{{ .name }}"
 		}
@@ -414,14 +415,14 @@ func TestAccLocalDockerV1Repository(t *testing.T) {
 
 func TestAccLocalDockerV2Repository(t *testing.T) {
 
-	_, fqrn, name := mkNames("dockerv2-local", "artifactory_local_docker_v2_repository")
+	_, fqrn, name := utils.MkNames("dockerv2-local", "artifactory_local_docker_v2_repository")
 	params := map[string]interface{}{
-		"block":     randBool(),
-		"retention": randSelect(1, 5, 10),
-		"max_tags":  randSelect(0, 5, 10),
+		"block":     utils.RandBool(),
+		"retention": utils.RandSelect(1, 5, 10),
+		"max_tags":  utils.RandSelect(0, 5, 10),
 		"name":      name,
 	}
-	localRepositoryBasic := executeTemplate("TestAccLocalDockerV2Repository", `
+	localRepositoryBasic := utils.ExecuteTemplate("TestAccLocalDockerV2Repository", `
 		resource "artifactory_local_docker_v2_repository" "{{ .name }}" {
 			key 	     = "{{ .name }}"
 			tag_retention = {{ .retention }}
@@ -450,11 +451,11 @@ func TestAccLocalDockerV2Repository(t *testing.T) {
 
 func TestAccLocalDockerV2RepositoryWithDefaultMaxUniqueTagsGH370(t *testing.T) {
 
-	_, fqrn, name := mkNames("dockerv2-local", "artifactory_local_docker_v2_repository")
+	_, fqrn, name := utils.MkNames("dockerv2-local", "artifactory_local_docker_v2_repository")
 	params := map[string]interface{}{
 		"name": name,
 	}
-	localRepositoryBasic := executeTemplate("TestAccLocalDockerV2Repository", `
+	localRepositoryBasic := utils.ExecuteTemplate("TestAccLocalDockerV2Repository", `
 		resource "artifactory_local_docker_v2_repository" "{{ .name }}" {
 			key = "{{ .name }}"
 		}
@@ -478,13 +479,13 @@ func TestAccLocalDockerV2RepositoryWithDefaultMaxUniqueTagsGH370(t *testing.T) {
 
 func TestAccLocalNugetRepository(t *testing.T) {
 
-	_, fqrn, name := mkNames("nuget-local", "artifactory_local_nuget_repository")
+	_, fqrn, name := utils.MkNames("nuget-local", "artifactory_local_nuget_repository")
 	params := map[string]interface{}{
-		"force_nuget_authentication": randBool(),
-		"max_unique_snapshots":       randSelect(0, 5, 10),
+		"force_nuget_authentication": utils.RandBool(),
+		"max_unique_snapshots":       utils.RandSelect(0, 5, 10),
 		"name":                       name,
 	}
-	localRepositoryBasic := executeTemplate("TestAccLocalNugetRepository", `
+	localRepositoryBasic := utils.ExecuteTemplate("TestAccLocalNugetRepository", `
 		resource "artifactory_local_nuget_repository" "{{ .name }}" {
 		  key                 = "{{ .name }}"
 		  max_unique_snapshots = {{ .max_unique_snapshots }}
@@ -513,7 +514,7 @@ var commonJavaParams = map[string]interface{}{
 	"name":                            "",
 	"checksum_policy_type":            "client-checksums",
 	"snapshot_version_behavior":       "unique",
-	"max_unique_snapshots":            randSelect(0, 5, 10),
+	"max_unique_snapshots":            utils.RandSelect(0, 5, 10),
 	"handle_releases":                 true,
 	"handle_snapshots":                true,
 	"suppress_pom_consistency_checks": false,
@@ -533,9 +534,9 @@ const localJavaRepositoryBasic = `
 
 func TestAccLocalMavenRepository(t *testing.T) {
 
-	_, fqrn, name := mkNames("maven-local", "artifactory_local_maven_repository")
+	_, fqrn, name := utils.MkNames("maven-local", "artifactory_local_maven_repository")
 	tempStruct := make(map[string]interface{})
-	copyInterfaceMap(commonJavaParams, tempStruct)
+	utils.CopyInterfaceMap(commonJavaParams, tempStruct)
 
 	tempStruct["name"] = name
 	tempStruct["resource_name"] = strings.Split(fqrn, ".")[0]
@@ -547,7 +548,7 @@ func TestAccLocalMavenRepository(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: executeTemplate(fqrn, localJavaRepositoryBasic, tempStruct),
+				Config: utils.ExecuteTemplate(fqrn, localJavaRepositoryBasic, tempStruct),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "key", name),
 					resource.TestCheckResourceAttr(fqrn, "checksum_policy_type", fmt.Sprintf("%s", tempStruct["checksum_policy_type"])),
@@ -565,12 +566,12 @@ func TestAccLocalMavenRepository(t *testing.T) {
 
 func TestAccLocalGenericRepository(t *testing.T) {
 
-	_, fqrn, name := mkNames("generic-local", "artifactory_local_generic_repository")
+	_, fqrn, name := utils.MkNames("generic-local", "artifactory_local_generic_repository")
 	params := map[string]interface{}{
 		"name":                name,
-		"priority_resolution": randBool(),
+		"priority_resolution": utils.RandBool(),
 	}
-	localRepositoryBasic := executeTemplate("TestAccLocalGenericRepository", `
+	localRepositoryBasic := utils.ExecuteTemplate("TestAccLocalGenericRepository", `
 		resource "artifactory_local_generic_repository" "{{ .name }}" {
 		  key                 = "{{ .name }}"
 		  priority_resolution = "{{ .priority_resolution }}"
@@ -595,18 +596,18 @@ func TestAccLocalGenericRepository(t *testing.T) {
 func TestAccLocalGenericRepositoryWithProjectAttributesGH318(t *testing.T) {
 
 	rand.Seed(time.Now().UnixNano())
-	projectKey := fmt.Sprintf("t%d", randomInt())
-	projectEnv := randSelect("DEV", "PROD").(string)
+	projectKey := fmt.Sprintf("t%d", utils.RandomInt())
+	projectEnv := utils.RandSelect("DEV", "PROD").(string)
 	repoName := fmt.Sprintf("%s-generic-local", projectKey)
 
-	_, fqrn, name := mkNames(repoName, "artifactory_local_generic_repository")
+	_, fqrn, name := utils.MkNames(repoName, "artifactory_local_generic_repository")
 
 	params := map[string]interface{}{
 		"name":       name,
 		"projectKey": projectKey,
 		"projectEnv": projectEnv,
 	}
-	localRepositoryBasic := executeTemplate("TestAccLocalGenericRepository", `
+	localRepositoryBasic := utils.ExecuteTemplate("TestAccLocalGenericRepository", `
 		resource "artifactory_local_generic_repository" "{{ .name }}" {
 		  key                  = "{{ .name }}"
 	 	  project_key          = "{{ .projectKey }}"
@@ -641,16 +642,16 @@ func TestAccLocalGenericRepositoryWithProjectAttributesGH318(t *testing.T) {
 func TestAccLocalGenericRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 
 	rand.Seed(time.Now().UnixNano())
-	projectKey := fmt.Sprintf("t%d", randomInt())
+	projectKey := fmt.Sprintf("t%d", utils.RandomInt())
 	repoName := fmt.Sprintf("%s-generic-local", projectKey)
 
-	_, fqrn, name := mkNames(repoName, "artifactory_local_generic_repository")
+	_, fqrn, name := utils.MkNames(repoName, "artifactory_local_generic_repository")
 
 	params := map[string]interface{}{
 		"name":       name,
 		"projectKey": projectKey,
 	}
-	localRepositoryBasic := executeTemplate("TestAccLocalGenericRepository", `
+	localRepositoryBasic := utils.ExecuteTemplate("TestAccLocalGenericRepository", `
 		resource "artifactory_local_generic_repository" "{{ .name }}" {
 		  key                  = "{{ .name }}"
 	 	  project_key          = "invalid-project-key"
@@ -679,16 +680,16 @@ func TestAccLocalGenericRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 func TestAccLocalGenericRepositoryWithInvalidProjectEnvironmentsGH318(t *testing.T) {
 
 	rand.Seed(time.Now().UnixNano())
-	projectKey := fmt.Sprintf("t%d", randomInt())
+	projectKey := fmt.Sprintf("t%d", utils.RandomInt())
 	repoName := fmt.Sprintf("%s-generic-local", projectKey)
 
-	_, fqrn, name := mkNames(repoName, "artifactory_local_generic_repository")
+	_, fqrn, name := utils.MkNames(repoName, "artifactory_local_generic_repository")
 
 	params := map[string]interface{}{
 		"name":       name,
 		"projectKey": projectKey,
 	}
-	localRepositoryBasic := executeTemplate("TestAccLocalGenericRepository", `
+	localRepositoryBasic := utils.ExecuteTemplate("TestAccLocalGenericRepository", `
 		resource "artifactory_local_generic_repository" "{{ .name }}" {
 		  key                  = "{{ .name }}"
 	 	  project_key          = "{{ .projectKey }}"
@@ -717,11 +718,11 @@ func TestAccLocalGenericRepositoryWithInvalidProjectEnvironmentsGH318(t *testing
 
 func TestAccLocalNpmRepository(t *testing.T) {
 
-	_, fqrn, name := mkNames("npm-local", "artifactory_local_npm_repository")
+	_, fqrn, name := utils.MkNames("npm-local", "artifactory_local_npm_repository")
 	params := map[string]interface{}{
 		"name": name,
 	}
-	localRepositoryBasic := executeTemplate("TestAccLocalNpmRepository", `
+	localRepositoryBasic := utils.ExecuteTemplate("TestAccLocalNpmRepository", `
 		resource "artifactory_local_npm_repository" "{{ .name }}" {
 		  key                 = "{{ .name }}"
 		}
@@ -744,14 +745,14 @@ func TestAccLocalNpmRepository(t *testing.T) {
 func mkTestCase(repoType string, t *testing.T) (*testing.T, resource.TestCase) {
 	name := fmt.Sprintf("terraform-local-%s-%d-full", repoType, rand.Int())
 	resourceName := fmt.Sprintf("artifactory_local_%s_repository.%s", repoType, name)
-	xrayIndex := randBool()
+	xrayIndex := utils.RandBool()
 
 	params := map[string]interface{}{
 		"repoType":  repoType,
 		"name":      name,
 		"xrayIndex": xrayIndex,
 	}
-	cfg := executeTemplate("TestAccLocalRepository", `
+	cfg := utils.ExecuteTemplate("TestAccLocalRepository", `
 		resource "artifactory_local_{{ .repoType }}_repository" "{{ .name }}" {
 		  key                 = "{{ .name }}"
 		  description = "Test repo for {{ .name }}"
@@ -835,9 +836,9 @@ func TestAccAllLocalRepoTypes(t *testing.T) {
 func makeLocalGradleLikeRepoTestCase(repoType string, t *testing.T) (*testing.T, resource.TestCase) {
 	name := fmt.Sprintf("%s-local", repoType)
 	resourceName := fmt.Sprintf("artifactory_local_%s_repository", repoType)
-	_, fqrn, name := mkNames(name, resourceName)
+	_, fqrn, name := utils.MkNames(name, resourceName)
 	tempStruct := make(map[string]interface{})
-	copyInterfaceMap(commonJavaParams, tempStruct)
+	utils.CopyInterfaceMap(commonJavaParams, tempStruct)
 
 	tempStruct["name"] = name
 	tempStruct["resource_name"] = strings.Split(fqrn, ".")[0]
@@ -849,7 +850,7 @@ func makeLocalGradleLikeRepoTestCase(repoType string, t *testing.T) (*testing.T,
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: executeTemplate(fqrn, localJavaRepositoryBasic, tempStruct),
+				Config: utils.ExecuteTemplate(fqrn, localJavaRepositoryBasic, tempStruct),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "key", name),
 					resource.TestCheckResourceAttr(fqrn, "checksum_policy_type", fmt.Sprintf("%s", tempStruct["checksum_policy_type"])),
@@ -874,12 +875,12 @@ func TestAccAllGradleLikeLocalRepoTypes(t *testing.T) {
 
 func TestAccLocalCargoRepository(t *testing.T) {
 
-	_, fqrn, name := mkNames("cargo-local", "artifactory_local_cargo_repository")
+	_, fqrn, name := utils.MkNames("cargo-local", "artifactory_local_cargo_repository")
 	params := map[string]interface{}{
-		"anonymous_access": randBool(),
+		"anonymous_access": utils.RandBool(),
 		"name":             name,
 	}
-	localRepositoryBasic := executeTemplate("TestAccLocalCargoRepository", `
+	localRepositoryBasic := utils.ExecuteTemplate("TestAccLocalCargoRepository", `
 		resource "artifactory_local_cargo_repository" "{{ .name }}" {
 		  key                 = "{{ .name }}"
 		  anonymous_access = {{ .anonymous_access }}

--- a/pkg/artifactory/resource_artifactory_local_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_local_repository_test.go
@@ -78,13 +78,16 @@ func TestAccLocalAlpineRepository(t *testing.T) {
 		"kp_name":   kpName,
 		"repo_name": name,
 	}) // we use randomness so that, in the case of failure and dangle, the next test can run without collision
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		CheckDestroy: compositeCheckDestroy(
-			verifyDeleted(fqrn, testCheckRepo),
-			verifyDeleted(kpFqrn, verifyKeyPair),
+			utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+			utils.VerifyDeleted(kpFqrn, provider, verifyKeyPair),
 		),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: localRepositoryBasic,
@@ -214,14 +217,17 @@ func TestAccLocalDebianRepository(t *testing.T) {
 		"kp_name2":  kpName2,
 		"repo_name": name,
 	}) // we use randomness so that, in the case of failure and dangle, the next test can run without collision
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		CheckDestroy: compositeCheckDestroy(
-			verifyDeleted(fqrn, testCheckRepo),
-			verifyDeleted(kpFqrn, verifyKeyPair),
-			verifyDeleted(kpFqrn2, verifyKeyPair),
+			utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+			utils.VerifyDeleted(kpFqrn, provider, verifyKeyPair),
+			utils.VerifyDeleted(kpFqrn2, provider, verifyKeyPair),
 		),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: localRepositoryBasic,
@@ -357,14 +363,17 @@ func TestAccLocalRpmRepository(t *testing.T) {
 		"kp_name2":  kpName2,
 		"repo_name": name,
 	}) // we use randomness so that, in the case of failure and dangle, the next test can run without collision
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		CheckDestroy: compositeCheckDestroy(
-			verifyDeleted(fqrn, testCheckRepo),
-			verifyDeleted(kpFqrn, verifyKeyPair),
-			verifyDeleted(kpFqrn2, verifyKeyPair),
+			utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+			utils.VerifyDeleted(kpFqrn, provider, verifyKeyPair),
+			utils.VerifyDeleted(kpFqrn2, provider, verifyKeyPair),
 		),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: localRepositoryBasic,
@@ -394,10 +403,13 @@ func TestAccLocalDockerV1Repository(t *testing.T) {
 			key 	     = "{{ .name }}"
 		}
 	`, params)
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: localRepositoryBasic,
@@ -430,10 +442,13 @@ func TestAccLocalDockerV2Repository(t *testing.T) {
 			block_pushing_schema1 = {{ .block }}
 		}
 	`, params)
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: localRepositoryBasic,
@@ -461,10 +476,12 @@ func TestAccLocalDockerV2RepositoryWithDefaultMaxUniqueTagsGH370(t *testing.T) {
 		}
 	`, params)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: localRepositoryBasic,
@@ -492,10 +509,13 @@ func TestAccLocalNugetRepository(t *testing.T) {
 		  force_nuget_authentication = {{ .force_nuget_authentication }}
 		}
 	`, params)
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: localRepositoryBasic,
@@ -542,10 +562,12 @@ func TestAccLocalMavenRepository(t *testing.T) {
 	tempStruct["resource_name"] = strings.Split(fqrn, ".")[0]
 	tempStruct["suppress_pom_consistency_checks"] = false
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: utils.ExecuteTemplate(fqrn, localJavaRepositoryBasic, tempStruct),
@@ -577,10 +599,13 @@ func TestAccLocalGenericRepository(t *testing.T) {
 		  priority_resolution = "{{ .priority_resolution }}"
 		}
 	`, params)
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: localRepositoryBasic,
@@ -615,16 +640,18 @@ func TestAccLocalGenericRepositoryWithProjectAttributesGH318(t *testing.T) {
 		}
 	`, params)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			createProject(t, projectKey)
+			utils.CreateProject(t, projectKey)
 		},
-		CheckDestroy: verifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
-			deleteProject(t, projectKey)
-			return testCheckRepo(id, request)
+		CheckDestroy: utils.VerifyDeleted(fqrn, provider, func(id string, request *resty.Request) (*resty.Response, error) {
+			utils.DeleteProject(t, projectKey)
+			return utils.TestCheckRepo(id, request)
 		}),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: localRepositoryBasic,
@@ -658,16 +685,18 @@ func TestAccLocalGenericRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 		}
 	`, params)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			createProject(t, projectKey)
+			utils.CreateProject(t, projectKey)
 		},
-		CheckDestroy: verifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
-			deleteProject(t, projectKey)
-			return testCheckRepo(id, request)
+		CheckDestroy: utils.VerifyDeleted(fqrn, provider, func(id string, request *resty.Request) (*resty.Response, error) {
+			utils.DeleteProject(t, projectKey)
+			return utils.TestCheckRepo(id, request)
 		}),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config:      localRepositoryBasic,
@@ -697,16 +726,18 @@ func TestAccLocalGenericRepositoryWithInvalidProjectEnvironmentsGH318(t *testing
 		}
 	`, params)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			createProject(t, projectKey)
+			utils.CreateProject(t, projectKey)
 		},
-		CheckDestroy: verifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
-			deleteProject(t, projectKey)
-			return testCheckRepo(id, request)
+		CheckDestroy: utils.VerifyDeleted(fqrn, provider, func(id string, request *resty.Request) (*resty.Response, error) {
+			utils.DeleteProject(t, projectKey)
+			return utils.TestCheckRepo(id, request)
 		}),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config:      localRepositoryBasic,
@@ -727,10 +758,13 @@ func TestAccLocalNpmRepository(t *testing.T) {
 		  key                 = "{{ .name }}"
 		}
 	`, params)
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: localRepositoryBasic,
@@ -761,10 +795,12 @@ func mkTestCase(repoType string, t *testing.T) (*testing.T, resource.TestCase) {
 		}
 	`, params)
 
+	provider := Provider()
+
 	return t, resource.TestCase{
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(resourceName, testCheckRepo),
+		CheckDestroy:      utils.VerifyDeleted(resourceName, provider, utils.TestCheckRepo),
 		Steps: []resource.TestStep{
 			{
 				Config: cfg,
@@ -792,7 +828,7 @@ func TestAccLocalAllRepoTypes(t *testing.T) {
 func makeLocalRepoTestCase(repoType string, t *testing.T) (*testing.T, resource.TestCase) {
 	name := fmt.Sprintf("terraform-local-%s-%d-full", repoType, rand.Int())
 	resourceName := fmt.Sprintf("artifactory_local_%s_repository.%s", repoType, name)
-	repoLayoutRef := getValidRandomDefaultRepoLayoutRef()
+	repoLayoutRef := utils.GetValidRandomDefaultRepoLayoutRef()
 
 	const localRepositoryConfigFull = `
 		resource "artifactory_local_%[1]s_repository" "%[2]s" {
@@ -804,10 +840,13 @@ func makeLocalRepoTestCase(repoType string, t *testing.T) (*testing.T, resource.
 	`
 
 	cfg := fmt.Sprintf(localRepositoryConfigFull, repoType, name, repoLayoutRef)
+
+	provider := Provider()
+
 	return t, resource.TestCase{
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(resourceName, testCheckRepo),
+		CheckDestroy:      utils.VerifyDeleted(resourceName, provider, utils.TestCheckRepo),
 		Steps: []resource.TestStep{
 			{
 				Config: cfg,
@@ -844,10 +883,12 @@ func makeLocalGradleLikeRepoTestCase(repoType string, t *testing.T) (*testing.T,
 	tempStruct["resource_name"] = strings.Split(fqrn, ".")[0]
 	tempStruct["suppress_pom_consistency_checks"] = true
 
+	provider := Provider()
+
 	return t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: utils.ExecuteTemplate(fqrn, localJavaRepositoryBasic, tempStruct),
@@ -886,10 +927,13 @@ func TestAccLocalCargoRepository(t *testing.T) {
 		  anonymous_access = {{ .anonymous_access }}
 		}
 	`, params)
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: localRepositoryBasic,

--- a/pkg/artifactory/resource_artifactory_local_rpm_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_rpm_repository.go
@@ -9,7 +9,7 @@ import (
 func resourceArtifactoryLocalRpmRepository() *schema.Resource {
 	const packageType = "rpm"
 
-	var rpmLocalSchema = mergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
+	var rpmLocalSchema = utils.MergeSchema(baseLocalRepoSchema, map[string]*schema.Schema{
 		"yum_root_depth": {
 			Type:             schema.TypeInt,
 			Optional:         true,
@@ -63,15 +63,15 @@ func resourceArtifactoryLocalRpmRepository() *schema.Resource {
 	}
 
 	unPackLocalRpmRepository := func(data *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{ResourceData: data}
+		d := &utils.ResourceData{ResourceData: data}
 		repo := RpmLocalRepositoryParams{
 			LocalRepositoryBaseParams: unpackBaseRepo("local", data, "rpm"),
-			RootDepth:                 d.getInt("yum_root_depth", false),
-			CalculateYumMetadata:      d.getBool("calculate_yum_metadata", false),
-			EnableFileListsIndexing:   d.getBool("enable_file_lists_indexing", false),
-			GroupFileNames:            d.getString("yum_group_file_names", false),
-			PrimaryKeyPairRef:         d.getString("primary_keypair_ref", false),
-			SecondaryKeyPairRef:       d.getString("secondary_keypair_ref", false),
+			RootDepth:                 d.GetInt("yum_root_depth", false),
+			CalculateYumMetadata:      d.GetBool("calculate_yum_metadata", false),
+			EnableFileListsIndexing:   d.GetBool("enable_file_lists_indexing", false),
+			GroupFileNames:            d.GetString("yum_group_file_names", false),
+			PrimaryKeyPairRef:         d.GetString("primary_keypair_ref", false),
+			SecondaryKeyPairRef:       d.GetString("secondary_keypair_ref", false),
 		}
 
 		return repo, repo.Id(), nil

--- a/pkg/artifactory/resource_artifactory_local_rpm_repository.go
+++ b/pkg/artifactory/resource_artifactory_local_rpm_repository.go
@@ -3,6 +3,7 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryLocalRpmRepository() *schema.Resource {
@@ -32,7 +33,7 @@ func resourceArtifactoryLocalRpmRepository() *schema.Resource {
 			Type:             schema.TypeString,
 			Optional:         true,
 			Default:          "",
-			ValidateDiagFunc: commaSeperatedList,
+			ValidateDiagFunc: utils.CommaSeperatedList,
 			Description: "A list of XML file names containing RPM group component definitions. Artifactory includes " +
 				"the group definitions as part of the calculated RPM metadata, as well as automatically generating a " +
 				"gzipped version of the group files, if required.",

--- a/pkg/artifactory/resource_artifactory_managed_user_test.go
+++ b/pkg/artifactory/resource_artifactory_managed_user_test.go
@@ -24,7 +24,7 @@ func TestAccManagedUser_NoGroups(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckManagedUserDestroy(FQRN),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(userNoGroups, name, id, id),
@@ -50,7 +50,7 @@ func TestAccManagedUser_EmptyGroups(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckManagedUserDestroy(FQRN),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(userEmptyGroups, name, id, id),
@@ -89,7 +89,7 @@ func TestAccManagedUser(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckManagedUserDestroy(FQRN),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(userFull, name, id, id),
@@ -123,7 +123,8 @@ func TestAccManagedUser(t *testing.T) {
 
 func testAccCheckManagedUserDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		client := provider.Meta().(*resty.Client)
 
 		rs, ok := s.RootModule().Resources[id]

--- a/pkg/artifactory/resource_artifactory_managed_user_test.go
+++ b/pkg/artifactory/resource_artifactory_managed_user_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 
@@ -19,7 +20,7 @@ func TestAccManagedUser_NoGroups(t *testing.T) {
 			password			= "Passsw0rd!"
 		}
 	`
-	id, FQRN, name := mkNames("foobar-", "artifactory_managed_user")
+	id, FQRN, name := utils.MkNames("foobar-", "artifactory_managed_user")
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckManagedUserDestroy(FQRN),
@@ -45,7 +46,7 @@ func TestAccManagedUser_EmptyGroups(t *testing.T) {
 			groups      		= []
 		}
 	`
-	id, FQRN, name := mkNames("foobar-", "artifactory_managed_user")
+	id, FQRN, name := utils.MkNames("foobar-", "artifactory_managed_user")
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckManagedUserDestroy(FQRN),
@@ -84,7 +85,7 @@ func TestAccManagedUser(t *testing.T) {
 			groups      		= [ "readers" ]
 		}
 	`
-	id, FQRN, name := mkNames("foobar-", "artifactory_managed_user")
+	id, FQRN, name := utils.MkNames("foobar-", "artifactory_managed_user")
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckManagedUserDestroy(FQRN),

--- a/pkg/artifactory/resource_artifactory_managed_user_test.go
+++ b/pkg/artifactory/resource_artifactory_managed_user_test.go
@@ -124,7 +124,11 @@ func TestAccManagedUser(t *testing.T) {
 func testAccCheckManagedUserDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		client := provider.Meta().(*resty.Client)
 
 		rs, ok := s.RootModule().Resources[id]

--- a/pkg/artifactory/resource_artifactory_oauth_settings.go
+++ b/pkg/artifactory/resource_artifactory_oauth_settings.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -162,7 +162,7 @@ func resourceOauthSettingsUpdate(ctx context.Context, d *schema.ResourceData, m 
 		return diag.Errorf("failed to marshal oauth settings during Update")
 	}
 
-	err = sendConfigurationPatch(content, m)
+	err = utils.SendConfigurationPatch(content, m)
 	if err != nil {
 		return diag.Errorf("failed to send PATCH request to Artifactory during Update")
 	}
@@ -178,7 +178,7 @@ security:
   oauthSettings: ~
 `
 
-	err := sendConfigurationPatch([]byte(content), m)
+	err := utils.SendConfigurationPatch([]byte(content), m)
 	if err != nil {
 		return diag.Errorf("failed to send PATCH request to Artifactory during Delete")
 	}
@@ -186,13 +186,13 @@ security:
 }
 
 func unpackOauthSecurity(s *schema.ResourceData) *OauthSecurity {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	security := new(OauthSecurity)
 
 	settings := OauthSettings{
-		EnableIntegration:        d.getBool("enable", false),
-		PersistUsers:             d.getBool("persist_users", false),
-		AllowUserToAccessProfile: d.getBool("allow_user_to_access_profile", false),
+		EnableIntegration:        d.GetBool("enable", false),
+		PersistUsers:             d.GetBool("persist_users", false),
+		AllowUserToAccessProfile: d.GetBool("allow_user_to_access_profile", false),
 	}
 
 	if v, ok := d.GetOkExists("oauth_provider"); ok {
@@ -220,7 +220,7 @@ func unpackOauthSecurity(s *schema.ResourceData) *OauthSecurity {
 }
 
 func packOauthSecurity(s *OauthSecurity, d *schema.ResourceData) diag.Diagnostics {
-	setValue := mkLens(d)
+	setValue := utils.MkLens(d)
 
 	setValue("enable", s.Oauth.Settings.EnableIntegration)
 	setValue("persist_users", s.Oauth.Settings.PersistUsers)

--- a/pkg/artifactory/resource_artifactory_oauth_settings_test.go
+++ b/pkg/artifactory/resource_artifactory_oauth_settings_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 const OauthSettingsTemplateFull = `
@@ -31,7 +32,7 @@ resource "artifactory_oauth_settings" "oauth" {
 func TestAccOauthSettings_full(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccOauthSettingsDestroy("artifactory_oauth_settings.oauth"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -80,7 +81,7 @@ resource "artifactory_oauth_settings" "oauth" {
 func TestAccOauthSettings_multipleProviders(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccOauthSettingsDestroy("artifactory_oauth_settings.oauth"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -98,7 +99,8 @@ func TestAccOauthSettings_multipleProviders(t *testing.T) {
 
 func testAccOauthSettingsDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		client := provider.Meta().(*resty.Client)
 
 		_, ok := s.RootModule().Resources[id]

--- a/pkg/artifactory/resource_artifactory_oauth_settings_test.go
+++ b/pkg/artifactory/resource_artifactory_oauth_settings_test.go
@@ -100,7 +100,11 @@ func TestAccOauthSettings_multipleProviders(t *testing.T) {
 func testAccOauthSettingsDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		client := provider.Meta().(*resty.Client)
 
 		_, ok := s.RootModule().Resources[id]

--- a/pkg/artifactory/resource_artifactory_permission_target_test.go
+++ b/pkg/artifactory/resource_artifactory_permission_target_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 const permissionNoIncludes = `
@@ -99,9 +100,9 @@ const permissionFull = `
 `
 
 func TestTestAccPermissionTarget_GitHubIssue126(test *testing.T) {
-	_, permFqrn, permName := mkNames("test-perm", "artifactory_permission_target")
-	_, _, repoName := mkNames("test-perm-repo", "artifactory_local_generic_repository")
-	_, _, username := mkNames("artifactory_user", "artifactory_user")
+	_, permFqrn, permName := utils.MkNames("test-perm", "artifactory_permission_target")
+	_, _, repoName := utils.MkNames("test-perm-repo", "artifactory_local_generic_repository")
+	_, _, username := utils.MkNames("artifactory_user", "artifactory_user")
 	testConfig := `
 		resource "artifactory_local_generic_repository" "{{ .repo_name }}" {
 		  key             = "{{ .repo_name }}"
@@ -138,7 +139,7 @@ func TestTestAccPermissionTarget_GitHubIssue126(test *testing.T) {
 		"username":  username,
 		"repo_name": repoName,
 	}
-	foo := executeTemplate(permFqrn, testConfig, variables)
+	foo := utils.ExecuteTemplate(permFqrn, testConfig, variables)
 	resource.Test(test, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(test) },
 		CheckDestroy:      testPermissionTargetCheckDestroy(permFqrn),
@@ -158,7 +159,7 @@ func TestTestAccPermissionTarget_GitHubIssue126(test *testing.T) {
 }
 
 func TestAccPermissionTarget_full(test *testing.T) {
-	_, permFqrn, permName := mkNames("test-perm", "artifactory_permission_target")
+	_, permFqrn, permName := utils.MkNames("test-perm", "artifactory_permission_target")
 
 	tempStruct := map[string]string{
 		"repo_name":       "example-repo-local",
@@ -171,7 +172,7 @@ func TestAccPermissionTarget_full(test *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: executeTemplate(permFqrn, permissionFull, tempStruct),
+				Config: utils.ExecuteTemplate(permFqrn, permissionFull, tempStruct),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(permFqrn, "name", permName),
 					resource.TestCheckResourceAttr(permFqrn, "repo.0.actions.0.users.#", "1"),
@@ -191,7 +192,7 @@ func TestAccPermissionTarget_full(test *testing.T) {
 }
 
 func TestAccPermissionTarget_addBuild(t *testing.T) {
-	_, permFqrn, permName := mkNames("test-perm", "artifactory_permission_target")
+	_, permFqrn, permName := utils.MkNames("test-perm", "artifactory_permission_target")
 
 	tempStruct := map[string]string{
 		"repo_name":       "example-repo-local", // because of race conditions in artifactory, this repo must first exist
@@ -204,7 +205,7 @@ func TestAccPermissionTarget_addBuild(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: executeTemplate(permFqrn, permissionNoIncludes, tempStruct),
+				Config: utils.ExecuteTemplate(permFqrn, permissionNoIncludes, tempStruct),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(permFqrn, "name", permName),
 					resource.TestCheckResourceAttr(permFqrn, "repo.0.actions.0.users.#", "1"),
@@ -215,7 +216,7 @@ func TestAccPermissionTarget_addBuild(t *testing.T) {
 				),
 			},
 			{
-				Config: executeTemplate(permFqrn, permissionJustBuild, tempStruct),
+				Config: utils.ExecuteTemplate(permFqrn, permissionJustBuild, tempStruct),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(permFqrn, "name", permName),
 					resource.TestCheckResourceAttr(permFqrn, "repo.#", "0"),
@@ -227,7 +228,7 @@ func TestAccPermissionTarget_addBuild(t *testing.T) {
 				),
 			},
 			{
-				Config: executeTemplate(permFqrn, permissionFull, tempStruct),
+				Config: utils.ExecuteTemplate(permFqrn, permissionFull, tempStruct),
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(permFqrn, "name", permName),
 					resource.TestCheckResourceAttr(permFqrn, "repo.0.actions.0.users.#", "1"),

--- a/pkg/artifactory/resource_artifactory_permission_target_test.go
+++ b/pkg/artifactory/resource_artifactory_permission_target_test.go
@@ -256,7 +256,11 @@ func testPermissionTargetCheckDestroy(id ...string) func(*terraform.State) error
 				return fmt.Errorf("err: Resource id[%s] not found", id)
 			}
 			provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-			utils.ConfigureProvider(provider)
+			provider, err := utils.ConfigureProvider(provider)
+			if err != nil {
+				return err
+			}
+
 			exists, _ := permTargetExists(rs.Primary.ID, provider.Meta())
 			if !exists {
 				return nil

--- a/pkg/artifactory/resource_artifactory_permission_target_test.go
+++ b/pkg/artifactory/resource_artifactory_permission_target_test.go
@@ -143,7 +143,7 @@ func TestTestAccPermissionTarget_GitHubIssue126(test *testing.T) {
 	resource.Test(test, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(test) },
 		CheckDestroy:      testPermissionTargetCheckDestroy(permFqrn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: foo,
@@ -169,7 +169,7 @@ func TestAccPermissionTarget_full(test *testing.T) {
 	resource.Test(test, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(test) },
 		CheckDestroy:      testPermissionTargetCheckDestroy(permFqrn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: utils.ExecuteTemplate(permFqrn, permissionFull, tempStruct),
@@ -202,7 +202,7 @@ func TestAccPermissionTarget_addBuild(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testPermissionTargetCheckDestroy(permFqrn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: utils.ExecuteTemplate(permFqrn, permissionNoIncludes, tempStruct),
@@ -255,7 +255,8 @@ func testPermissionTargetCheckDestroy(id ...string) func(*terraform.State) error
 			if !ok {
 				return fmt.Errorf("err: Resource id[%s] not found", id)
 			}
-			provider, _ := testAccProviders["artifactory"]()
+			provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+			utils.ConfigureProvider(provider)
 			exists, _ := permTargetExists(rs.Primary.ID, provider.Meta())
 			if !exists {
 				return nil

--- a/pkg/artifactory/resource_artifactory_pull_replication.go
+++ b/pkg/artifactory/resource_artifactory_pull_replication.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 var pullReplicationSchema = map[string]*schema.Schema{
@@ -82,32 +83,32 @@ func resourceArtifactoryPullReplication() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema:      mergeSchema(replicationSchemaCommon, pullReplicationSchema),
+		Schema:      utils.MergeSchema(replicationSchemaCommon, pullReplicationSchema),
 		Description: "Used for configuring pull replication on local or remote repos.",
 	}
 }
 
 func unpackPullReplication(s *schema.ResourceData) *ReplicationBody {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	replicationConfig := new(ReplicationBody)
 
-	replicationConfig.RepoKey = d.getString("repo_key", false)
-	replicationConfig.CronExp = d.getString("cron_exp", false)
-	replicationConfig.EnableEventReplication = d.getBool("enable_event_replication", false)
-	replicationConfig.URL = d.getString("url", false)
-	replicationConfig.Username = d.getString("username", false)
-	replicationConfig.Password = d.getString("password", false)
-	replicationConfig.Enabled = d.getBool("enabled", false)
-	replicationConfig.SyncDeletes = d.getBool("sync_deletes", false)
-	replicationConfig.SyncProperties = d.getBool("sync_properties", false)
-	replicationConfig.SyncStatistics = d.getBool("sync_statistics", false)
-	replicationConfig.PathPrefix = d.getString("path_prefix", false)
+	replicationConfig.RepoKey = d.GetString("repo_key", false)
+	replicationConfig.CronExp = d.GetString("cron_exp", false)
+	replicationConfig.EnableEventReplication = d.GetBool("enable_event_replication", false)
+	replicationConfig.URL = d.GetString("url", false)
+	replicationConfig.Username = d.GetString("username", false)
+	replicationConfig.Password = d.GetString("password", false)
+	replicationConfig.Enabled = d.GetBool("enabled", false)
+	replicationConfig.SyncDeletes = d.GetBool("sync_deletes", false)
+	replicationConfig.SyncProperties = d.GetBool("sync_properties", false)
+	replicationConfig.SyncStatistics = d.GetBool("sync_statistics", false)
+	replicationConfig.PathPrefix = d.GetString("path_prefix", false)
 
 	return replicationConfig
 }
 
 func packPullReplication(config PullReplication, d *schema.ResourceData) diag.Diagnostics {
-	setValue := mkLens(d)
+	setValue := utils.MkLens(d)
 
 	setValue("repo_key", config.RepoKey)
 	setValue("cron_exp", config.CronExp)

--- a/pkg/artifactory/resource_artifactory_pull_replication_test.go
+++ b/pkg/artifactory/resource_artifactory_pull_replication_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func mkTclForPullRepConfg(name, cron, url string) string {
@@ -39,7 +39,7 @@ func mkTclForPullRepConfg(name, cron, url string) string {
 
 func TestAccPullReplicationInvalidCron(t *testing.T) {
 
-	_, fqrn, name := mkNames("lib-local", "artifactory_pull_replication")
+	_, fqrn, name := utils.MkNames("lib-local", "artifactory_pull_replication")
 	var failCron = mkTclForPullRepConfg(name, "0 0 * * * !!", os.Getenv("ARTIFACTORY_URL"))
 
 	resource.Test(t, resource.TestCase{
@@ -56,7 +56,7 @@ func TestAccPullReplicationInvalidCron(t *testing.T) {
 }
 
 func TestAccPullReplicationLocalRepo(t *testing.T) {
-	_, fqrn, name := mkNames("lib-local", "artifactory_pull_replication")
+	_, fqrn, name := utils.MkNames("lib-local", "artifactory_pull_replication")
 	config := mkTclForPullRepConfg(name, "0 0 * * * ?", os.Getenv("ARTIFACTORY_URL"))
 	updatedConfig := mkTclForPullRepConfg(name, "1 0 * * * ?", os.Getenv("ARTIFACTORY_URL"))
 	resource.Test(t, resource.TestCase{
@@ -105,8 +105,8 @@ func compositeCheckDestroy(funcs ...func(state *terraform.State) error) func(sta
 }
 
 func TestAccPullReplicationRemoteRepo(t *testing.T) {
-	_, fqrn, name := mkNames("lib-remote", "artifactory_pull_replication")
-	_, fqrepoName, repo_name := mkNames("lib-remote", "artifactory_remote_maven_repository")
+	_, fqrn, name := utils.MkNames("lib-remote", "artifactory_pull_replication")
+	_, fqrepoName, repo_name := utils.MkNames("lib-remote", "artifactory_remote_maven_repository")
 	var tcl = `
 		resource "artifactory_remote_maven_repository" "{{ .remote_name }}" {
 			key 				  = "{{ .remote_name }}"
@@ -121,7 +121,7 @@ func TestAccPullReplicationRemoteRepo(t *testing.T) {
 			depends_on = [artifactory_remote_maven_repository.{{ .remote_name }}]
 		}
 	`
-	tcl = executeTemplate("foo", tcl, map[string]string{
+	tcl = utils.ExecuteTemplate("foo", tcl, map[string]string{
 		"repoconfig_name": name,
 		"remote_name":     repo_name,
 	})

--- a/pkg/artifactory/resource_artifactory_pull_replication_test.go
+++ b/pkg/artifactory/resource_artifactory_pull_replication_test.go
@@ -45,7 +45,7 @@ func TestAccPullReplicationInvalidCron(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccCheckReplicationDestroy(fqrn),
 		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      failCron,
@@ -61,7 +61,7 @@ func TestAccPullReplicationLocalRepo(t *testing.T) {
 	updatedConfig := mkTclForPullRepConfg(name, "1 0 * * * ?", os.Getenv("ARTIFACTORY_URL"))
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccCheckReplicationDestroy(fqrn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -125,13 +125,16 @@ func TestAccPullReplicationRemoteRepo(t *testing.T) {
 		"repoconfig_name": name,
 		"remote_name":     repo_name,
 	})
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		CheckDestroy: compositeCheckDestroy(
-			verifyDeleted(fqrepoName, testCheckRepo),
+			utils.VerifyDeleted(fqrepoName, provider, utils.TestCheckRepo),
 			testAccCheckReplicationDestroy(fqrn),
 		),
 
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{

--- a/pkg/artifactory/resource_artifactory_push_replication.go
+++ b/pkg/artifactory/resource_artifactory_push_replication.go
@@ -146,15 +146,15 @@ func resourceArtifactoryPushReplication() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: mergeSchema(pushReplicationSchemaCommon, pushRepMultipleSchema),
+		Schema: utils.MergeSchema(pushReplicationSchemaCommon, pushRepMultipleSchema),
 	}
 }
 
 func unpackPushReplication(s *schema.ResourceData) UpdatePushReplication {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	pushReplication := new(UpdatePushReplication)
 
-	repo := d.getString("repo_key", false)
+	repo := d.GetString("repo_key", false)
 
 	if v, ok := d.GetOk("replications"); ok {
 		arr := v.([]interface{})
@@ -165,8 +165,8 @@ func unpackPushReplication(s *schema.ResourceData) UpdatePushReplication {
 		for i, o := range arr {
 			if i == 0 {
 				pushReplication.RepoKey = repo
-				pushReplication.CronExp = d.getString("cron_exp", false)
-				pushReplication.EnableEventReplication = d.getBool("enable_event_replication", false)
+				pushReplication.CronExp = d.GetString("cron_exp", false)
+				pushReplication.EnableEventReplication = d.GetBool("enable_event_replication", false)
 			}
 
 			m := o.(map[string]interface{})
@@ -174,7 +174,7 @@ func unpackPushReplication(s *schema.ResourceData) UpdatePushReplication {
 			var replication updateReplicationBody
 
 			replication.RepoKey = repo
-			replication.CronExp = d.getString("cron_exp", false)
+			replication.CronExp = d.GetString("cron_exp", false)
 
 			if v, ok = m["url"]; ok {
 				replication.URL = v.(string)
@@ -225,7 +225,7 @@ func unpackPushReplication(s *schema.ResourceData) UpdatePushReplication {
 
 func packPushReplication(pushReplication *GetPushReplication, d *schema.ResourceData) diag.Diagnostics {
 	var errors []error
-	setValue := mkLens(d)
+	setValue := utils.MkLens(d)
 
 	setValue("repo_key", pushReplication.RepoKey)
 	setValue("cron_exp", pushReplication.CronExp)

--- a/pkg/artifactory/resource_artifactory_push_replication.go
+++ b/pkg/artifactory/resource_artifactory_push_replication.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 	"golang.org/x/exp/slices"
 )
 
@@ -58,7 +59,7 @@ var pushReplicationSchemaCommon = map[string]*schema.Schema{
 	"cron_exp": {
 		Type:             schema.TypeString,
 		Required:         true,
-		ValidateDiagFunc: validation.ToDiagFunc(validateCron),
+		ValidateDiagFunc: validation.ToDiagFunc(utils.ValidateCron),
 	},
 	"enable_event_replication": {
 		Type:     schema.TypeBool,

--- a/pkg/artifactory/resource_artifactory_push_replication_test.go
+++ b/pkg/artifactory/resource_artifactory_push_replication_test.go
@@ -164,7 +164,11 @@ func testAccCheckPushReplicationDestroy(id string) func(*terraform.State) error 
 			return fmt.Errorf("err: Resource id[%s] not found", id)
 		}
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		exists, _ := repConfigExists(rs.Primary.ID, provider.Meta())
 		if exists {
 			return fmt.Errorf("error: Replication %s still exists", id)

--- a/pkg/artifactory/resource_artifactory_push_replication_test.go
+++ b/pkg/artifactory/resource_artifactory_push_replication_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccPushReplicationInvalidPushCronFails(t *testing.T) {
@@ -76,7 +77,7 @@ func TestAccPushReplication_full(t *testing.T) {
 		"username": rtDefaultUser,
 		"proxy":    testProxy,
 	}
-	replicationConfig := executeTemplate("TestAccPushReplication", `
+	replicationConfig := utils.ExecuteTemplate("TestAccPushReplication", `
 		resource "artifactory_local_maven_repository" "lib-local" {
 			key = "lib-local"
 		}
@@ -95,7 +96,7 @@ func TestAccPushReplication_full(t *testing.T) {
 		}
 	`, params)
 
-	replicationUpdateConfig := executeTemplate("TestAccPushReplication", `
+	replicationUpdateConfig := utils.ExecuteTemplate("TestAccPushReplication", `
 		resource "artifactory_local_maven_repository" "lib-local" {
 			key = "lib-local"
 		}

--- a/pkg/artifactory/resource_artifactory_push_replication_test.go
+++ b/pkg/artifactory/resource_artifactory_push_replication_test.go
@@ -30,7 +30,7 @@ func TestAccPushReplicationInvalidPushCronFails(t *testing.T) {
 		}
 	`
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      invalidCron,
@@ -59,7 +59,7 @@ func TestAccPushReplicationInvalidUrlFails(t *testing.T) {
 		}
 	`
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      invalidUrl,
@@ -118,13 +118,13 @@ func TestAccPushReplication_full(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			createProxy(t, testProxy)
+			utils.CreateProxy(t, testProxy)
 		},
 		CheckDestroy: func() func(*terraform.State) error {
-			deleteProxy(t, testProxy)
+			utils.DeleteProxy(t, testProxy)
 			return testAccCheckPushReplicationDestroy("artifactory_push_replication.lib-local")
 		}(),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -163,7 +163,8 @@ func testAccCheckPushReplicationDestroy(id string) func(*terraform.State) error 
 		if !ok {
 			return fmt.Errorf("err: Resource id[%s] not found", id)
 		}
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		exists, _ := repConfigExists(rs.Primary.ID, provider.Meta())
 		if exists {
 			return fmt.Errorf("error: Replication %s still exists", id)

--- a/pkg/artifactory/resource_artifactory_remote_bower_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_bower_repository.go
@@ -3,6 +3,7 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type BowerRemoteRepo struct {
@@ -14,7 +15,7 @@ type BowerRemoteRepo struct {
 func resourceArtifactoryRemoteBowerRepository() *schema.Resource {
 	const packageType = "bower"
 
-	var bowerRemoteSchema = mergeSchema(baseRemoteRepoSchema, vcsRemoteRepoSchema, map[string]*schema.Schema{
+	var bowerRemoteSchema = utils.MergeSchema(baseRemoteRepoSchema, vcsRemoteRepoSchema, map[string]*schema.Schema{
 		"bower_registry_url": {
 			Type:         schema.TypeString,
 			Optional:     true,
@@ -25,11 +26,11 @@ func resourceArtifactoryRemoteBowerRepository() *schema.Resource {
 	}, repoLayoutRefSchema("remote", packageType))
 
 	var unpackBowerRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 		repo := BowerRemoteRepo{
 			RemoteRepositoryBaseParams: unpackBaseRemoteRepo(s, packageType),
 			RemoteRepositoryVcsParams:  unpackVcsRemoteRepo(s),
-			BowerRegistryUrl:           d.getString("bower_registry_url", false),
+			BowerRegistryUrl:           d.GetString("bower_registry_url", false),
 		}
 		return repo, repo.Id(), nil
 	}

--- a/pkg/artifactory/resource_artifactory_remote_cargo_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_cargo_repository.go
@@ -3,6 +3,7 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type CargoRemoteRepo struct {
@@ -14,7 +15,7 @@ type CargoRemoteRepo struct {
 func resourceArtifactoryRemoteCargoRepository() *schema.Resource {
 	const packageType = "cargo"
 
-	var cargoRemoteSchema = mergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
+	var cargoRemoteSchema = utils.MergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
 		"git_registry_url": {
 			Type:         schema.TypeString,
 			Required:     true,
@@ -30,11 +31,11 @@ func resourceArtifactoryRemoteCargoRepository() *schema.Resource {
 	}, repoLayoutRefSchema("remote", packageType))
 
 	var unpackCargoRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 		repo := CargoRemoteRepo{
 			RemoteRepositoryBaseParams: unpackBaseRemoteRepo(s, packageType),
-			RegistryUrl:                d.getString("git_registry_url", false),
-			AnonymousAccess:            d.getBool("anonymous_access", false),
+			RegistryUrl:                d.GetString("git_registry_url", false),
+			AnonymousAccess:            d.GetBool("anonymous_access", false),
 		}
 		return repo, repo.Id(), nil
 	}

--- a/pkg/artifactory/resource_artifactory_remote_cocoapods_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_cocoapods_repository.go
@@ -3,6 +3,7 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type CocoapodsRemoteRepo struct {
@@ -14,7 +15,7 @@ type CocoapodsRemoteRepo struct {
 func resourceArtifactoryRemoteCocoapodsRepository() *schema.Resource {
 	const packageType = "cocoapods"
 
-	var cocoapodsRemoteSchema = mergeSchema(baseRemoteRepoSchema, vcsRemoteRepoSchema, map[string]*schema.Schema{
+	var cocoapodsRemoteSchema = utils.MergeSchema(baseRemoteRepoSchema, vcsRemoteRepoSchema, map[string]*schema.Schema{
 		"pods_specs_repo_url": {
 			Type:         schema.TypeString,
 			Optional:     true,
@@ -25,11 +26,11 @@ func resourceArtifactoryRemoteCocoapodsRepository() *schema.Resource {
 	}, repoLayoutRefSchema("remote", packageType))
 
 	var unpackCocoapodsRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 		repo := CocoapodsRemoteRepo{
 			RemoteRepositoryBaseParams: unpackBaseRemoteRepo(s, packageType),
 			RemoteRepositoryVcsParams:  unpackVcsRemoteRepo(s),
-			PodsSpecsRepoUrl:           d.getString("pods_specs_repo_url", false),
+			PodsSpecsRepoUrl:           d.GetString("pods_specs_repo_url", false),
 		}
 		return repo, repo.Id(), nil
 	}

--- a/pkg/artifactory/resource_artifactory_remote_composer_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_composer_repository.go
@@ -3,6 +3,7 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type ComposerRemoteRepo struct {
@@ -14,7 +15,7 @@ type ComposerRemoteRepo struct {
 func resourceArtifactoryRemoteComposerRepository() *schema.Resource {
 	const packageType = "composer"
 
-	var composerRemoteSchema = mergeSchema(baseRemoteRepoSchema, vcsRemoteRepoSchema, map[string]*schema.Schema{
+	var composerRemoteSchema = utils.MergeSchema(baseRemoteRepoSchema, vcsRemoteRepoSchema, map[string]*schema.Schema{
 		"composer_registry_url": {
 			Type:         schema.TypeString,
 			Optional:     true,
@@ -25,11 +26,11 @@ func resourceArtifactoryRemoteComposerRepository() *schema.Resource {
 	}, repoLayoutRefSchema("remote", packageType))
 
 	var unpackComposerRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 		repo := ComposerRemoteRepo{
 			RemoteRepositoryBaseParams: unpackBaseRemoteRepo(s, packageType),
 			RemoteRepositoryVcsParams:  unpackVcsRemoteRepo(s),
-			ComposerRegistryUrl:        d.getString("composer_registry_url", false),
+			ComposerRegistryUrl:        d.GetString("composer_registry_url", false),
 		}
 		return repo, repo.Id(), nil
 	}

--- a/pkg/artifactory/resource_artifactory_remote_docker_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_docker_repository.go
@@ -2,6 +2,7 @@ package artifactory
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type DockerRemoteRepository struct {
@@ -15,7 +16,7 @@ type DockerRemoteRepository struct {
 func resourceArtifactoryRemoteDockerRepository() *schema.Resource {
 	const packageType = "docker"
 
-	var dockerRemoteSchema = mergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
+	var dockerRemoteSchema = utils.MergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
 		"external_dependencies_enabled": {
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -48,13 +49,13 @@ func resourceArtifactoryRemoteDockerRepository() *schema.Resource {
 	}, repoLayoutRefSchema("remote", packageType))
 
 	var unpackDockerRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 		repo := DockerRemoteRepository{
 			RemoteRepositoryBaseParams:   unpackBaseRemoteRepo(s, packageType),
-			EnableTokenAuthentication:    d.getBool("enable_token_authentication", false),
-			ExternalDependenciesEnabled:  d.getBool("external_dependencies_enabled", false),
-			BlockPushingSchema1:          d.getBool("block_pushing_schema1", false),
-			ExternalDependenciesPatterns: d.getList("external_dependencies_patterns"),
+			EnableTokenAuthentication:    d.GetBool("enable_token_authentication", false),
+			ExternalDependenciesEnabled:  d.GetBool("external_dependencies_enabled", false),
+			BlockPushingSchema1:          d.GetBool("block_pushing_schema1", false),
+			ExternalDependenciesPatterns: d.GetList("external_dependencies_patterns"),
 		}
 		if len(repo.ExternalDependenciesPatterns) == 0 {
 			repo.ExternalDependenciesPatterns = []string{"**"}
@@ -65,7 +66,7 @@ func resourceArtifactoryRemoteDockerRepository() *schema.Resource {
 	// Special handling for "external_dependencies_patterns" attribute to match default value behavior in UI.
 	dockerRemoteRepoPacker := universalPack(
 		allHclPredicate(
-			schemaHasKey(dockerRemoteSchema),
+			utils.SchemaHasKey(dockerRemoteSchema),
 			noPassword,
 			ignoreHclPredicate("external_dependencies_patterns"),
 		),

--- a/pkg/artifactory/resource_artifactory_remote_generic_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_generic_repository.go
@@ -2,6 +2,7 @@ package artifactory
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryRemoteGenericRepository(pkt string) *schema.Resource {
@@ -19,7 +20,7 @@ func resourceArtifactoryRemoteGenericRepository(pkt string) *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	mergedRemoteRepoSchema := mergeSchema(baseRemoteRepoSchema, repoLayoutRefSchema("remote", pkt))
+	mergedRemoteRepoSchema := utils.MergeSchema(baseRemoteRepoSchema, repoLayoutRefSchema("remote", pkt))
 
 	return mkResourceSchema(mergedRemoteRepoSchema, defaultPacker(mergedRemoteRepoSchema), unpack, constructor)
 }

--- a/pkg/artifactory/resource_artifactory_remote_go_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_go_repository.go
@@ -3,6 +3,7 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type GoRemoteRepo struct {
@@ -13,7 +14,7 @@ type GoRemoteRepo struct {
 func resourceArtifactoryRemoteGoRepository() *schema.Resource {
 	const packageType = "go"
 
-	var goRemoteSchema = mergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
+	var goRemoteSchema = utils.MergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
 		"vcs_git_provider": {
 			Type:             schema.TypeString,
 			Optional:         true,
@@ -24,10 +25,10 @@ func resourceArtifactoryRemoteGoRepository() *schema.Resource {
 	}, repoLayoutRefSchema("remote", packageType))
 
 	var unpackGoRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 		repo := GoRemoteRepo{
 			RemoteRepositoryBaseParams: unpackBaseRemoteRepo(s, packageType),
-			VcsGitProvider:             d.getString("vcs_git_provider", false),
+			VcsGitProvider:             d.GetString("vcs_git_provider", false),
 		}
 		return repo, repo.Id(), nil
 	}

--- a/pkg/artifactory/resource_artifactory_remote_helm_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_helm_repository.go
@@ -3,12 +3,13 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryRemoteHelmRepository() *schema.Resource {
 	const packageType = "helm"
 
-	var helmRemoteSchema = mergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
+	var helmRemoteSchema = utils.MergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
 		"helm_charts_base_url": {
 			Type:             schema.TypeString,
 			Optional:         true,
@@ -44,12 +45,12 @@ func resourceArtifactoryRemoteHelmRepository() *schema.Resource {
 	}
 
 	var unpackHelmRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 		repo := HelmRemoteRepo{
 			RemoteRepositoryBaseParams:   unpackBaseRemoteRepo(s, packageType),
-			HelmChartsBaseURL:            d.getString("helm_charts_base_url", false),
-			ExternalDependenciesEnabled:  d.getBool("external_dependencies_enabled", false),
-			ExternalDependenciesPatterns: d.getList("external_dependencies_patterns"),
+			HelmChartsBaseURL:            d.GetString("helm_charts_base_url", false),
+			ExternalDependenciesEnabled:  d.GetBool("external_dependencies_enabled", false),
+			ExternalDependenciesPatterns: d.GetList("external_dependencies_patterns"),
 		}
 		if len(repo.ExternalDependenciesPatterns) == 0 {
 			repo.ExternalDependenciesPatterns = []string{"**"}
@@ -60,7 +61,7 @@ func resourceArtifactoryRemoteHelmRepository() *schema.Resource {
 	// Special handling for "external_dependencies_patterns" attribute to match default value behavior in UI.
 	helmRemoteRepoPacker := universalPack(
 		allHclPredicate(
-			schemaHasKey(helmRemoteSchema),
+			utils.SchemaHasKey(helmRemoteSchema),
 			noPassword,
 			ignoreHclPredicate("external_dependencies_patterns"),
 		),

--- a/pkg/artifactory/resource_artifactory_remote_java_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_java_repository.go
@@ -3,10 +3,11 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryRemoteJavaRepository(repoType string, suppressPom bool) *schema.Resource {
-	var javaRemoteSchema = mergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
+	var javaRemoteSchema = utils.MergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
 		"fetch_jars_eagerly": {
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -69,16 +70,16 @@ func resourceArtifactoryRemoteJavaRepository(repoType string, suppressPom bool) 
 	}
 
 	var unpackJavaRemoteRepo = func(data *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{data}
+		d := &utils.ResourceData{data}
 		repo := JavaRemoteRepo{
 			RemoteRepositoryBaseParams:   unpackBaseRemoteRepo(data, repoType),
-			FetchJarsEagerly:             d.getBool("fetch_jars_eagerly", false),
-			FetchSourcesEagerly:          d.getBool("fetch_sources_eagerly", false),
-			RemoteRepoChecksumPolicyType: d.getString("remote_repo_checksum_policy_type", false),
-			HandleReleases:               d.getBool("handle_releases", false),
-			HandleSnapshots:              d.getBool("handle_snapshots", false),
-			SuppressPomConsistencyChecks: d.getBool("suppress_pom_consistency_checks", false),
-			RejectInvalidJars:            d.getBool("reject_invalid_jars", false),
+			FetchJarsEagerly:             d.GetBool("fetch_jars_eagerly", false),
+			FetchSourcesEagerly:          d.GetBool("fetch_sources_eagerly", false),
+			RemoteRepoChecksumPolicyType: d.GetString("remote_repo_checksum_policy_type", false),
+			HandleReleases:               d.GetBool("handle_releases", false),
+			HandleSnapshots:              d.GetBool("handle_snapshots", false),
+			SuppressPomConsistencyChecks: d.GetBool("suppress_pom_consistency_checks", false),
+			RejectInvalidJars:            d.GetBool("reject_invalid_jars", false),
 		}
 		return repo, repo.Id(), nil
 	}

--- a/pkg/artifactory/resource_artifactory_remote_nuget_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_nuget_repository.go
@@ -3,6 +3,7 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type NugetRemoteRepo struct {
@@ -16,7 +17,7 @@ type NugetRemoteRepo struct {
 func resourceArtifactoryRemoteNugetRepository() *schema.Resource {
 	const packageType = "nuget"
 
-	var nugetRemoteSchema = mergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
+	var nugetRemoteSchema = utils.MergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
 		"feed_context_path": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -46,13 +47,13 @@ func resourceArtifactoryRemoteNugetRepository() *schema.Resource {
 	}, repoLayoutRefSchema("remote", packageType))
 
 	var unpackNugetRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 		repo := NugetRemoteRepo{
 			RemoteRepositoryBaseParams: unpackBaseRemoteRepo(s, packageType),
-			FeedContextPath:            d.getString("feed_context_path", false),
-			DownloadContextPath:        d.getString("download_context_path", false),
-			V3FeedUrl:                  d.getString("v3_feed_url", false),
-			ForceNugetAuthentication:   d.getBool("force_nuget_authentication", false),
+			FeedContextPath:            d.GetString("feed_context_path", false),
+			DownloadContextPath:        d.GetString("download_context_path", false),
+			V3FeedUrl:                  d.GetString("v3_feed_url", false),
+			ForceNugetAuthentication:   d.GetBool("force_nuget_authentication", false),
 		}
 		return repo, repo.Id(), nil
 	}

--- a/pkg/artifactory/resource_artifactory_remote_pypi_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_pypi_repository.go
@@ -3,12 +3,13 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryRemotePypiRepository() *schema.Resource {
 	const packageType = "pypi"
 
-	var pypiRemoteSchema = mergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
+	var pypiRemoteSchema = utils.MergeSchema(baseRemoteRepoSchema, map[string]*schema.Schema{
 		"pypi_registry_url": {
 			Type:             schema.TypeString,
 			Optional:         true,
@@ -32,11 +33,11 @@ func resourceArtifactoryRemotePypiRepository() *schema.Resource {
 	}
 
 	var unpackPypiRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 		repo := PypiRemoteRepo{
 			RemoteRepositoryBaseParams: unpackBaseRemoteRepo(s, packageType),
-			PypiRegistryUrl:            d.getString("pypi_registry_url", false),
-			PypiRepositorySuffix:       d.getString("pypi_repository_suffix", false),
+			PypiRegistryUrl:            d.GetString("pypi_registry_url", false),
+			PypiRepositorySuffix:       d.GetString("pypi_repository_suffix", false),
 		}
 		return repo, repo.Id(), nil
 	}

--- a/pkg/artifactory/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_remote_repository_test.go
@@ -11,12 +11,13 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccLocalAllowDotsUnderscorersAndDashesInKeyGH129(t *testing.T) {
-	_, fqrn, name := mkNames("terraform-local-test-repo-basic", "artifactory_remote_debian_repository")
+	_, fqrn, name := utils.MkNames("terraform-local-test-repo-basic", "artifactory_remote_debian_repository")
 
-	key := fmt.Sprintf("debian-remote.teleport_%d", randomInt())
+	key := fmt.Sprintf("debian-remote.teleport_%d", utils.RandomInt())
 	localRepositoryBasic := fmt.Sprintf(`
 		resource "artifactory_remote_debian_repository" "%s" {
 			key              = "%s"
@@ -406,7 +407,7 @@ func TestAccRemoteDockerRepositoryWithListRemoteFolderItems(t *testing.T) {
 }
 
 func TestAccRemoteRepositoryChangeConfigGH148(t *testing.T) {
-	_, fqrn, name := mkNames("github-remote", "artifactory_remote_generic_repository")
+	_, fqrn, name := utils.MkNames("github-remote", "artifactory_remote_generic_repository")
 	const step1 = `
 		locals {
 		  allowed_github_repos = [
@@ -456,7 +457,7 @@ func TestAccRemoteRepositoryChangeConfigGH148(t *testing.T) {
 		ProviderFactories: testAccProviders,
 		Steps: []resource.TestStep{
 			{
-				Config: executeTemplate("one", step1, map[string]interface{}{
+				Config: utils.ExecuteTemplate("one", step1, map[string]interface{}{
 					"name": name,
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -466,7 +467,7 @@ func TestAccRemoteRepositoryChangeConfigGH148(t *testing.T) {
 				),
 			},
 			{
-				Config: executeTemplate("two", step2, map[string]interface{}{
+				Config: utils.ExecuteTemplate("two", step2, map[string]interface{}{
 					"name": name,
 				}),
 				Check: resource.ComposeTestCheckFunc(
@@ -522,7 +523,7 @@ func TestAccRemoteRepository_nugetNew(t *testing.T) {
 			force_nuget_authentication = true
 		}
 	`
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("terraform-remote-test-repo-nuget%d", id)
 	fqrn := fmt.Sprintf("artifactory_remote_nuget_repository.%s", name)
 	resource.Test(t, resource.TestCase{
@@ -545,7 +546,7 @@ func TestAccRemoteRepository_nugetNew(t *testing.T) {
 
 // if you wish to override any of the default fields, just pass it as "extrFields" as these will overwrite
 func mkNewRemoteTestCase(repoType string, t *testing.T, extraFields map[string]interface{}) (*testing.T, resource.TestCase) {
-	_, fqrn, name := mkNames("terraform-remote-test-repo-full", fmt.Sprintf("artifactory_remote_%s_repository", repoType))
+	_, fqrn, name := utils.MkNames("terraform-remote-test-repo-full", fmt.Sprintf("artifactory_remote_%s_repository", repoType))
 
 	defaultFields := map[string]interface{}{
 		"key":      name,
@@ -562,7 +563,7 @@ func mkNewRemoteTestCase(repoType string, t *testing.T, extraFields map[string]i
 		"hard_fail":                      true,
 		"offline":                        true,
 		"blacked_out":                    true,
-		"xray_index":                     randBool(),
+		"xray_index":                     utils.RandBool(),
 		"store_artifacts_locally":        true,
 		"socket_timeout_millis":          25000,
 		"local_address":                  "",
@@ -585,7 +586,7 @@ func mkNewRemoteTestCase(repoType string, t *testing.T, extraFields map[string]i
 			"enabled": false, // even when set to true, it seems to come back as false on the wire
 		},
 	}
-	allFields := mergeMaps(defaultFields, extraFields)
+	allFields := utils.MergeMaps(defaultFields, extraFields)
 	allFieldsHcl := fmtMapToHcl(allFields)
 	const remoteRepoFull = `
 		resource "artifactory_remote_%s_repository" "%s" {
@@ -612,7 +613,7 @@ func mkNewRemoteTestCase(repoType string, t *testing.T, extraFields map[string]i
 }
 
 func mkRemoteTestCaseWithAdditionalCheckFunctions(repoType string, t *testing.T, extraFields map[string]interface{}) (*testing.T, resource.TestCase) {
-	_, fqrn, name := mkNames("terraform-remote-test-repo-full", fmt.Sprintf("artifactory_remote_%s_repository", repoType))
+	_, fqrn, name := utils.MkNames("terraform-remote-test-repo-full", fmt.Sprintf("artifactory_remote_%s_repository", repoType))
 
 	defaultFields := map[string]interface{}{
 		"key":      name,
@@ -651,7 +652,7 @@ func mkRemoteTestCaseWithAdditionalCheckFunctions(repoType string, t *testing.T,
 			"enabled": false, // even when set to true, it seems to come back as false on the wire
 		},
 	}
-	allFields := mergeMaps(defaultFields, extraFields)
+	allFields := utils.MergeMaps(defaultFields, extraFields)
 	allFieldsHcl := fmtMapToHcl(allFields)
 	const remoteRepoFull = `
 		resource "artifactory_remote_%s_repository" "%s" {
@@ -694,7 +695,7 @@ func TestAccRemoteRepository_generic_with_propagate(t *testing.T) {
 
 		}
 	`
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("terraform-remote-test-repo-basic%d", id)
 	fqrn := fmt.Sprintf("artifactory_remote_generic_repository.%s", name)
 	resource.Test(t, resource.TestCase{
@@ -716,9 +717,9 @@ func TestAccRemoteRepository_generic_with_propagate(t *testing.T) {
 
 // https://github.com/jfrog/terraform-provider-artifactory/issues/225
 func TestAccRemoteRepository_MissedRetrievalCachePeriodSecs_retained_between_updates_GH225(t *testing.T) {
-	_, fqrn, name := mkNames("terraform-remote-test-repo-basic", "artifactory_remote_cran_repository")
+	_, fqrn, name := utils.MkNames("terraform-remote-test-repo-basic", "artifactory_remote_cran_repository")
 
-	key := fmt.Sprintf("cran-remote-%d", randomInt())
+	key := fmt.Sprintf("cran-remote-%d", utils.RandomInt())
 	remoteRepositoryInit := fmt.Sprintf(`
 		resource "artifactory_remote_cran_repository" "%s" {
 			key              = "%s"
@@ -772,9 +773,9 @@ func TestAccRemoteRepository_MissedRetrievalCachePeriodSecs_retained_between_upd
 
 // https://github.com/jfrog/terraform-provider-artifactory/issues/241
 func TestAccRemoteRepository_assumed_offline_period_secs_has_default_value_GH241(t *testing.T) {
-	_, fqrn, name := mkNames("terraform-remote-test-repo-docker", "artifactory_remote_docker_repository")
+	_, fqrn, name := utils.MkNames("terraform-remote-test-repo-docker", "artifactory_remote_docker_repository")
 
-	key := fmt.Sprintf("docker-remote-%d", randomInt())
+	key := fmt.Sprintf("docker-remote-%d", utils.RandomInt())
 	remoteRepositoryInit := fmt.Sprintf(`
 		resource "artifactory_remote_docker_repository" "%s" {
 			key                                   = "%s"
@@ -804,9 +805,9 @@ func TestAccRemoteRepository_assumed_offline_period_secs_has_default_value_GH241
 }
 
 func TestAccRemoteProxyUpdateGH2(t *testing.T) {
-	_, fqrn, name := mkNames("terraform-remote-test-repo-proxy", "artifactory_remote_go_repository")
+	_, fqrn, name := utils.MkNames("terraform-remote-test-repo-proxy", "artifactory_remote_go_repository")
 
-	key := fmt.Sprintf("go-remote.proxy_%d", randomInt())
+	key := fmt.Sprintf("go-remote.proxy_%d", utils.RandomInt())
 	fakeProxy := "test-proxy"
 
 	remoteRepositoryWithProxy := fmt.Sprintf(`
@@ -877,18 +878,18 @@ func TestAccRemoteProxyUpdateGH2(t *testing.T) {
 func TestAccRemoteRepositoryWithProjectAttributesGH318(t *testing.T) {
 
 	rand.Seed(time.Now().UnixNano())
-	projectKey := fmt.Sprintf("t%d", randomInt())
-	projectEnv := randSelect("DEV", "PROD").(string)
+	projectKey := fmt.Sprintf("t%d", utils.RandomInt())
+	projectEnv := utils.RandSelect("DEV", "PROD").(string)
 	repoName := fmt.Sprintf("%s-pypi-remote", projectKey)
 
-	_, fqrn, name := mkNames(repoName, "artifactory_remote_pypi_repository")
+	_, fqrn, name := utils.MkNames(repoName, "artifactory_remote_pypi_repository")
 
 	params := map[string]interface{}{
 		"name":       name,
 		"projectKey": projectKey,
 		"projectEnv": projectEnv,
 	}
-	remoteRepositoryBasic := executeTemplate("TestAccRemotePyPiRepository", `
+	remoteRepositoryBasic := utils.ExecuteTemplate("TestAccRemotePyPiRepository", `
 		resource "artifactory_remote_pypi_repository" "{{ .name }}" {
 		  key                  = "{{ .name }}"
 	 	  project_key          = "{{ .projectKey }}"
@@ -924,16 +925,16 @@ func TestAccRemoteRepositoryWithProjectAttributesGH318(t *testing.T) {
 func TestAccRemoteRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 
 	rand.Seed(time.Now().UnixNano())
-	projectKey := fmt.Sprintf("t%d", randomInt())
+	projectKey := fmt.Sprintf("t%d", utils.RandomInt())
 	repoName := fmt.Sprintf("%s-pypi-remote", projectKey)
 
-	_, fqrn, name := mkNames(repoName, "artifactory_remote_pypi_repository")
+	_, fqrn, name := utils.MkNames(repoName, "artifactory_remote_pypi_repository")
 
 	params := map[string]interface{}{
 		"name":       name,
 		"projectKey": projectKey,
 	}
-	remoteRepositoryBasic := executeTemplate("TestAccRemotePyPiRepository", `
+	remoteRepositoryBasic := utils.ExecuteTemplate("TestAccRemotePyPiRepository", `
 		resource "artifactory_remote_pypi_repository" "{{ .name }}" {
 		  key                  = "{{ .name }}"
 	 	  project_key          = "invalid-project-key"

--- a/pkg/artifactory/resource_artifactory_remote_vcs_repository.go
+++ b/pkg/artifactory/resource_artifactory_remote_vcs_repository.go
@@ -2,6 +2,7 @@ package artifactory
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type VcsRemoteRepo struct {
@@ -13,7 +14,7 @@ type VcsRemoteRepo struct {
 func resourceArtifactoryRemoteVcsRepository() *schema.Resource {
 	const packageType = "vcs"
 
-	var vcsRemoteSchema = mergeSchema(baseRemoteRepoSchema, vcsRemoteRepoSchema, map[string]*schema.Schema{
+	var vcsRemoteSchema = utils.MergeSchema(baseRemoteRepoSchema, vcsRemoteRepoSchema, map[string]*schema.Schema{
 		"max_unique_snapshots": {
 			Type:     schema.TypeInt,
 			Optional: true,
@@ -25,11 +26,11 @@ func resourceArtifactoryRemoteVcsRepository() *schema.Resource {
 	}, repoLayoutRefSchema("remote", packageType))
 
 	var unpackVcsRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 		repo := VcsRemoteRepo{
 			RemoteRepositoryBaseParams: unpackBaseRemoteRepo(s, packageType),
 			RemoteRepositoryVcsParams:  unpackVcsRemoteRepo(s),
-			MaxUniqueSnapshots:         d.getInt("max_unique_snapshots", false),
+			MaxUniqueSnapshots:         d.GetInt("max_unique_snapshots", false),
 		}
 		return repo, repo.Id(), nil
 	}

--- a/pkg/artifactory/resource_artifactory_replication_config.go
+++ b/pkg/artifactory/resource_artifactory_replication_config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type GetReplicationConfig struct {
@@ -32,7 +33,7 @@ var replicationSchemaCommon = map[string]*schema.Schema{
 	"cron_exp": {
 		Type:         schema.TypeString,
 		Required:     true,
-		ValidateFunc: validateCron,
+		ValidateFunc: utils.ValidateCron,
 	},
 	"enable_event_replication": {
 		Type:     schema.TypeBool,

--- a/pkg/artifactory/resource_artifactory_replication_config.go
+++ b/pkg/artifactory/resource_artifactory_replication_config.go
@@ -118,17 +118,17 @@ func resourceArtifactoryReplicationConfig() *schema.Resource {
 			State: schema.ImportStatePassthrough,
 		},
 
-		Schema: mergeSchema(replicationSchemaCommon, repMultipleSchema),
+		Schema: utils.MergeSchema(replicationSchemaCommon, repMultipleSchema),
 		DeprecationMessage: "This resource has been deprecated in favour of the more explicitly name" +
 			"artifactory_push_replication resource.",
 	}
 }
 
 func unpackReplicationConfig(s *schema.ResourceData) UpdateReplicationConfig {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	replicationConfig := new(UpdateReplicationConfig)
 
-	repo := d.getString("repo_key", false)
+	repo := d.GetString("repo_key", false)
 
 	if v, ok := d.GetOkExists("replications"); ok {
 		arr := v.([]interface{})
@@ -139,8 +139,8 @@ func unpackReplicationConfig(s *schema.ResourceData) UpdateReplicationConfig {
 		for i, o := range arr {
 			if i == 0 {
 				replicationConfig.RepoKey = repo
-				replicationConfig.CronExp = d.getString("cron_exp", false)
-				replicationConfig.EnableEventReplication = d.getBool("enable_event_replication", false)
+				replicationConfig.CronExp = d.GetString("cron_exp", false)
+				replicationConfig.EnableEventReplication = d.GetBool("enable_event_replication", false)
 			}
 
 			m := o.(map[string]interface{})
@@ -198,7 +198,7 @@ func unpackReplicationConfig(s *schema.ResourceData) UpdateReplicationConfig {
 
 func packReplicationConfig(replicationConfig *GetReplicationConfig, d *schema.ResourceData) diag.Diagnostics {
 	var errors []error
-	setValue := mkLens(d)
+	setValue := utils.MkLens(d)
 
 	setValue("repo_key", replicationConfig.RepoKey)
 	setValue("cron_exp", replicationConfig.CronExp)

--- a/pkg/artifactory/resource_artifactory_replication_config_test.go
+++ b/pkg/artifactory/resource_artifactory_replication_config_test.go
@@ -126,7 +126,11 @@ func testAccCheckReplicationDestroy(id string) func(*terraform.State) error {
 			return fmt.Errorf("err: Resource id[%s] not found", id)
 		}
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		exists, _ := repConfigExists(rs.Primary.ID, provider.Meta())
 		if exists {
 			return fmt.Errorf("error: Replication %s still exists", id)

--- a/pkg/artifactory/resource_artifactory_replication_config_test.go
+++ b/pkg/artifactory/resource_artifactory_replication_config_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestInvalidCronFails(t *testing.T) {
@@ -29,7 +30,7 @@ func TestInvalidCronFails(t *testing.T) {
 		}
 	`
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      invalidCron,
@@ -57,7 +58,7 @@ func TestInvalidReplicationUrlFails(t *testing.T) {
 		}
 	`
 	resource.Test(t, resource.TestCase{
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      invalidUrl,
@@ -89,13 +90,13 @@ func TestAccReplication_full(t *testing.T) {
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			createProxy(t, testProxy)
+			utils.CreateProxy(t, testProxy)
 		},
 		CheckDestroy: func() func(*terraform.State) error {
-			deleteProxy(t, testProxy)
+			utils.DeleteProxy(t, testProxy)
 			return testAccCheckReplicationDestroy("artifactory_replication_config.lib-local")
 		}(),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -124,7 +125,8 @@ func testAccCheckReplicationDestroy(id string) func(*terraform.State) error {
 		if !ok {
 			return fmt.Errorf("err: Resource id[%s] not found", id)
 		}
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		exists, _ := repConfigExists(rs.Primary.ID, provider.Meta())
 		if exists {
 			return fmt.Errorf("error: Replication %s still exists", id)

--- a/pkg/artifactory/resource_artifactory_saml_settings.go
+++ b/pkg/artifactory/resource_artifactory_saml_settings.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 	"gopkg.in/yaml.v2"
 )
 
@@ -157,7 +157,7 @@ func resourceSamlSettingsUpdate(ctx context.Context, d *schema.ResourceData, m i
 		return diag.Errorf("failed to marshal saml settings during Update")
 	}
 
-	err = sendConfigurationPatch(content, m)
+	err = utils.SendConfigurationPatch(content, m)
 	if err != nil {
 		return diag.Errorf("failed to send PATCH request to Artifactory during Update")
 	}
@@ -173,7 +173,7 @@ security:
   samlSettings: ~
 `
 
-	err := sendConfigurationPatch([]byte(content), m)
+	err := utils.SendConfigurationPatch([]byte(content), m)
 	if err != nil {
 		return diag.Errorf("failed to send PATCH request to Artifactory during Delete")
 	}
@@ -182,23 +182,23 @@ security:
 }
 
 func unpackSamlSecurity(s *schema.ResourceData) *SamlSecurity {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	security := *new(SamlSecurity)
 
 	settings := SamlSettings{
-		EnableIntegration:         d.getBool("enable", false),
-		Certificate:               d.getString("certificate", false),
-		EmailAttribute:            d.getString("email_attribute", false),
-		GroupAttribute:            d.getString("group_attribute", false),
-		LoginUrl:                  d.getString("login_url", false),
-		LogoutUrl:                 d.getString("logout_url", false),
-		NoAutoUserCreation:        d.getBool("no_auto_user_creation", false),
-		ServiceProviderName:       d.getString("service_provider_name", false),
-		AllowUserToAccessProfile:  d.getBool("allow_user_to_access_profile", false),
-		AutoRedirect:              d.getBool("auto_redirect", false),
-		SyncGroups:                d.getBool("sync_groups", false),
-		VerifyAudienceRestriction: d.getBool("verify_audience_restriction", false),
-		UseEncryptedAssertion:     d.getBool("use_encrypted_assertion", false),
+		EnableIntegration:         d.GetBool("enable", false),
+		Certificate:               d.GetString("certificate", false),
+		EmailAttribute:            d.GetString("email_attribute", false),
+		GroupAttribute:            d.GetString("group_attribute", false),
+		LoginUrl:                  d.GetString("login_url", false),
+		LogoutUrl:                 d.GetString("logout_url", false),
+		NoAutoUserCreation:        d.GetBool("no_auto_user_creation", false),
+		ServiceProviderName:       d.GetString("service_provider_name", false),
+		AllowUserToAccessProfile:  d.GetBool("allow_user_to_access_profile", false),
+		AutoRedirect:              d.GetBool("auto_redirect", false),
+		SyncGroups:                d.GetBool("sync_groups", false),
+		VerifyAudienceRestriction: d.GetBool("verify_audience_restriction", false),
+		UseEncryptedAssertion:     d.GetBool("use_encrypted_assertion", false),
 	}
 
 	security.Saml.Settings = settings
@@ -206,7 +206,7 @@ func unpackSamlSecurity(s *schema.ResourceData) *SamlSecurity {
 }
 
 func packSamlSecurity(s *SamlSecurity, d *schema.ResourceData) diag.Diagnostics {
-	setValue := mkLens(d)
+	setValue := utils.MkLens(d)
 
 	setValue("enable", s.Saml.Settings.EnableIntegration)
 	setValue("certificate", s.Saml.Settings.Certificate)

--- a/pkg/artifactory/resource_artifactory_saml_settings_test.go
+++ b/pkg/artifactory/resource_artifactory_saml_settings_test.go
@@ -58,7 +58,11 @@ func TestAccSamlSettings_full(t *testing.T) {
 func testAccSamlSettingsDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		c := provider.Meta().(*resty.Client)
 
 		_, ok := s.RootModule().Resources[id]

--- a/pkg/artifactory/resource_artifactory_saml_settings_test.go
+++ b/pkg/artifactory/resource_artifactory_saml_settings_test.go
@@ -5,10 +5,9 @@ import (
 	"testing"
 
 	"github.com/go-resty/resty/v2"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 const SamlSettingsTemplateFull = `
@@ -31,7 +30,7 @@ resource "artifactory_saml_settings" "saml" {
 func TestAccSamlSettings_full(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccSamlSettingsDestroy("artifactory_saml_settings.saml"),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -58,8 +57,8 @@ func TestAccSamlSettings_full(t *testing.T) {
 
 func testAccSamlSettingsDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		provider, _ := testAccProviders["artifactory"]()
-
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		c := provider.Meta().(*resty.Client)
 
 		_, ok := s.RootModule().Resources[id]

--- a/pkg/artifactory/resource_artifactory_single_replication_config.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-
 	"github.com/go-resty/resty/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactorySingleReplicationConfig() *schema.Resource {
@@ -22,7 +22,7 @@ func resourceArtifactorySingleReplicationConfig() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: mergeSchema(replicationSchemaCommon, replicationSchema),
+		Schema: utils.MergeSchema(replicationSchemaCommon, replicationSchema),
 		Description: "Used for configuring replications on repos. However, the TCL only makes " +
 			"good sense for local repo replication (PUSH) and not remote (PULL).",
 		DeprecationMessage: "This resource has been deprecated in favour of the more explicitly name" +
@@ -31,28 +31,28 @@ func resourceArtifactorySingleReplicationConfig() *schema.Resource {
 }
 
 func unpackSingleReplicationConfig(s *schema.ResourceData) *updateReplicationBody {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	replicationConfig := new(updateReplicationBody)
 
-	replicationConfig.RepoKey = d.getString("repo_key", false)
-	replicationConfig.CronExp = d.getString("cron_exp", false)
-	replicationConfig.EnableEventReplication = d.getBool("enable_event_replication", false)
-	replicationConfig.URL = d.getString("url", false)
-	replicationConfig.SocketTimeoutMillis = d.getInt("socket_timeout_millis", false)
-	replicationConfig.Username = d.getString("username", false)
-	replicationConfig.Enabled = d.getBool("enabled", false)
-	replicationConfig.SyncDeletes = d.getBool("sync_deletes", false)
-	replicationConfig.SyncProperties = d.getBool("sync_properties", false)
-	replicationConfig.SyncStatistics = d.getBool("sync_statistics", false)
-	replicationConfig.PathPrefix = d.getString("path_prefix", false)
+	replicationConfig.RepoKey = d.GetString("repo_key", false)
+	replicationConfig.CronExp = d.GetString("cron_exp", false)
+	replicationConfig.EnableEventReplication = d.GetBool("enable_event_replication", false)
+	replicationConfig.URL = d.GetString("url", false)
+	replicationConfig.SocketTimeoutMillis = d.GetInt("socket_timeout_millis", false)
+	replicationConfig.Username = d.GetString("username", false)
+	replicationConfig.Enabled = d.GetBool("enabled", false)
+	replicationConfig.SyncDeletes = d.GetBool("sync_deletes", false)
+	replicationConfig.SyncProperties = d.GetBool("sync_properties", false)
+	replicationConfig.SyncStatistics = d.GetBool("sync_statistics", false)
+	replicationConfig.PathPrefix = d.GetString("path_prefix", false)
 	replicationConfig.Proxy = handleResetWithNonExistantValue(d, "proxy")
-	replicationConfig.Password = d.getString("password", false)
+	replicationConfig.Password = d.GetString("password", false)
 
 	return replicationConfig
 }
 
 func packPushReplicationBody(config getReplicationBody, d *schema.ResourceData) diag.Diagnostics {
-	setValue := mkLens(d)
+	setValue := utils.MkLens(d)
 
 	setValue("repo_key", config.RepoKey)
 	setValue("cron_exp", config.CronExp)
@@ -82,7 +82,7 @@ func packPushReplicationBody(config getReplicationBody, d *schema.ResourceData) 
 }
 
 func packPullReplicationBody(config PullReplication, d *schema.ResourceData) diag.Diagnostics {
-	setValue := mkLens(d)
+	setValue := utils.MkLens(d)
 
 	setValue("repo_key", config.RepoKey)
 	setValue("cron_exp", config.CronExp)

--- a/pkg/artifactory/resource_artifactory_single_replication_config_test.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config_test.go
@@ -2,13 +2,14 @@ package artifactory
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"log"
 	"os"
 	"regexp"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func mkTclForRepConfg(name, cron, url, proxy string) string {
@@ -39,7 +40,7 @@ func mkTclForRepConfg(name, cron, url, proxy string) string {
 }
 func TestInvalidCronSingleReplication(t *testing.T) {
 
-	_, fqrn, name := mkNames("lib-local", "artifactory_single_replication_config")
+	_, fqrn, name := utils.MkNames("lib-local", "artifactory_single_replication_config")
 	var failCron = mkTclForRepConfg(name, "0 0 * * * !!", os.Getenv("ARTIFACTORY_URL"), "")
 
 	resource.Test(t, resource.TestCase{
@@ -57,7 +58,7 @@ func TestInvalidCronSingleReplication(t *testing.T) {
 
 func TestInvalidUrlSingleReplication(t *testing.T) {
 
-	_, fqrn, name := mkNames("lib-local", "artifactory_single_replication_config")
+	_, fqrn, name := utils.MkNames("lib-local", "artifactory_single_replication_config")
 	var failCron = mkTclForRepConfg(name, "0 0 * * * ?", "bad_url", "")
 
 	resource.Test(t, resource.TestCase{
@@ -75,7 +76,7 @@ func TestInvalidUrlSingleReplication(t *testing.T) {
 
 func TestAccSingleReplication_full(t *testing.T) {
 	const testProxy = "testProxy"
-	_, fqrn, name := mkNames("lib-local", "artifactory_single_replication_config")
+	_, fqrn, name := utils.MkNames("lib-local", "artifactory_single_replication_config")
 	config := mkTclForRepConfg(name, "0 0 * * * ?", os.Getenv("ARTIFACTORY_URL"), testProxy)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
@@ -104,7 +105,7 @@ func TestAccSingleReplication_full(t *testing.T) {
 }
 
 func TestAccSingleReplication_withDelRepo(t *testing.T) {
-	_, fqrn, name := mkNames("lib-local", "artifactory_single_replication_config")
+	_, fqrn, name := utils.MkNames("lib-local", "artifactory_single_replication_config")
 	config := mkTclForRepConfg(name, "0 0 * * * ?", os.Getenv("ARTIFACTORY_URL"), "")
 	var deleteRepo = func() {
 		restyClient := getTestResty(t)
@@ -142,8 +143,8 @@ func TestAccSingleReplication_withDelRepo(t *testing.T) {
 }
 
 func TestAccSingleReplicationRemoteRepo(t *testing.T) {
-	_, fqrn, name := mkNames("lib-remote", "artifactory_single_replication_config")
-	_, fqrepoName, repo_name := mkNames("lib-remote", "artifactory_remote_maven_repository")
+	_, fqrn, name := utils.MkNames("lib-remote", "artifactory_single_replication_config")
+	_, fqrepoName, repo_name := utils.MkNames("lib-remote", "artifactory_remote_maven_repository")
 	var tcl = `
 		resource "artifactory_remote_maven_repository" "{{ .remote_name }}" {
 			key 				  = "{{ .remote_name }}"
@@ -160,7 +161,7 @@ func TestAccSingleReplicationRemoteRepo(t *testing.T) {
 			depends_on = [artifactory_remote_maven_repository.{{ .remote_name }}]
 		}
 	`
-	tcl = executeTemplate("foo", tcl, map[string]string{
+	tcl = utils.ExecuteTemplate("foo", tcl, map[string]string{
 		"repoconfig_name": name,
 		"remote_name":     repo_name,
 		"username":        rtDefaultUser,

--- a/pkg/artifactory/resource_artifactory_single_replication_config_test.go
+++ b/pkg/artifactory/resource_artifactory_single_replication_config_test.go
@@ -46,7 +46,7 @@ func TestInvalidCronSingleReplication(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccCheckReplicationDestroy(fqrn),
 		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      failCron,
@@ -64,7 +64,7 @@ func TestInvalidUrlSingleReplication(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccCheckReplicationDestroy(fqrn),
 		PreCheck:          func() { testAccPreCheck(t) },
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config:      failCron,
@@ -80,13 +80,13 @@ func TestAccSingleReplication_full(t *testing.T) {
 	config := mkTclForRepConfg(name, "0 0 * * * ?", os.Getenv("ARTIFACTORY_URL"), testProxy)
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
-			createProxy(t, testProxy)
+			utils.CreateProxy(t, testProxy)
 		},
 		CheckDestroy: func() func(*terraform.State) error {
-			deleteProxy(t, testProxy)
+			utils.DeleteProxy(t, testProxy)
 			return testAccCheckReplicationDestroy(fqrn)
 		}(),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -108,7 +108,7 @@ func TestAccSingleReplication_withDelRepo(t *testing.T) {
 	_, fqrn, name := utils.MkNames("lib-local", "artifactory_single_replication_config")
 	config := mkTclForRepConfg(name, "0 0 * * * ?", os.Getenv("ARTIFACTORY_URL"), "")
 	var deleteRepo = func() {
-		restyClient := getTestResty(t)
+		restyClient := utils.GetTestResty(t)
 		_, err := restyClient.R().Delete("artifactory/api/repositories/" + name)
 		if err != nil {
 			t.Fatal(err)
@@ -117,7 +117,7 @@ func TestAccSingleReplication_withDelRepo(t *testing.T) {
 	}
 	resource.Test(t, resource.TestCase{
 		CheckDestroy:      testAccCheckReplicationDestroy(fqrn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 
 		Steps: []resource.TestStep{
 			{
@@ -166,13 +166,16 @@ func TestAccSingleReplicationRemoteRepo(t *testing.T) {
 		"remote_name":     repo_name,
 		"username":        rtDefaultUser,
 	})
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		CheckDestroy: compositeCheckDestroy(
-			verifyDeleted(fqrepoName, testCheckRepo),
+			utils.VerifyDeleted(fqrepoName, provider, utils.TestCheckRepo),
 			testAccCheckReplicationDestroy(fqrn),
 		),
 
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{

--- a/pkg/artifactory/resource_artifactory_user_test.go
+++ b/pkg/artifactory/resource_artifactory_user_test.go
@@ -46,7 +46,7 @@ func TestAccUserPasswordNotChangeWhenOtherAttributesChangeGH340(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckUserDestroy(fqrn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: userInitial,
@@ -85,7 +85,7 @@ func TestAccUser_basic(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckUserDestroy(fqrn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(userBasic, name, id, id),
@@ -119,7 +119,7 @@ func TestAccUserShouldCreateWithoutPassword(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckUserDestroy(fqrn),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(userBasic, name, id, id),
@@ -165,7 +165,7 @@ func TestAccUser_full(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckUserDestroy(FQRN),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(userFull, name, id, id),
@@ -208,7 +208,7 @@ func TestAccUser_NoGroups(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckUserDestroy(FQRN),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(userNoGroups, name, id, id),
@@ -233,7 +233,7 @@ func TestAccUser_EmptyGroups(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckUserDestroy(FQRN),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(Provider()),
 		Steps: []resource.TestStep{
 			{
 				Config: fmt.Sprintf(userEmptyGroups, name, id, id),
@@ -248,7 +248,8 @@ func TestAccUser_EmptyGroups(t *testing.T) {
 
 func testAccCheckUserDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		provider, _ := testAccProviders["artifactory"]()
+		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
+		utils.ConfigureProvider(provider)
 		client := provider.Meta().(*resty.Client)
 
 		rs, ok := s.RootModule().Resources[id]

--- a/pkg/artifactory/resource_artifactory_user_test.go
+++ b/pkg/artifactory/resource_artifactory_user_test.go
@@ -6,13 +6,13 @@ import (
 	"testing"
 
 	"github.com/go-resty/resty/v2"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccUserPasswordNotChangeWhenOtherAttributesChangeGH340(t *testing.T) {
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("user-%d", id)
 	fqrn := fmt.Sprintf("artifactory_user.%s", name)
 
@@ -24,7 +24,7 @@ func TestAccUserPasswordNotChangeWhenOtherAttributesChangeGH340(t *testing.T) {
 		"email":    email,
 		"password": password,
 	}
-	userInitial := executeTemplate("TestUser", `
+	userInitial := utils.ExecuteTemplate("TestUser", `
 		resource "artifactory_user" "{{ .name }}" {
 			name              = "{{ .name }}"
 			email             = "{{ .email }}"
@@ -33,7 +33,7 @@ func TestAccUserPasswordNotChangeWhenOtherAttributesChangeGH340(t *testing.T) {
 			disable_ui_access = false
 		}
 	`, params)
-	userUpdated := executeTemplate("TestUser", `
+	userUpdated := utils.ExecuteTemplate("TestUser", `
 		resource "artifactory_user" "{{ .name }}" {
 			name              = "{{ .name }}"
 			email             = "{{ .email }}"
@@ -79,7 +79,7 @@ func TestAccUser_basic(t *testing.T) {
 			groups  = [ "readers" ]
 		}
 	`
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("foobar-%d", id)
 	fqrn := fmt.Sprintf("artifactory_user.%s", name)
 	resource.Test(t, resource.TestCase{
@@ -113,7 +113,7 @@ func TestAccUserShouldCreateWithoutPassword(t *testing.T) {
 			groups  = [ "readers" ]
 		}
 	`
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("foobar-%d", id)
 	fqrn := fmt.Sprintf("artifactory_user.%s", name)
 	resource.Test(t, resource.TestCase{
@@ -161,7 +161,7 @@ func TestAccUser_full(t *testing.T) {
 			groups      		= [ "readers" ]
 		}
 	`
-	id, FQRN, name := mkNames("foobar-", "artifactory_user")
+	id, FQRN, name := utils.MkNames("foobar-", "artifactory_user")
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckUserDestroy(FQRN),
@@ -204,7 +204,7 @@ func TestAccUser_NoGroups(t *testing.T) {
 			email       		= "dummy%d@a.com"
 		}
 	`
-	id, FQRN, name := mkNames("foobar-", "artifactory_user")
+	id, FQRN, name := utils.MkNames("foobar-", "artifactory_user")
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckUserDestroy(FQRN),
@@ -229,7 +229,7 @@ func TestAccUser_EmptyGroups(t *testing.T) {
 			groups      		= []
 		}
 	`
-	id, FQRN, name := mkNames("foobar-", "artifactory_user")
+	id, FQRN, name := utils.MkNames("foobar-", "artifactory_user")
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
 		CheckDestroy:      testAccCheckUserDestroy(FQRN),

--- a/pkg/artifactory/resource_artifactory_user_test.go
+++ b/pkg/artifactory/resource_artifactory_user_test.go
@@ -249,7 +249,11 @@ func TestAccUser_EmptyGroups(t *testing.T) {
 func testAccCheckUserDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
 		provider, _ := utils.TestAccProviders(Provider())["artifactory"]()
-		utils.ConfigureProvider(provider)
+		provider, err := utils.ConfigureProvider(provider)
+		if err != nil {
+			return err
+		}
+
 		client := provider.Meta().(*resty.Client)
 
 		rs, ok := s.RootModule().Resources[id]

--- a/pkg/artifactory/resource_artifactory_virtual_alpine_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_alpine_repository.go
@@ -3,13 +3,14 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryAlpineVirtualRepository() *schema.Resource {
 
 	const packageType = "alpine"
 
-	var alpineVirtualSchema = mergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
+	var alpineVirtualSchema = utils.MergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
 		"primary_keypair_ref": {
 			Type:             schema.TypeString,
 			Optional:         true,
@@ -24,11 +25,11 @@ func resourceArtifactoryAlpineVirtualRepository() *schema.Resource {
 	}
 
 	var unpackAlpineVirtualRepository = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 
 		repo := AlpineVirtualRepositoryParams{
 			VirtualRepositoryBaseParamsWithRetrievalCachePeriodSecs: unpackBaseVirtRepoWithRetrievalCachePeriodSecs(s, packageType),
-			PrimaryKeyPairRef: d.getString("primary_keypair_ref", false),
+			PrimaryKeyPairRef: d.GetString("primary_keypair_ref", false),
 		}
 		repo.PackageType = packageType
 		return &repo, repo.Key, nil

--- a/pkg/artifactory/resource_artifactory_virtual_bower_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_bower_repository.go
@@ -3,13 +3,14 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryBowerVirtualRepository() *schema.Resource {
 
 	const packageType = "bower"
 
-	var bowerVirtualSchema = mergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
+	var bowerVirtualSchema = utils.MergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
 		"external_dependencies_enabled": {
 			Type:        schema.TypeBool,
 			Default:     false,
@@ -44,13 +45,13 @@ func resourceArtifactoryBowerVirtualRepository() *schema.Resource {
 	}
 
 	var unpackBowerVirtualRepository = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 
 		repo := BowerVirtualRepositoryParams{
 			VirtualRepositoryBaseParams:    unpackBaseVirtRepo(s, packageType),
-			ExternalDependenciesEnabled:    d.getBool("external_dependencies_enabled", false),
-			ExternalDependenciesRemoteRepo: d.getString("external_dependencies_remote_repo", false),
-			ExternalDependenciesPatterns:   d.getList("external_dependencies_patterns"),
+			ExternalDependenciesEnabled:    d.GetBool("external_dependencies_enabled", false),
+			ExternalDependenciesRemoteRepo: d.GetString("external_dependencies_remote_repo", false),
+			ExternalDependenciesPatterns:   d.GetList("external_dependencies_patterns"),
 		}
 		repo.PackageType = packageType
 		return &repo, repo.Key, nil

--- a/pkg/artifactory/resource_artifactory_virtual_debian_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_debian_repository.go
@@ -1,16 +1,18 @@
 package artifactory
 
 import (
+	"regexp"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"regexp"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryDebianVirtualRepository() *schema.Resource {
 
 	const packageType = "debian"
 
-	var debianVirtualSchema = mergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
+	var debianVirtualSchema = utils.MergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
 		"primary_keypair_ref": {
 			Type:             schema.TypeString,
 			Optional:         true,
@@ -39,7 +41,7 @@ func resourceArtifactoryDebianVirtualRepository() *schema.Resource {
 			Optional:         true,
 			Default:          "amd64,i386",
 			ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.StringIsNotEmpty, validation.StringMatch(regexp.MustCompile(`.+(?:,.+)*`), "must be comma separated string"))),
-			StateFunc:        formatCommaSeparatedString,
+			StateFunc:        utils.FormatCommaSeparatedString,
 			Description:      `(Optional) Specifying  architectures will speed up Artifactory's initial metadata indexing process. The default architecture values are amd64 and i386.`,
 		},
 	}, repoLayoutRefSchema("virtual", packageType))
@@ -53,14 +55,14 @@ func resourceArtifactoryDebianVirtualRepository() *schema.Resource {
 	}
 
 	var unpackDebianVirtualRepository = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 
 		repo := DebianVirtualRepositoryParams{
 			VirtualRepositoryBaseParamsWithRetrievalCachePeriodSecs: unpackBaseVirtRepoWithRetrievalCachePeriodSecs(s, packageType),
-			OptionalIndexCompressionFormats:                         d.getSet("optional_index_compression_formats"),
-			PrimaryKeyPairRef:                                       d.getString("primary_keypair_ref", false),
-			SecondaryKeyPairRef:                                     d.getString("secondary_keypair_ref", false),
-			DebianDefaultArchitectures:                              d.getString("debian_default_architectures", false),
+			OptionalIndexCompressionFormats:                         d.GetSet("optional_index_compression_formats"),
+			PrimaryKeyPairRef:                                       d.GetString("primary_keypair_ref", false),
+			SecondaryKeyPairRef:                                     d.GetString("secondary_keypair_ref", false),
+			DebianDefaultArchitectures:                              d.GetString("debian_default_architectures", false),
 		}
 		repo.PackageType = packageType
 		return &repo, repo.Key, nil

--- a/pkg/artifactory/resource_artifactory_virtual_generic_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_generic_repository.go
@@ -3,6 +3,7 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryVirtualGenericRepository(pkt string) *schema.Resource {
@@ -17,13 +18,13 @@ func resourceArtifactoryVirtualGenericRepository(pkt string) *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	genericSchema := mergeSchema(baseVirtualRepoSchema, repoLayoutRefSchema("virtual", pkt))
+	genericSchema := utils.MergeSchema(baseVirtualRepoSchema, repoLayoutRefSchema("virtual", pkt))
 
 	return mkResourceSchema(genericSchema, defaultPacker(genericSchema), unpack, constructor)
 }
 
 func resourceArtifactoryVirtualRepositoryWithRetrievalCachePeriodSecs(pkt string) *schema.Resource {
-	var repoWithRetrivalCachePeriodSecsVirtualSchema = mergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
+	var repoWithRetrivalCachePeriodSecsVirtualSchema = utils.MergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
 		"retrieval_cache_period_seconds": {
 			Type:         schema.TypeInt,
 			Optional:     true,

--- a/pkg/artifactory/resource_artifactory_virtual_go_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_go_repository.go
@@ -2,13 +2,14 @@ package artifactory
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryGoVirtualRepository() *schema.Resource {
 
 	const packageType = "go"
 
-	var goVirtualSchema = mergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
+	var goVirtualSchema = utils.MergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
 
 		"external_dependencies_enabled": {
 			Type:        schema.TypeBool,
@@ -37,12 +38,12 @@ func resourceArtifactoryGoVirtualRepository() *schema.Resource {
 	}
 
 	var unpackGoVirtualRepository = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 
 		repo := GoVirtualRepositoryParams{
 			VirtualRepositoryBaseParams:  unpackBaseVirtRepo(s, packageType),
-			ExternalDependenciesPatterns: d.getList("external_dependencies_patterns"),
-			ExternalDependenciesEnabled:  d.getBool("external_dependencies_enabled", false),
+			ExternalDependenciesPatterns: d.GetList("external_dependencies_patterns"),
+			ExternalDependenciesEnabled:  d.GetBool("external_dependencies_enabled", false),
 		}
 		repo.PackageType = "go"
 		return &repo, repo.Key, nil

--- a/pkg/artifactory/resource_artifactory_virtual_helm_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_helm_repository.go
@@ -2,13 +2,14 @@ package artifactory
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryHelmVirtualRepository() *schema.Resource {
 
 	const packageType = "helm"
 
-	helmVirtualSchema := mergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
+	helmVirtualSchema := utils.MergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
 		"use_namespaces": {
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -23,10 +24,10 @@ func resourceArtifactoryHelmVirtualRepository() *schema.Resource {
 	}
 
 	unpackHelmVirtualRepository := func(data *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{data}
+		d := &utils.ResourceData{data}
 		repo := HelmVirtualRepositoryParams{
 			VirtualRepositoryBaseParamsWithRetrievalCachePeriodSecs: unpackBaseVirtRepoWithRetrievalCachePeriodSecs(data, "helm"),
-			UseNamespaces: d.getBool("use_namespaces", false),
+			UseNamespaces: d.GetBool("use_namespaces", false),
 		}
 
 		return repo, repo.Id(), nil

--- a/pkg/artifactory/resource_artifactory_virtual_java_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_java_repository.go
@@ -3,6 +3,7 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type CommonJavaVirtualRepositoryParams struct {
@@ -18,7 +19,7 @@ type JavaVirtualRepositoryParams struct {
 
 func resourceArtifactoryJavaVirtualRepository(repoType string) *schema.Resource {
 
-	var mavenVirtualSchema = mergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
+	var mavenVirtualSchema = utils.MergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
 
 		"force_maven_authentication": {
 			Type:        schema.TypeBool,
@@ -45,14 +46,14 @@ func resourceArtifactoryJavaVirtualRepository(repoType string) *schema.Resource 
 	}, repoLayoutRefSchema("virtual", repoType))
 
 	var unpackMavenVirtualRepository = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 
 		repo := JavaVirtualRepositoryParams{
 			VirtualRepositoryBaseParams: unpackBaseVirtRepo(s, repoType),
 			CommonJavaVirtualRepositoryParams: CommonJavaVirtualRepositoryParams{
-				KeyPair:                              d.getString("key_pair", false),
-				ForceMavenAuthentication:             d.getBool("force_maven_authentication", false),
-				PomRepositoryReferencesCleanupPolicy: d.getString("pom_repository_references_cleanup_policy", false),
+				KeyPair:                              d.GetString("key_pair", false),
+				ForceMavenAuthentication:             d.GetBool("force_maven_authentication", false),
+				PomRepositoryReferencesCleanupPolicy: d.GetString("pom_repository_references_cleanup_policy", false),
 			},
 		}
 		repo.PackageType = repoType

--- a/pkg/artifactory/resource_artifactory_virtual_nuget_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_nuget_repository.go
@@ -2,13 +2,14 @@ package artifactory
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryNugetVirtualRepository() *schema.Resource {
 
 	const packageType = "nuget"
 
-	var nugetVirtualSchema = mergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
+	var nugetVirtualSchema = utils.MergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
 		"force_nuget_authentication": {
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -23,11 +24,11 @@ func resourceArtifactoryNugetVirtualRepository() *schema.Resource {
 	}
 
 	var unpackNugetVirtualRepository = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 
 		repo := NugetVirtualRepositoryParams{
 			VirtualRepositoryBaseParams: unpackBaseVirtRepo(s, packageType),
-			ForceNugetAuthentication:    d.getBool("force_nuget_authentication", false),
+			ForceNugetAuthentication:    d.GetBool("force_nuget_authentication", false),
 		}
 		repo.PackageType = packageType
 		return &repo, repo.Key, nil

--- a/pkg/artifactory/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_virtual_repository_test.go
@@ -23,10 +23,13 @@ func TestAccVirtualRepository_basic(t *testing.T) {
 			repositories = []
 		}
 	`
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -69,10 +72,13 @@ func TestAccVirtualRepository_reset_default_deployment_repo(t *testing.T) {
 			depends_on = [artifactory_local_maven_repository.%[1]s]
 		}
 	`
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -122,10 +128,12 @@ func TestAccVirtualGoRepository_basic(t *testing.T) {
 		}
 	`, name, name)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -160,10 +168,12 @@ func TestAccVirtualConanRepository_basic(t *testing.T) {
 		}
 	`, name, name)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -193,10 +203,12 @@ func TestAccVirtualGenericRepository_basic(t *testing.T) {
 		}
 	`, name, name)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -231,10 +243,12 @@ func TestAccVirtualMavenRepository_basic(t *testing.T) {
 		}
 	`, name, name)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -269,10 +283,12 @@ func TestAccVirtualHelmRepository_basic(t *testing.T) {
 		}
 	`, params)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -403,14 +419,16 @@ func TestAccVirtualRpmRepository(t *testing.T) {
 		"repo_name": name,
 	}) // we use randomness so that, in the case of failure and dangle, the next test can run without collision
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() { testAccPreCheck(t) },
 		CheckDestroy: compositeCheckDestroy(
-			verifyDeleted(fqrn, testCheckRepo),
-			verifyDeleted(kpFqrn, verifyKeyPair),
-			verifyDeleted(kpFqrn2, verifyKeyPair),
+			utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+			utils.VerifyDeleted(kpFqrn, provider, verifyKeyPair),
+			utils.VerifyDeleted(kpFqrn2, provider, verifyKeyPair),
 		),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: virtualRepositoryBasic,
@@ -444,10 +462,13 @@ func TestAccVirtualRepository_update(t *testing.T) {
 			repositories = []
 		}
 	`
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -489,10 +510,13 @@ func TestNugetPackageCreationFull(t *testing.T) {
 			force_nuget_authentication	= true
 		}
 	`
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -525,10 +549,13 @@ func TestAccVirtualRepository_full(t *testing.T) {
 			pom_repository_references_cleanup_policy = "discard_active_reference"
 		}
 	`
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -571,16 +598,18 @@ func TestAccVirtualGenericRepositoryWithProjectAttributesGH318(t *testing.T) {
 		}
 	`, params)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			createProject(t, projectKey)
+			utils.CreateProject(t, projectKey)
 		},
-		CheckDestroy: verifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
-			deleteProject(t, projectKey)
-			return testCheckRepo(id, request)
+		CheckDestroy: utils.VerifyDeleted(fqrn, provider, func(id string, request *resty.Request) (*resty.Response, error) {
+			utils.DeleteProject(t, projectKey)
+			return utils.TestCheckRepo(id, request)
 		}),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config: virtualRepositoryBasic,
@@ -614,16 +643,18 @@ func TestAccVirtualRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 		}
 	`, params)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			testAccPreCheck(t)
-			createProject(t, projectKey)
+			utils.CreateProject(t, projectKey)
 		},
-		CheckDestroy: verifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
-			deleteProject(t, projectKey)
-			return testCheckRepo(id, request)
+		CheckDestroy: utils.VerifyDeleted(fqrn, provider, func(id string, request *resty.Request) (*resty.Response, error) {
+			utils.DeleteProject(t, projectKey)
+			return utils.TestCheckRepo(id, request)
 		}),
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		Steps: []resource.TestStep{
 			{
 				Config:      virualRepositoryBasic,
@@ -672,7 +703,7 @@ func mkNewVirtualTestCase(repoType string, t *testing.T, extraFields map[string]
 		"notes":       "Internal description",
 	}
 	allFields := utils.MergeMaps(defaultFields, extraFields)
-	allFieldsHcl := fmtMapToHcl(allFields)
+	allFieldsHcl := utils.FmtMapToHcl(allFields)
 	const virtualRepoFull = `
         resource "artifactory_remote_%[1]s_repository" "%[3]s" {
 			key = "%[3]s"
@@ -685,16 +716,18 @@ func mkNewVirtualTestCase(repoType string, t *testing.T, extraFields map[string]
             depends_on = [artifactory_remote_%[1]s_repository.%[3]s]
 		}
 	`
-	extraChecks := mapToTestChecks(fqrn, extraFields)
-	defaultChecks := mapToTestChecks(fqrn, allFields)
+	extraChecks := utils.MapToTestChecks(fqrn, extraFields)
+	defaultChecks := utils.MapToTestChecks(fqrn, allFields)
 
 	checks := append(defaultChecks, extraChecks...)
 	config := fmt.Sprintf(virtualRepoFull, repoType, name, remoteRepoName, allFieldsHcl)
 
+	provider := Provider()
+
 	return t, resource.TestCase{
-		ProviderFactories: testAccProviders,
+		ProviderFactories: utils.TestAccProviders(provider),
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
 		Steps: []resource.TestStep{
 			{
 				Config: config,
@@ -739,10 +772,13 @@ func TestAccVirtualDebianRepository_full(t *testing.T) {
             ]
 		}
 	`
+
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{

--- a/pkg/artifactory/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource_artifactory_virtual_repository_test.go
@@ -10,10 +10,11 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func TestAccVirtualRepository_basic(t *testing.T) {
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("foo%d", id)
 	fqrn := fmt.Sprintf("artifactory_virtual_maven_repository.%s", name)
 	const virtualRepositoryBasic = `
@@ -41,7 +42,7 @@ func TestAccVirtualRepository_basic(t *testing.T) {
 }
 
 func TestAccVirtualRepository_reset_default_deployment_repo(t *testing.T) {
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("foo%d", id)
 	localRepoName := fmt.Sprintf("%s-local", name)
 	fqrn := fmt.Sprintf("artifactory_virtual_maven_repository.%s", name)
@@ -103,7 +104,7 @@ func TestAccVirtualRepository_reset_default_deployment_repo(t *testing.T) {
 }
 
 func TestAccVirtualGoRepository_basic(t *testing.T) {
-	_, fqrn, name := mkNames("foo", "artifactory_virtual_go_repository")
+	_, fqrn, name := utils.MkNames("foo", "artifactory_virtual_go_repository")
 	const packageType = "go"
 	var virtualRepositoryBasic = fmt.Sprintf(`
 		resource "artifactory_virtual_go_repository" "%s" {
@@ -145,7 +146,7 @@ func TestAccVirtualGoRepository_basic(t *testing.T) {
 }
 
 func TestAccVirtualConanRepository_basic(t *testing.T) {
-	_, fqrn, name := mkNames("foo", "artifactory_virtual_conan_repository")
+	_, fqrn, name := utils.MkNames("foo", "artifactory_virtual_conan_repository")
 	var virtualRepositoryBasic = fmt.Sprintf(`
 		resource "artifactory_virtual_conan_repository" "%s" {
 		  key          = "%s"
@@ -179,7 +180,7 @@ func TestAccVirtualConanRepository_basic(t *testing.T) {
 }
 
 func TestAccVirtualGenericRepository_basic(t *testing.T) {
-	_, fqrn, name := mkNames("foo", "artifactory_virtual_generic_repository")
+	_, fqrn, name := utils.MkNames("foo", "artifactory_virtual_generic_repository")
 	const packageType = "generic"
 	var virtualRepositoryBasic = fmt.Sprintf(`
 		resource "artifactory_virtual_generic_repository" "%s" {
@@ -214,7 +215,7 @@ func TestAccVirtualGenericRepository_basic(t *testing.T) {
 func TestAccVirtualMavenRepository_basic(t *testing.T) {
 	const packageType = "maven"
 
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("foo%d", id)
 	fqrn := fmt.Sprintf("artifactory_virtual_maven_repository.%s", name)
 	var virtualRepositoryBasic = fmt.Sprintf(`
@@ -254,14 +255,14 @@ func TestAccVirtualMavenRepository_basic(t *testing.T) {
 }
 
 func TestAccVirtualHelmRepository_basic(t *testing.T) {
-	_, fqrn, name := mkNames("virtual-helm-repo", "artifactory_virtual_helm_repository")
-	useNamespaces := randBool()
+	_, fqrn, name := utils.MkNames("virtual-helm-repo", "artifactory_virtual_helm_repository")
+	useNamespaces := utils.RandBool()
 
 	params := map[string]interface{}{
 		"name":          name,
 		"useNamespaces": useNamespaces,
 	}
-	virtualRepositoryBasic := executeTemplate("TestAccVirtualHelmRepository", `
+	virtualRepositoryBasic := utils.ExecuteTemplate("TestAccVirtualHelmRepository", `
 		resource "artifactory_virtual_helm_repository" "{{ .name }}" {
 		  key            = "{{ .name }}"
 	 	  use_namespaces = {{ .useNamespaces }}
@@ -288,10 +289,10 @@ func TestAccVirtualHelmRepository_basic(t *testing.T) {
 
 func TestAccVirtualRpmRepository(t *testing.T) {
 	const packageType = "rpm"
-	_, fqrn, name := mkNames("virtual-rpm-repo", "artifactory_virtual_rpm_repository")
-	kpId, kpFqrn, kpName := mkNames("some-keypair1-", "artifactory_keypair")
-	kpId2, kpFqrn2, kpName2 := mkNames("some-keypair2-", "artifactory_keypair")
-	virtualRepositoryBasic := executeTemplate("keypair", `
+	_, fqrn, name := utils.MkNames("virtual-rpm-repo", "artifactory_virtual_rpm_repository")
+	kpId, kpFqrn, kpName := utils.MkNames("some-keypair1-", "artifactory_keypair")
+	kpId2, kpFqrn2, kpName2 := utils.MkNames("some-keypair2-", "artifactory_keypair")
+	virtualRepositoryBasic := utils.ExecuteTemplate("keypair", `
 		resource "artifactory_keypair" "{{ .kp_name }}" {
 			pair_name  = "{{ .kp_name }}"
 			pair_type = "GPG"
@@ -426,7 +427,7 @@ func TestAccVirtualRpmRepository(t *testing.T) {
 }
 
 func TestAccVirtualRepository_update(t *testing.T) {
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("foo%d", id)
 	fqrn := fmt.Sprintf("artifactory_virtual_maven_repository.%s", name)
 	const virtualRepositoryUpdateBefore = `
@@ -472,7 +473,7 @@ func TestAccVirtualRepository_update(t *testing.T) {
 }
 
 func TestNugetPackageCreationFull(t *testing.T) {
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("foo%d", id)
 	fqrn := fmt.Sprintf("artifactory_virtual_nuget_repository.%s", name)
 	const virtualRepositoryFull = `
@@ -508,7 +509,7 @@ func TestNugetPackageCreationFull(t *testing.T) {
 
 }
 func TestAccVirtualRepository_full(t *testing.T) {
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("foo%d", id)
 	fqrn := fmt.Sprintf("artifactory_virtual_maven_repository.%s", name)
 	const virtualRepositoryFull = `
@@ -551,18 +552,18 @@ func TestAccVirtualRepository_full(t *testing.T) {
 func TestAccVirtualGenericRepositoryWithProjectAttributesGH318(t *testing.T) {
 
 	rand.Seed(time.Now().UnixNano())
-	projectKey := fmt.Sprintf("t%d", randomInt())
-	projectEnv := randSelect("DEV", "PROD").(string)
+	projectKey := fmt.Sprintf("t%d", utils.RandomInt())
+	projectEnv := utils.RandSelect("DEV", "PROD").(string)
 	repoName := fmt.Sprintf("%s-generic-virtual", projectKey)
 
-	_, fqrn, name := mkNames(repoName, "artifactory_virtual_generic_repository")
+	_, fqrn, name := utils.MkNames(repoName, "artifactory_virtual_generic_repository")
 
 	params := map[string]interface{}{
 		"name":       name,
 		"projectKey": projectKey,
 		"projectEnv": projectEnv,
 	}
-	virtualRepositoryBasic := executeTemplate("TestAccVirtualGenericRepository", `
+	virtualRepositoryBasic := utils.ExecuteTemplate("TestAccVirtualGenericRepository", `
 		resource "artifactory_virtual_generic_repository" "{{ .name }}" {
 		  key                  = "{{ .name }}"
 	 	  project_key          = "{{ .projectKey }}"
@@ -597,16 +598,16 @@ func TestAccVirtualGenericRepositoryWithProjectAttributesGH318(t *testing.T) {
 func TestAccVirtualRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 
 	rand.Seed(time.Now().UnixNano())
-	projectKey := fmt.Sprintf("t%d", randomInt())
+	projectKey := fmt.Sprintf("t%d", utils.RandomInt())
 	repoName := fmt.Sprintf("%s-generic-virtual", projectKey)
 
-	_, fqrn, name := mkNames(repoName, "artifactory_virtual_generic_repository")
+	_, fqrn, name := utils.MkNames(repoName, "artifactory_virtual_generic_repository")
 
 	params := map[string]interface{}{
 		"name":       name,
 		"projectKey": projectKey,
 	}
-	virualRepositoryBasic := executeTemplate("TestAccVirtualGenericRepository", `
+	virualRepositoryBasic := utils.ExecuteTemplate("TestAccVirtualGenericRepository", `
 		resource "artifactory_virtual_generic_repository" "{{ .name }}" {
 		  key                  = "{{ .name }}"
 	 	  project_key          = "invalid-project-key"
@@ -663,14 +664,14 @@ func TestAccAllVirtualGradleLikeRepository(t *testing.T) {
 
 // if you wish to override any of the default fields, just pass it as "extraFields" as these will overwrite
 func mkNewVirtualTestCase(repoType string, t *testing.T, extraFields map[string]interface{}) (*testing.T, resource.TestCase) {
-	_, fqrn, name := mkNames("terraform-virtual-test-repo-full", fmt.Sprintf("artifactory_virtual_%s_repository", repoType))
+	_, fqrn, name := utils.MkNames("terraform-virtual-test-repo-full", fmt.Sprintf("artifactory_virtual_%s_repository", repoType))
 	remoteRepoName := fmt.Sprintf("%s-local", name)
 	defaultFields := map[string]interface{}{
 		"key":         name,
 		"description": "A test virtual repo",
 		"notes":       "Internal description",
 	}
-	allFields := mergeMaps(defaultFields, extraFields)
+	allFields := utils.MergeMaps(defaultFields, extraFields)
 	allFieldsHcl := fmtMapToHcl(allFields)
 	const virtualRepoFull = `
         resource "artifactory_remote_%[1]s_repository" "%[3]s" {
@@ -724,7 +725,7 @@ func TestAccVirtualBowerRepository(t *testing.T) {
 }
 
 func TestAccVirtualDebianRepository_full(t *testing.T) {
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("foo%d", id)
 	fqrn := fmt.Sprintf("artifactory_virtual_debian_repository.%s", name)
 	const virtualRepositoryBasic = `

--- a/pkg/artifactory/resource_artifactory_virtual_rpm_repository.go
+++ b/pkg/artifactory/resource_artifactory_virtual_rpm_repository.go
@@ -3,13 +3,14 @@ package artifactory
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 func resourceArtifactoryRpmVirtualRepository() *schema.Resource {
 
 	const packageType = "rpm"
 
-	var rpmVirtualSchema = mergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
+	var rpmVirtualSchema = utils.MergeSchema(baseVirtualRepoSchema, map[string]*schema.Schema{
 		"primary_keypair_ref": {
 			Type:             schema.TypeString,
 			Optional:         true,
@@ -35,13 +36,13 @@ func resourceArtifactoryRpmVirtualRepository() *schema.Resource {
 	}
 
 	var unpackRpmVirtualRepository = func(s *schema.ResourceData) (interface{}, string, error) {
-		d := &ResourceData{s}
+		d := &utils.ResourceData{s}
 
 		repo := RpmVirtualRepositoryParams{
 			VirtualRepositoryBaseParams: unpackBaseVirtRepo(s, "rpm"),
 			CommonRpmDebianVirtualRepositoryParams: CommonRpmDebianVirtualRepositoryParams{
-				PrimaryKeyPairRef:   d.getString("primary_keypair_ref", false),
-				SecondaryKeyPairRef: d.getString("secondary_keypair_ref", false),
+				PrimaryKeyPairRef:   d.GetString("primary_keypair_ref", false),
+				SecondaryKeyPairRef: d.GetString("secondary_keypair_ref", false),
 			},
 		}
 		repo.PackageType = "rpm"

--- a/pkg/artifactory/resource_artifactory_webhook_build.go
+++ b/pkg/artifactory/resource_artifactory_webhook_build.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type BuildWebhookCriteria struct {
@@ -14,13 +15,13 @@ type BuildWebhookCriteria struct {
 }
 
 var buildWebhookSchema = func(webhookType string) map[string]*schema.Schema {
-	return mergeSchema(baseWebhookBaseSchema(webhookType), map[string]*schema.Schema{
+	return utils.MergeSchema(baseWebhookBaseSchema(webhookType), map[string]*schema.Schema{
 		"criteria": {
 			Type:     schema.TypeSet,
 			Required: true,
 			MaxItems: 1,
 			Elem: &schema.Resource{
-				Schema: mergeSchema(baseCriteriaSchema, map[string]*schema.Schema{
+				Schema: utils.MergeSchema(baseCriteriaSchema, map[string]*schema.Schema{
 					"any_build": {
 						Type:        schema.TypeBool,
 						Required:    true,
@@ -49,7 +50,7 @@ var packBuildCriteria = func(artifactoryCriteria map[string]interface{}) map[str
 var unpackBuildCriteria = func(terraformCriteria map[string]interface{}, baseCriteria BaseWebhookCriteria) interface{} {
 	return BuildWebhookCriteria{
 		AnyBuild:            terraformCriteria["any_build"].(bool),
-		SelectedBuilds:      castToStringArr(terraformCriteria["selected_builds"].(*schema.Set).List()),
+		SelectedBuilds:      utils.CastToStringArr(terraformCriteria["selected_builds"].(*schema.Set).List()),
 		BaseWebhookCriteria: baseCriteria,
 	}
 }

--- a/pkg/artifactory/resource_artifactory_webhook_release_bundle.go
+++ b/pkg/artifactory/resource_artifactory_webhook_release_bundle.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type ReleaseBundleWebhookCriteria struct {
@@ -14,13 +15,13 @@ type ReleaseBundleWebhookCriteria struct {
 }
 
 var releaseBundleWebhookSchema = func(webhookType string) map[string]*schema.Schema {
-	return mergeSchema(baseWebhookBaseSchema(webhookType), map[string]*schema.Schema{
+	return utils.MergeSchema(baseWebhookBaseSchema(webhookType), map[string]*schema.Schema{
 		"criteria": {
 			Type:     schema.TypeSet,
 			Required: true,
 			MaxItems: 1,
 			Elem: &schema.Resource{
-				Schema: mergeSchema(baseCriteriaSchema, map[string]*schema.Schema{
+				Schema: utils.MergeSchema(baseCriteriaSchema, map[string]*schema.Schema{
 					"any_release_bundle": {
 						Type:        schema.TypeBool,
 						Required:    true,
@@ -49,7 +50,7 @@ var packReleaseBundleCriteria = func(artifactoryCriteria map[string]interface{})
 var unpackReleaseBundleCriteria = func(terraformCriteria map[string]interface{}, baseCriteria BaseWebhookCriteria) interface{} {
 	return ReleaseBundleWebhookCriteria{
 		AnyReleaseBundle:              terraformCriteria["any_release_bundle"].(bool),
-		RegisteredReleaseBundlesNames: castToStringArr(terraformCriteria["registered_release_bundle_names"].(*schema.Set).List()),
+		RegisteredReleaseBundlesNames: utils.CastToStringArr(terraformCriteria["registered_release_bundle_names"].(*schema.Set).List()),
 		BaseWebhookCriteria:           baseCriteria,
 	}
 }

--- a/pkg/artifactory/resource_artifactory_webhook_repo.go
+++ b/pkg/artifactory/resource_artifactory_webhook_repo.go
@@ -5,6 +5,7 @@ import (
 	"log"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type RepoWebhookCriteria struct {
@@ -15,13 +16,13 @@ type RepoWebhookCriteria struct {
 }
 
 var repoWebhookSchema = func(webhookType string) map[string]*schema.Schema {
-	return mergeSchema(baseWebhookBaseSchema(webhookType), map[string]*schema.Schema{
+	return utils.MergeSchema(baseWebhookBaseSchema(webhookType), map[string]*schema.Schema{
 		"criteria": {
 			Type:     schema.TypeSet,
 			Required: true,
 			MaxItems: 1,
 			Elem: &schema.Resource{
-				Schema: mergeSchema(baseCriteriaSchema, map[string]*schema.Schema{
+				Schema: utils.MergeSchema(baseCriteriaSchema, map[string]*schema.Schema{
 					"any_local": {
 						Type:        schema.TypeBool,
 						Required:    true,
@@ -57,7 +58,7 @@ var unpackRepoCriteria = func(terraformCriteria map[string]interface{}, baseCrit
 	return RepoWebhookCriteria{
 		AnyLocal:            terraformCriteria["any_local"].(bool),
 		AnyRemote:           terraformCriteria["any_remote"].(bool),
-		RepoKeys:            castToStringArr(terraformCriteria["repo_keys"].(*schema.Set).List()),
+		RepoKeys:            utils.CastToStringArr(terraformCriteria["repo_keys"].(*schema.Set).List()),
 		BaseWebhookCriteria: baseCriteria,
 	}
 }

--- a/pkg/artifactory/resource_artifactory_webhook_test.go
+++ b/pkg/artifactory/resource_artifactory_webhook_test.go
@@ -97,10 +97,12 @@ func webhookCriteriaValidationTestCase(webhookType string, t *testing.T) (*testi
 	}
 	webhookConfig := utils.ExecuteTemplate("TestAccWebhookCriteriaValidation", template, params)
 
+	provider := Provider()
+
 	return t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -136,10 +138,12 @@ func TestAccWebhookEventTypesValidation(t *testing.T) {
 		}
 	`, params)
 
+	provider := Provider()
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckRepo),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, utils.TestCheckRepo),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -229,10 +233,12 @@ func webhookTestCase(webhookType string, t *testing.T) (*testing.T, resource.Tes
 		testChecks = append(testChecks, eventTypeCheck)
 	}
 
+	provider := Provider()
+
 	return t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
-		CheckDestroy:      verifyDeleted(fqrn, testCheckWebhook),
-		ProviderFactories: testAccProviders,
+		CheckDestroy:      utils.VerifyDeleted(fqrn, provider, testCheckWebhook),
+		ProviderFactories: utils.TestAccProviders(provider),
 
 		Steps: []resource.TestStep{
 			{
@@ -246,6 +252,6 @@ func webhookTestCase(webhookType string, t *testing.T) (*testing.T, resource.Tes
 func testCheckWebhook(id string, request *resty.Request) (*resty.Response, error) {
 	return request.
 		SetPathParam("webhookKey", id).
-		AddRetryCondition(neverRetry).
+		AddRetryCondition(utils.NeverRetry).
 		Get(webhookUrl)
 }

--- a/pkg/artifactory/resource_artifactory_webhook_test.go
+++ b/pkg/artifactory/resource_artifactory_webhook_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 var domainRepoTypeLookup = map[string]string{
@@ -75,7 +76,7 @@ func TestAccWebhookCriteriaValidation(t *testing.T) {
 }
 
 func webhookCriteriaValidationTestCase(webhookType string, t *testing.T) (*testing.T, resource.TestCase) {
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("webhook-%d", id)
 	fqrn := fmt.Sprintf("artifactory_%s_webhook.%s", webhookType, name)
 
@@ -94,7 +95,7 @@ func webhookCriteriaValidationTestCase(webhookType string, t *testing.T) (*testi
 		"webhookName": name,
 		"eventTypes":  domainEventTypesSupported[webhookType],
 	}
-	webhookConfig := executeTemplate("TestAccWebhookCriteriaValidation", template, params)
+	webhookConfig := utils.ExecuteTemplate("TestAccWebhookCriteriaValidation", template, params)
 
 	return t, resource.TestCase{
 		PreCheck:          func() { testAccPreCheck(t) },
@@ -111,7 +112,7 @@ func webhookCriteriaValidationTestCase(webhookType string, t *testing.T) (*testi
 }
 
 func TestAccWebhookEventTypesValidation(t *testing.T) {
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("webhook-%d", id)
 	fqrn := fmt.Sprintf("artifactory_artifact_webhook.%s", name)
 
@@ -121,7 +122,7 @@ func TestAccWebhookEventTypesValidation(t *testing.T) {
 		"webhookName": name,
 		"eventType":   wrongEventType,
 	}
-	webhookConfig := executeTemplate("TestAccWebhookEventTypesValidation", `
+	webhookConfig := utils.ExecuteTemplate("TestAccWebhookEventTypesValidation", `
 		resource "artifactory_artifact_webhook" "{{ .webhookName }}" {
 			key         = "{{ .webhookName }}"
 			description = "test description"
@@ -160,7 +161,7 @@ func TestAccWebhookAllTypes(t *testing.T) {
 }
 
 func webhookTestCase(webhookType string, t *testing.T) (*testing.T, resource.TestCase) {
-	id := randomInt()
+	id := utils.RandomInt()
 	name := fmt.Sprintf("webhook-%d", id)
 	fqrn := fmt.Sprintf("artifactory_%s_webhook.%s", webhookType, name)
 
@@ -174,10 +175,10 @@ func webhookTestCase(webhookType string, t *testing.T) (*testing.T, resource.Tes
 		"webhookType": webhookType,
 		"webhookName": name,
 		"eventTypes":  eventTypes,
-		"anyLocal":    randBool(),
-		"anyRemote":   randBool(),
+		"anyLocal":    utils.RandBool(),
+		"anyRemote":   utils.RandBool(),
 	}
-	webhookConfig := executeTemplate("TestAccWebhook{{ .webhookType }}Type", `
+	webhookConfig := utils.ExecuteTemplate("TestAccWebhook{{ .webhookType }}Type", `
 		resource "artifactory_local_{{ .repoType }}_repository" "{{ .repoName }}" {
 			key = "{{ .repoName }}"
 		}

--- a/pkg/artifactory/user.go
+++ b/pkg/artifactory/user.go
@@ -79,22 +79,22 @@ var baseUserSchema = map[string]*schema.Schema{
 }
 
 func unpackUser(s *schema.ResourceData) User {
-	d := &ResourceData{s}
+	d := &utils.ResourceData{s}
 	return User{
-		Name:                     d.getString("name", false),
-		Email:                    d.getString("email", false),
-		Password:                 d.getString("password", false),
-		Admin:                    d.getBool("admin", false),
-		ProfileUpdatable:         d.getBool("profile_updatable", false),
-		DisableUIAccess:          d.getBool("disable_ui_access", false),
-		InternalPasswordDisabled: d.getBool("internal_password_disabled", false),
-		Groups:                   d.getSet("groups"),
+		Name:                     d.GetString("name", false),
+		Email:                    d.GetString("email", false),
+		Password:                 d.GetString("password", false),
+		Admin:                    d.GetBool("admin", false),
+		ProfileUpdatable:         d.GetBool("profile_updatable", false),
+		DisableUIAccess:          d.GetBool("disable_ui_access", false),
+		InternalPasswordDisabled: d.GetBool("internal_password_disabled", false),
+		Groups:                   d.GetSet("groups"),
 	}
 }
 
 func packUser(user User, d *schema.ResourceData) diag.Diagnostics {
 
-	setValue := mkLens(d)
+	setValue := utils.MkLens(d)
 
 	setValue("name", user.Name)
 	setValue("email", user.Email)
@@ -104,7 +104,7 @@ func packUser(user User, d *schema.ResourceData) diag.Diagnostics {
 	errors := setValue("internal_password_disabled", user.InternalPasswordDisabled)
 
 	if user.Groups != nil {
-		errors = setValue("groups", schema.NewSet(schema.HashString, castToInterfaceArr(user.Groups)))
+		errors = setValue("groups", schema.NewSet(schema.HashString, utils.CastToInterfaceArr(user.Groups)))
 	}
 
 	if errors != nil && len(errors) > 0 {
@@ -117,7 +117,7 @@ func packUser(user User, d *schema.ResourceData) diag.Diagnostics {
 const usersEndpointPath = "artifactory/api/security/users/"
 
 func resourceUserRead(ctx context.Context, rd *schema.ResourceData, m interface{}) diag.Diagnostics {
-	d := &ResourceData{rd}
+	d := &utils.ResourceData{rd}
 
 	userName := d.Id()
 	user := &User{}
@@ -197,8 +197,8 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface
 }
 
 func resourceUserDelete(ctx context.Context, rd *schema.ResourceData, m interface{}) diag.Diagnostics {
-	d := &ResourceData{rd}
-	userName := d.getString("name", false)
+	d := &utils.ResourceData{rd}
+	userName := d.GetString("name", false)
 
 	_, err := m.(*resty.Client).R().Delete(usersEndpointPath + userName)
 	if err != nil {
@@ -211,7 +211,7 @@ func resourceUserDelete(ctx context.Context, rd *schema.ResourceData, m interfac
 }
 
 func resourceUserExists(data *schema.ResourceData, m interface{}) (bool, error) {
-	d := &ResourceData{data}
+	d := &utils.ResourceData{data}
 	name := d.Id()
 
 	resp, err := m.(*resty.Client).R().Head(usersEndpointPath + name)

--- a/pkg/artifactory/user.go
+++ b/pkg/artifactory/user.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
 )
 
 type User struct {
@@ -36,7 +37,7 @@ var baseUserSchema = map[string]*schema.Schema{
 	"email": {
 		Type:             schema.TypeString,
 		Required:         true,
-		ValidateDiagFunc: validation.ToDiagFunc(validateIsEmail),
+		ValidateDiagFunc: validation.ToDiagFunc(utils.ValidateIsEmail),
 		Description:      "(Required) Email for user.",
 	},
 	"admin": {

--- a/pkg/artifactory/util.go
+++ b/pkg/artifactory/util.go
@@ -2,8 +2,6 @@ package artifactory
 
 import (
 	"bytes"
-	"crypto/sha256"
-	"encoding/hex"
 	"fmt"
 	"math/rand"
 	"sort"
@@ -17,12 +15,6 @@ import (
 
 type ResourceData struct{ *schema.ResourceData }
 
-func (d *ResourceData) getStringRef(key string, onlyIfChanged bool) *string {
-	if v, ok := d.GetOk(key); ok && (!onlyIfChanged || d.HasChange(key)) {
-		return StringPtr(v.(string))
-	}
-	return nil
-}
 func (d *ResourceData) getString(key string, onlyIfChanged bool) string {
 	if v, ok := d.GetOk(key); ok && (!onlyIfChanged || d.HasChange(key)) {
 		return v.(string)
@@ -44,13 +36,6 @@ func (d *ResourceData) getBool(key string, onlyIfChanged bool) bool {
 	return false
 }
 
-func (d *ResourceData) getIntRef(key string, onlyIfChanged bool) *int {
-	if v, ok := d.GetOkExists(key); ok && (!onlyIfChanged || d.HasChange(key)) {
-		return IntPtr(v.(int))
-	}
-	return nil
-}
-
 func (d *ResourceData) getInt(key string, onlyIfChanged bool) int {
 	if v, ok := d.GetOkExists(key); ok && (!onlyIfChanged || d.HasChange(key)) {
 		return v.(int)
@@ -58,13 +43,6 @@ func (d *ResourceData) getInt(key string, onlyIfChanged bool) int {
 	return 0
 }
 
-func (d *ResourceData) getSetRef(key string) *[]string {
-	if v, ok := d.GetOkExists(key); ok {
-		arr := castToStringArr(v.(*schema.Set).List())
-		return &arr
-	}
-	return new([]string)
-}
 func (d *ResourceData) getSet(key string) []string {
 	if v, ok := d.GetOkExists(key); ok {
 		arr := castToStringArr(v.(*schema.Set).List())
@@ -78,13 +56,6 @@ func (d *ResourceData) getList(key string) []string {
 		return arr
 	}
 	return []string{}
-}
-func (d *ResourceData) getListRef(key string) *[]string {
-	if v, ok := d.GetOkExists(key); ok {
-		arr := castToStringArr(v.([]interface{}))
-		return &arr
-	}
-	return new([]string)
 }
 
 func castToStringArr(arr []interface{}) []string {
@@ -103,17 +74,6 @@ func castToInterfaceArr(arr []string) []interface{} {
 	}
 
 	return cpy
-}
-
-func getMD5Hash(o interface{}) string {
-	if len(o.(string)) == 0 { // Don't hash empty strings
-		return ""
-	}
-
-	hasher := sha256.New()
-	hasher.Write([]byte(o.(string)))
-	hasher.Write([]byte("OQ9@#9i4$c8g$4^n%PKT8hUva3CC^5"))
-	return hex.EncodeToString(hasher.Sum(nil))
 }
 
 func randomInt() int {
@@ -204,12 +164,6 @@ func sendConfigurationPatch(content []byte, m interface{}) error {
 }
 
 func BoolPtr(v bool) *bool { return &v }
-
-func IntPtr(v int) *int { return &v }
-
-func Int64Ptr(v int64) *int64 { return &v }
-
-func StringPtr(v string) *string { return &v }
 
 func formatCommaSeparatedString(thing interface{}) string {
 	fields := strings.Fields(thing.(string))

--- a/pkg/artifactory/util_test.go
+++ b/pkg/artifactory/util_test.go
@@ -2,7 +2,6 @@ package artifactory
 
 import (
 	"fmt"
-	"gopkg.in/yaml.v2"
 	"math"
 	"net/http"
 	"reflect"
@@ -12,6 +11,8 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/utils"
+	"gopkg.in/yaml.v2"
 )
 
 func fmtMapToHcl(fields map[string]interface{}) string {
@@ -194,7 +195,7 @@ func testAccDeleteRepo(t *testing.T, repo string) {
 
 //Usage of the function is strictly restricted to Test Cases
 func getValidRandomDefaultRepoLayoutRef() string {
-	return randSelect("simple-default", "bower-default", "composer-default", "conan-default", "go-default", "maven-2-default", "ivy-default", "npm-default", "nuget-default", "puppet-default", "sbt-default").(string)
+	return utils.RandSelect("simple-default", "bower-default", "composer-default", "conan-default", "go-default", "maven-2-default", "ivy-default", "npm-default", "nuget-default", "puppet-default", "sbt-default").(string)
 }
 
 // updateProxiesConfig is used by createProxy and deleteProxy to interact with a proxy on Artifactory
@@ -202,7 +203,7 @@ var updateProxiesConfig = func(t *testing.T, proxyKey string, getProxiesBody fun
 	body := getProxiesBody()
 	restyClient := getTestResty(t)
 
-	err := sendConfigurationPatch(body, restyClient)
+	err := utils.SendConfigurationPatch(body, restyClient)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/utils/test.go
+++ b/pkg/utils/test.go
@@ -133,14 +133,14 @@ var TestAccProviders = func(provider *schema.Provider) map[string]func() (*schem
 	}
 }
 
-var ConfigureProvider = func(provider *schema.Provider) error {
+func ConfigureProvider(provider *schema.Provider) (*schema.Provider, error) {
 	ctx := context.Background()
 	configErr := provider.Configure(ctx, terraform.NewResourceConfigRaw(nil))
 	if configErr != nil {
-		return fmt.Errorf("error: Failed to configure provider %v", configErr)
+		return nil, fmt.Errorf("error: Failed to configure provider %v", configErr)
 	}
 
-	return nil
+	return provider, nil
 }
 
 func VerifyDeleted(id string, provider *schema.Provider, check CheckFun) func(*terraform.State) error {

--- a/pkg/utils/test.go
+++ b/pkg/utils/test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -8,6 +9,7 @@ import (
 	"os"
 	"reflect"
 	"strings"
+	"text/template"
 	"testing"
 
 	"github.com/go-resty/resty/v2"
@@ -87,6 +89,38 @@ func toHclFormat(thing interface{}) string {
 	default:
 		return fmt.Sprintf("%v", thing)
 	}
+}
+
+func ExecuteTemplate(name, temp string, fields interface{}) string {
+	var tpl bytes.Buffer
+	if err := template.Must(template.New(name).Parse(temp)).Execute(&tpl, fields); err != nil {
+		panic(err)
+	}
+
+	return tpl.String()
+}
+
+func MergeMaps(schemata ...map[string]interface{}) map[string]interface{} {
+	result := map[string]interface{}{}
+	for _, schma := range schemata {
+		for k, v := range schma {
+			result[k] = v
+		}
+	}
+	return result
+}
+
+func CopyInterfaceMap(source map[string]interface{}, target map[string]interface{}) map[string]interface{} {
+	for k, v := range source {
+		target[k] = v
+	}
+	return target
+}
+
+func MkNames(name, resource string) (int, string, string) {
+	id := RandomInt()
+	n := fmt.Sprintf("%s%d", name, id)
+	return id, fmt.Sprintf("%s.%s", resource, n), n
 }
 
 type CheckFun func(id string, request *resty.Request) (*resty.Response, error)

--- a/pkg/utils/test.go
+++ b/pkg/utils/test.go
@@ -268,7 +268,7 @@ var updateProxiesConfig = func(t *testing.T, proxyKey string, getProxiesBody fun
 }
 
 // CreateProxy creates a new proxy on Artifactory with the given key
-var CreateProxy = func(t *testing.T, proxyKey string) {
+func CreateProxy(t *testing.T, proxyKey string) {
 	type proxy struct {
 		Key             string `yaml:"key"`
 		Host            string `yaml:"host"`
@@ -298,7 +298,7 @@ var CreateProxy = func(t *testing.T, proxyKey string) {
 }
 
 // DeleteProxy deletes an existing proxy on Artifactory with the given key
-var DeleteProxy = func(t *testing.T, proxyKey string) {
+func DeleteProxy(t *testing.T, proxyKey string) {
 	updateProxiesConfig(t, proxyKey, func() []byte {
 		// Return empty yaml to clean up all proxies
 		return []byte(`proxies: ~`)

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -1,14 +1,12 @@
 package utils
 
 import (
-	"bytes"
 	"fmt"
 	"math/rand"
 	"net/http"
 	"net/url"
 	"sort"
 	"strings"
-	"text/template"
 	"time"
 
 	"github.com/go-resty/resty/v2"
@@ -23,6 +21,8 @@ func (d *ResourceData) GetString(key string, onlyIfChanged bool) string {
 	}
 	return ""
 }
+
+func BoolPtr(v bool) *bool { return &v }
 
 func (d *ResourceData) GetBoolRef(key string, onlyIfChanged bool) *bool {
 	if v, ok := d.GetOkExists(key); ok && (!onlyIfChanged || d.HasChange(key)) {
@@ -91,23 +91,6 @@ func RandSelect(items ...interface{}) interface{} {
 	return items[RandomInt()%len(items)]
 }
 
-func MergeMaps(schemata ...map[string]interface{}) map[string]interface{} {
-	result := map[string]interface{}{}
-	for _, schma := range schemata {
-		for k, v := range schma {
-			result[k] = v
-		}
-	}
-	return result
-}
-
-func CopyInterfaceMap(source map[string]interface{}, target map[string]interface{}) map[string]interface{} {
-	for k, v := range source {
-		target[k] = v
-	}
-	return target
-}
-
 func MergeSchema(schemata ...map[string]*schema.Schema) map[string]*schema.Schema {
 	result := map[string]*schema.Schema{}
 	for _, schma := range schemata {
@@ -116,21 +99,6 @@ func MergeSchema(schemata ...map[string]*schema.Schema) map[string]*schema.Schem
 		}
 	}
 	return result
-}
-
-func ExecuteTemplate(name, temp string, fields interface{}) string {
-	var tpl bytes.Buffer
-	if err := template.Must(template.New(name).Parse(temp)).Execute(&tpl, fields); err != nil {
-		panic(err)
-	}
-
-	return tpl.String()
-}
-
-func MkNames(name, resource string) (int, string, string) {
-	id := RandomInt()
-	n := fmt.Sprintf("%s%d", name, id)
-	return id, fmt.Sprintf("%s.%s", resource, n), n
 }
 
 type Lens func(key string, value interface{}) []error
@@ -163,8 +131,6 @@ func SendConfigurationPatch(content []byte, m interface{}) error {
 
 	return err
 }
-
-func BoolPtr(v bool) *bool { return &v }
 
 func FormatCommaSeparatedString(thing interface{}) string {
 	fields := strings.Fields(thing.(string))

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -1,4 +1,4 @@
-package artifactory
+package utils
 
 import (
 	"bytes"
@@ -15,50 +15,50 @@ import (
 
 type ResourceData struct{ *schema.ResourceData }
 
-func (d *ResourceData) getString(key string, onlyIfChanged bool) string {
+func (d *ResourceData) GetString(key string, onlyIfChanged bool) string {
 	if v, ok := d.GetOk(key); ok && (!onlyIfChanged || d.HasChange(key)) {
 		return v.(string)
 	}
 	return ""
 }
 
-func (d *ResourceData) getBoolRef(key string, onlyIfChanged bool) *bool {
+func (d *ResourceData) GetBoolRef(key string, onlyIfChanged bool) *bool {
 	if v, ok := d.GetOkExists(key); ok && (!onlyIfChanged || d.HasChange(key)) {
 		return BoolPtr(v.(bool))
 	}
 	return nil
 }
 
-func (d *ResourceData) getBool(key string, onlyIfChanged bool) bool {
+func (d *ResourceData) GetBool(key string, onlyIfChanged bool) bool {
 	if v, ok := d.GetOkExists(key); ok && (!onlyIfChanged || d.HasChange(key)) {
 		return v.(bool)
 	}
 	return false
 }
 
-func (d *ResourceData) getInt(key string, onlyIfChanged bool) int {
+func (d *ResourceData) GetInt(key string, onlyIfChanged bool) int {
 	if v, ok := d.GetOkExists(key); ok && (!onlyIfChanged || d.HasChange(key)) {
 		return v.(int)
 	}
 	return 0
 }
 
-func (d *ResourceData) getSet(key string) []string {
+func (d *ResourceData) GetSet(key string) []string {
 	if v, ok := d.GetOkExists(key); ok {
-		arr := castToStringArr(v.(*schema.Set).List())
+		arr := CastToStringArr(v.(*schema.Set).List())
 		return arr
 	}
 	return nil
 }
-func (d *ResourceData) getList(key string) []string {
+func (d *ResourceData) GetList(key string) []string {
 	if v, ok := d.GetOkExists(key); ok {
-		arr := castToStringArr(v.([]interface{}))
+		arr := CastToStringArr(v.([]interface{}))
 		return arr
 	}
 	return []string{}
 }
 
-func castToStringArr(arr []interface{}) []string {
+func CastToStringArr(arr []interface{}) []string {
 	cpy := make([]string, 0, len(arr))
 	for _, r := range arr {
 		cpy = append(cpy, r.(string))
@@ -67,7 +67,7 @@ func castToStringArr(arr []interface{}) []string {
 	return cpy
 }
 
-func castToInterfaceArr(arr []string) []interface{} {
+func CastToInterfaceArr(arr []string) []interface{} {
 	cpy := make([]interface{}, 0, len(arr))
 	for _, r := range arr {
 		cpy = append(cpy, r)
@@ -76,20 +76,20 @@ func castToInterfaceArr(arr []string) []interface{} {
 	return cpy
 }
 
-func randomInt() int {
+func RandomInt() int {
 	rand.Seed(time.Now().UnixNano())
 	return rand.Intn(10000000)
 }
 
-func randBool() bool {
-	return randomInt()%2 == 0
+func RandBool() bool {
+	return RandomInt()%2 == 0
 }
 
-func randSelect(items ...interface{}) interface{} {
-	return items[randomInt()%len(items)]
+func RandSelect(items ...interface{}) interface{} {
+	return items[RandomInt()%len(items)]
 }
 
-func mergeMaps(schemata ...map[string]interface{}) map[string]interface{} {
+func MergeMaps(schemata ...map[string]interface{}) map[string]interface{} {
 	result := map[string]interface{}{}
 	for _, schma := range schemata {
 		for k, v := range schma {
@@ -99,14 +99,14 @@ func mergeMaps(schemata ...map[string]interface{}) map[string]interface{} {
 	return result
 }
 
-func copyInterfaceMap(source map[string]interface{}, target map[string]interface{}) map[string]interface{} {
+func CopyInterfaceMap(source map[string]interface{}, target map[string]interface{}) map[string]interface{} {
 	for k, v := range source {
 		target[k] = v
 	}
 	return target
 }
 
-func mergeSchema(schemata ...map[string]*schema.Schema) map[string]*schema.Schema {
+func MergeSchema(schemata ...map[string]*schema.Schema) map[string]*schema.Schema {
 	result := map[string]*schema.Schema{}
 	for _, schma := range schemata {
 		for k, v := range schma {
@@ -116,7 +116,7 @@ func mergeSchema(schemata ...map[string]*schema.Schema) map[string]*schema.Schem
 	return result
 }
 
-func executeTemplate(name, temp string, fields interface{}) string {
+func ExecuteTemplate(name, temp string, fields interface{}) string {
 	var tpl bytes.Buffer
 	if err := template.Must(template.New(name).Parse(temp)).Execute(&tpl, fields); err != nil {
 		panic(err)
@@ -125,8 +125,8 @@ func executeTemplate(name, temp string, fields interface{}) string {
 	return tpl.String()
 }
 
-func mkNames(name, resource string) (int, string, string) {
-	id := randomInt()
+func MkNames(name, resource string) (int, string, string) {
+	id := RandomInt()
 	n := fmt.Sprintf("%s%d", name, id)
 	return id, fmt.Sprintf("%s.%s", resource, n), n
 }
@@ -135,7 +135,7 @@ type Lens func(key string, value interface{}) []error
 
 type Schema map[string]*schema.Schema
 
-func schemaHasKey(skeema map[string]*schema.Schema) HclPredicate {
+func SchemaHasKey(skeema map[string]*schema.Schema) HclPredicate {
 	return func(key string) bool {
 		_, ok := skeema[key]
 		return ok
@@ -144,7 +144,7 @@ func schemaHasKey(skeema map[string]*schema.Schema) HclPredicate {
 
 type HclPredicate func(hcl string) bool
 
-func mkLens(d *schema.ResourceData) Lens {
+func MkLens(d *schema.ResourceData) Lens {
 	var errors []error
 	return func(key string, value interface{}) []error {
 		if err := d.Set(key, value); err != nil {
@@ -154,8 +154,7 @@ func mkLens(d *schema.ResourceData) Lens {
 	}
 }
 
-func sendConfigurationPatch(content []byte, m interface{}) error {
-
+func SendConfigurationPatch(content []byte, m interface{}) error {
 	_, err := m.(*resty.Client).R().SetBody(content).
 		SetHeader("Content-Type", "application/yaml").
 		Patch("artifactory/api/system/configuration")
@@ -165,7 +164,7 @@ func sendConfigurationPatch(content []byte, m interface{}) error {
 
 func BoolPtr(v bool) *bool { return &v }
 
-func formatCommaSeparatedString(thing interface{}) string {
+func FormatCommaSeparatedString(thing interface{}) string {
 	fields := strings.Fields(thing.(string))
 	sort.Strings(fields)
 	return strings.Join(fields, ",")

--- a/pkg/utils/validators.go
+++ b/pkg/utils/validators.go
@@ -1,9 +1,8 @@
-package artifactory
+package utils
 
 import (
 	"fmt"
 	"net/mail"
-	"os"
 	"regexp"
 	"strings"
 
@@ -14,7 +13,7 @@ import (
 	"gopkg.in/ldap.v2"
 )
 
-func validateLowerCase(value interface{}, key string) (ws []string, es []error) {
+func ValidateLowerCase(value interface{}, key string) (ws []string, es []error) {
 	m := value.(string)
 	low := strings.ToLower(m)
 
@@ -24,7 +23,7 @@ func validateLowerCase(value interface{}, key string) (ws []string, es []error) 
 	return
 }
 
-func validateCron(value interface{}, key string) (ws []string, es []error) {
+func ValidateCron(value interface{}, key string) (ws []string, es []error) {
 	_, err := cronexpr.Parse(value.(string))
 	if err != nil {
 		return nil, []error{err}
@@ -32,7 +31,7 @@ func validateCron(value interface{}, key string) (ws []string, es []error) {
 	return nil, nil
 }
 
-var commaSeperatedList = validation.ToDiagFunc(
+var CommaSeperatedList = validation.ToDiagFunc(
 	validation.StringMatch(regexp.MustCompile(`.+(?:,.+)*`), "must be comma separated string"),
 )
 
@@ -475,11 +474,11 @@ var validLicenseTypes = []string{
 
 var licenseTypeValidator = validation.StringInSlice(validLicenseTypes, false)
 
-var projectKeyValidator = validation.ToDiagFunc(
+var ProjectKeyValidator = validation.ToDiagFunc(
 	validation.StringMatch(regexp.MustCompile(`^[a-z0-9]{3,10}$`), "project_key must be 3 - 10 lowercase alphanumeric characters"),
 )
 
-func repoLayoutRefSchemaOverrideValidator(_ interface{}, _ cty.Path) diag.Diagnostics {
+func RepoLayoutRefSchemaOverrideValidator(_ interface{}, _ cty.Path) diag.Diagnostics {
 	return diag.Diagnostics{
 		diag.Diagnostic{
 			Severity: diag.Error,
@@ -489,7 +488,7 @@ func repoLayoutRefSchemaOverrideValidator(_ interface{}, _ cty.Path) diag.Diagno
 	}
 }
 
-func validateIsEmail(address interface{}, _ string) ([]string, []error) {
+func ValidateIsEmail(address interface{}, _ string) ([]string, []error) {
 	_, err := mail.ParseAddress(address.(string))
 	if err != nil {
 		return nil, []error{fmt.Errorf("%s is not a valid address: %s", address, err)}
@@ -497,7 +496,7 @@ func validateIsEmail(address interface{}, _ string) ([]string, []error) {
 	return nil, nil
 }
 
-func validateLdapDn(value interface{}, _ string) ([]string, []error) {
+func ValidateLdapDn(value interface{}, _ string) ([]string, []error) {
 	_, err := ldap.ParseDN(value.(string))
 	if err != nil {
 		return nil, []error{err}
@@ -505,16 +504,9 @@ func validateLdapDn(value interface{}, _ string) ([]string, []error) {
 	return nil, nil
 }
 
-func validateLdapFilter(value interface{}, _ string) ([]string, []error) {
+func ValidateLdapFilter(value interface{}, _ string) ([]string, []error) {
 	_, err := ldap.CompileFilter(value.(string))
 	if err != nil {
-		return nil, []error{err}
-	}
-	return nil, nil
-}
-
-func fileExist(value interface{}, _ string) ([]string, []error) {
-	if _, err := os.Stat(value.(string)); err != nil {
 		return nil, []error{err}
 	}
 	return nil, nil


### PR DESCRIPTION
First part of refactoring how the code are packaged. Moving the `util.go` and `util_test.go` to a different package is the most involved/challenging work. Now that this is done, the rest of the re-packaging (different repo packages, etc.) will be straightforward.

- Move `util.go` and `util_test.go` to `utils` package
- Fix circular references by `artifactory` package and test code once we move to `utils` package
- Move code that was in `utils.go` to `util_test.go` that only used for tests.