### PR TITLE
Improve usage telemetry

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,8 +48,7 @@ attach:
 
 acceptance: fmtcheck
 	export TF_ACC=true && \
-		test -n ARTIFACTORY_USERNAME && test -n ARTIFACTORY_PASSWORD && test -n ARTIFACTORY_URL \
-		&& go test -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}-test'" -v -p 1 -parallel 20 -timeout 20m ./pkg/...
+		go test -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}'" -v -p 1 -parallel 20 -timeout 20m ./pkg/...
 
 acceptance_federated:
 	export TF_ACC=true && \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,7 @@
 TEST?=./...
 TARGET_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
 PKG_NAME=pkg/artifactory
-PKG_VERSION_PATH=github.com/jfrog/terraform-provider-artifactory/${PKG_NAME}/provider
+PKG_VERSION_PATH=github.com/jfrog/terraform-provider-artifactory/v6/${PKG_NAME}/provider
 VERSION := $(shell git tag --sort=-creatordate | head -1 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')
 NEXT_VERSION := $(shell echo ${VERSION}| awk -F '.' '{print $$1 "." $$2 "." $$3 +1 }' )
 BUILD_PATH=terraform.d/plugins/registry.terraform.io/jfrog/artifactory/${NEXT_VERSION}/${TARGET_ARCH}

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -48,7 +48,7 @@ attach:
 
 acceptance: fmtcheck
 	export TF_ACC=true && \
-		go test -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}'" -v -p 1 -parallel 20 -timeout 20m ./pkg/...
+		go test -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}-test'" -v -p 1 -parallel 20 -timeout 20m ./pkg/...
 
 acceptance_federated:
 	export TF_ACC=true && \

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-log v0.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
-	github.com/jfrog/terraform-provider-shared v0.1.0
+	github.com/jfrog/terraform-provider-shared v0.3.0
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-log v0.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
-	github.com/jfrog/terraform-provider-shared v0.3.0
+	github.com/jfrog/terraform-provider-shared v0.4.0
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-log v0.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
-	github.com/jfrog/terraform-provider-shared v0.4.0
+	github.com/jfrog/terraform-provider-shared v0.5.0
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v0.3.0 h1:va3toJrofl5W7tAbU7HSV5z65utNAqaCtkqu3GEeFTk=
-github.com/jfrog/terraform-provider-shared v0.3.0/go.mod h1:8QRccISRVo/Ht/e7vjcNhjb49BJSheZ1bfEUwGdgZi8=
+github.com/jfrog/terraform-provider-shared v0.4.0 h1:MCI8YIkddn195tGMe8HqYh6vkrJgMawu1sXMaNs0GPE=
+github.com/jfrog/terraform-provider-shared v0.4.0/go.mod h1:2ueIlfizwfDAkL1jm3hmvYBqbMusQtHz33ZpDiPOyxA=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v0.1.0 h1:gbhmpOKf3FW5qddhpgDx0hku4H+i/IKH0jnYqLGrmnM=
-github.com/jfrog/terraform-provider-shared v0.1.0/go.mod h1:8QRccISRVo/Ht/e7vjcNhjb49BJSheZ1bfEUwGdgZi8=
+github.com/jfrog/terraform-provider-shared v0.3.0 h1:va3toJrofl5W7tAbU7HSV5z65utNAqaCtkqu3GEeFTk=
+github.com/jfrog/terraform-provider-shared v0.3.0/go.mod h1:8QRccISRVo/Ht/e7vjcNhjb49BJSheZ1bfEUwGdgZi8=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v0.4.0 h1:MCI8YIkddn195tGMe8HqYh6vkrJgMawu1sXMaNs0GPE=
-github.com/jfrog/terraform-provider-shared v0.4.0/go.mod h1:2ueIlfizwfDAkL1jm3hmvYBqbMusQtHz33ZpDiPOyxA=
+github.com/jfrog/terraform-provider-shared v0.5.0 h1:1TEHe3ZkLSNBcxcQ5Ba9X05WiXJpbScRR7eaeXW00CA=
+github.com/jfrog/terraform-provider-shared v0.5.0/go.mod h1:2ueIlfizwfDAkL1jm3hmvYBqbMusQtHz33ZpDiPOyxA=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/pkg/acctest/test.go
+++ b/pkg/acctest/test.go
@@ -10,8 +10,8 @@ import (
 	"reflect"
 	"strings"
 	"sync"
-	"text/template"
 	"testing"
+	"text/template"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -27,7 +27,7 @@ import (
 
 const RtDefaultUser = "admin"
 
-// PreCheck(t) must be called before using this provider instance.
+// Provider PreCheck(t) must be called before using this provider instance.
 var Provider *schema.Provider
 var ProviderFactories map[string]func() (*schema.Provider, error)
 
@@ -47,7 +47,7 @@ func init() {
 	}
 }
 
-// This PreCheck function should be present in every acceptance test.
+// PreCheck This function should be present in every acceptance test.
 func PreCheck(t *testing.T) {
 	// Since we are outside the scope of the Terraform configuration we must
 	// call Configure() to properly initialize the provider configuration.
@@ -200,7 +200,7 @@ func VerifyDeleted(id string, check CheckFun) func(*terraform.State) error {
 		}
 
 		if Provider == nil {
-			return fmt.Errorf("Provider is not initialized. Please PreCheck() is included in your acceptance test.")
+			return fmt.Errorf("provider is not initialized. Please PreCheck() is included in your acceptance test")
 		}
 
 		client := Provider.Meta().(*resty.Client)
@@ -266,7 +266,7 @@ func DeleteProject(t *testing.T, projectKey string) {
 	}
 }
 
-// Create a local repository with Xray indexing enabled. It will be used in the tests
+// CreateRepo Create a local repository with Xray indexing enabled. It will be used in the tests
 func CreateRepo(t *testing.T, repo string, rclass string, packageType string,
 	handleReleases bool, handleSnapshots bool) {
 	restyClient := GetTestResty(t)
@@ -309,7 +309,7 @@ func DeleteRepo(t *testing.T, repo string) {
 	}
 }
 
-//Usage of the function is strictly restricted to Test Cases
+// GetValidRandomDefaultRepoLayoutRef Usage of the function is strictly restricted to Test Cases
 func GetValidRandomDefaultRepoLayoutRef() string {
 	return test.RandSelect("simple-default", "bower-default", "composer-default", "conan-default", "go-default", "maven-2-default", "ivy-default", "npm-default", "nuget-default", "puppet-default", "sbt-default").(string)
 }

--- a/pkg/artifactory/datasource/datasource_artifactory_file.go
+++ b/pkg/artifactory/datasource/datasource_artifactory_file.go
@@ -37,7 +37,7 @@ func (fi FileInfo) Id() string {
 	return fi.Repo + fi.Path
 }
 
-func DataSourceArtifactoryFile() *schema.Resource {
+func ArtifactoryFile() *schema.Resource {
 	return &schema.Resource{
 		ReadContext: dataSourceFileReader,
 		Schema: map[string]*schema.Schema{
@@ -128,7 +128,7 @@ func DataSourceArtifactoryFile() *schema.Resource {
 	}
 }
 
-func dataSourceFileReader(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func dataSourceFileReader(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	repository := d.Get("repository").(string)
 	path := d.Get("path").(string)
 	outputPath := d.Get("output_path").(string)
@@ -216,5 +216,5 @@ func dataSourceFileReader(ctx context.Context, d *schema.ResourceData, m interfa
 		return nil
 	}
 
-	return diag.FromErr(packFileInfo(fileInfo, d))
+	return packFileInfo(fileInfo, d)
 }

--- a/pkg/artifactory/provider/provider.go
+++ b/pkg/artifactory/provider/provider.go
@@ -190,16 +190,16 @@ func addTelemetry(resourceMap map[string]*schema.Resource) map[string]*schema.Re
 
 	for name, skeema := range resourceMap {
 		if skeema.CreateContext != nil {
-			skeema.CreateContext = util.ApplyTelemetry(Version, name, "CREATE", skeema.CreateContext)
+			skeema.CreateContext = util.ApplyTelemetry(productId, name, "CREATE", skeema.CreateContext)
 		}
 		if skeema.ReadContext != nil {
-			skeema.ReadContext = util.ApplyTelemetry(Version, name, "READ", skeema.ReadContext)
+			skeema.ReadContext = util.ApplyTelemetry(productId, name, "READ", skeema.ReadContext)
 		}
 		if skeema.UpdateContext != nil {
-			skeema.UpdateContext = util.ApplyTelemetry(Version, name, "UPDATE", skeema.UpdateContext)
+			skeema.UpdateContext = util.ApplyTelemetry(productId, name, "UPDATE", skeema.UpdateContext)
 		}
 		if skeema.DeleteContext != nil {
-			skeema.DeleteContext = util.ApplyTelemetry(Version, name, "DELETE", skeema.DeleteContext)
+			skeema.DeleteContext = util.ApplyTelemetry(productId, name, "DELETE", skeema.DeleteContext)
 		}
 	}
 	return resourceMap

--- a/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_generic_repository.go
+++ b/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_generic_repository.go
@@ -51,7 +51,7 @@ func ResourceArtifactoryFederatedGenericRepository(repoType string) *schema.Reso
 	}
 
 	var unpackMembers = func(data *schema.ResourceData) []Member {
-		d := &util.ResourceData{data}
+		d := &util.ResourceData{ResourceData: data}
 
 		var members []Member
 

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook.go
@@ -357,11 +357,11 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: domainSchemaLookup[webhookType],
+		Schema:        domainSchemaLookup[webhookType],
 		CustomizeDiff: customdiff.All(
 			eventTypesDiff,
 			criteriaDiff,
 		),
-		Description: "Provides an Artifactory webhook resource",
+		Description:   "Provides an Artifactory webhook resource",
 	}
 }


### PR DESCRIPTION
Add more granular usage tracking to the resource and resource's CRUD funcs level.

Now the usage request no longer a blocker when fails. It will only log the error when it fails.

Also:
- Move the usage func to the shared module
- Fix package version path in make file