### PR TITLE
GH-439 support multiple handlers in webhook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 6.7.0 (May 12, 2022)
+
+IMPROVEMENTS:
+
+* resource/artifactory_*_webhook: Add support for multiple outlets (handlers) of the webhook. Existing attributes (`url`, `secret`, `proxy`, and `custom_http_headers`) will be automatically migrated to be the first handler.
+
+To migrate to new webhook schema with multiple handlers:
+- Update your HCL and copy the attributes (`url`, `secret`, `proxy`, and `custom_http_headers`) into a `handler` block (See `sample.tf` for full examples)
+- Execute `terraform apply -refresh-only` to update the Terraform state
+
+PR: [#](https://github.com/jfrog/terraform-provider-artifactory/pull/). Issue [#439](https://github.com/jfrog/terraform-provider-artifactory/issues/439)
+
 ## 6.6.1 (May 5, 2022). Tested on Artifactory 7.37.16
 
 BUG FIXES:

--- a/docs/resources/artifact_property_webhook.md
+++ b/docs/resources/artifact_property_webhook.md
@@ -22,13 +22,16 @@ resource "artifactory_artifact_property_webhook" "artifact-webhook" {
     include_patterns  = ["foo/**"]
     exclude_patterns  = ["bar/**"]
   }
-  url          = "http://tempurl.org/webhook"
-  secret       = "some-secret"
-  proxy        = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 
   depends_on = [artifactory_local_generic_repository.my-generic-local]
@@ -51,7 +54,8 @@ The following arguments are supported:
   * `repo_keys` - (Required) Trigger on this list of repo keys.
   * `include_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**".
   * `exclude_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**".
-* `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
-* `secret` - (Optional) Secret authentication token that will be sent to the configured URL
-* `proxy` - (Optional) Proxy key from Artifactory Proxies setting.
-* `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.
+* `handler` - (Required) At least one is required
+  * `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
+  * `secret` - (Optional) Secret authentication token that will be sent to the configured URL
+  * `proxy` - (Optional) Proxy key from Artifactory Proxies setting.
+  * `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.

--- a/docs/resources/artifact_webhook.md
+++ b/docs/resources/artifact_webhook.md
@@ -22,13 +22,16 @@ resource "artifactory_artifact_webhook" "artifact-webhook" {
     include_patterns  = ["foo/**"]
     exclude_patterns  = ["bar/**"]
   }
-  url         = "http://tempurl.org/webhook"
-  secret      = "some-secret"
-  proxy       = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 
   depends_on = [artifactory_local_generic_repository.my-generic-local]
@@ -51,7 +54,8 @@ The following arguments are supported:
   * `repo_keys` - (Required) Trigger on this list of repo keys.
   * `include_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**".
   * `exclude_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**".
-* `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
-* `secret` - (Optional) Secret authentication token that will be sent to the configured URL.
-* `proxy` - (Optional) Proxy key from Artifactory Proxies setting.
-* `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.
+* `handler` - (Required) At least one is required
+  * `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
+  * `secret` - (Optional) Secret authentication token that will be sent to the configured URL.
+  * `proxy` - (Optional) Proxy key from Artifactory Proxies setting.
+  * `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.

--- a/docs/resources/artifactory_release_bundle_webhook.md
+++ b/docs/resources/artifactory_release_bundle_webhook.md
@@ -17,13 +17,16 @@ resource "artifactory_artifactory_release_bundle_webhook" "artifactory-release-b
     include_patterns                = ["foo/**"]
     exclude_patterns                = ["bar/**"]
   }
-  url         = "http://tempurl.org/webhook"
-  secret      = "some-secret"
-  proxy       = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 }
 ```
@@ -43,7 +46,8 @@ The following arguments are supported:
   * `registered_release_bundle_names` - (Required) Trigger on this list of release bundle names
   * `include_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**"
   * `exclude_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**"
-* `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
-* `secret` - (Optional) Secret authentication token that will be sent to the configured URL
-* `proxy` - (Optional) Proxy key from Artifactory Proxies setting
-* `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.
+* `handler` - (Required) At least one is required
+  * `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
+  * `secret` - (Optional) Secret authentication token that will be sent to the configured URL
+  * `proxy` - (Optional) Proxy key from Artifactory Proxies setting
+  * `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.

--- a/docs/resources/build_webhook.md
+++ b/docs/resources/build_webhook.md
@@ -17,13 +17,16 @@ resource "artifactory_build_webhook" "build-webhook" {
     include_patterns  = ["foo/**"]
     exclude_patterns  = ["bar/**"]
   }
-  url         = "http://tempurl.org/webhook"
-  secret      = "some-secret"
-  proxy       = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 }
 ```
@@ -43,7 +46,8 @@ The following arguments are supported:
   * `selected_builds` - (Required) Trigger on this list of build names.
   * `include_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**".
   * `exclude_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**".
-* `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
-* `secret` - (Optional) Secret authentication token that will be sent to the configured URL.
-* `proxy` - (Optional) Proxy key from Artifactory Proxies setting.
-* `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.
+* `handler` - (Required) At least one is required
+  * `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
+  * `secret` - (Optional) Secret authentication token that will be sent to the configured URL.
+  * `proxy` - (Optional) Proxy key from Artifactory Proxies setting.
+  * `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.

--- a/docs/resources/distribution_webhook.md
+++ b/docs/resources/distribution_webhook.md
@@ -17,13 +17,16 @@ resource "artifactory_distribution_webhook" "distribution-webhook" {
     include_patterns                = ["foo/**"]
     exclude_patterns                = ["bar/**"]
   }
-  url         = "http://tempurl.org/webhook"
-  secret      = "some-secret"
-  proxy       = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 }
 ```
@@ -43,7 +46,8 @@ The following arguments are supported:
   * `registered_release_bundle_names` - (Required) Trigger on this list of release bundle names.
   * `include_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**".
   * `exclude_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**".
-* `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
-* `secret` - (Optional) Secret authentication token that will be sent to the configured URL.
-* `proxy` - (Optional) Proxy key from Artifactory Proxies setting.
-* `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.
+* `handler` - (Required) At least one is required
+  * `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
+  * `secret` - (Optional) Secret authentication token that will be sent to the configured URL.
+  * `proxy` - (Optional) Proxy key from Artifactory Proxies setting.
+  * `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.

--- a/docs/resources/docker_webhook.md
+++ b/docs/resources/docker_webhook.md
@@ -22,13 +22,16 @@ resource "artifactory_docker_webhook" "docker-webhook" {
     include_patterns  = ["foo/**"]
     exclude_patterns  = ["bar/**"]
   }
-  url         = "http://tempurl.org/webhook"
-  secret      = "some-secret"
-  proxy       = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 
   depends_on = [artifactory_local_docker_v2_repository.my-docker-local]
@@ -51,7 +54,8 @@ The following arguments are supported:
   * `repo_keys` - (Required) Trigger on this list of repo keys.
   * `include_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**".
   * `exclude_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**".
-* `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
-* `secret` - (Optional) Secret authentication token that will be sent to the configured URL.
-* `proxy` - (Optional) Proxy key from Artifactory Proxies setting.
-* `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.
+* `handler` - (Required) At least one is required
+  * `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
+  * `secret` - (Optional) Secret authentication token that will be sent to the configured URL.
+  * `proxy` - (Optional) Proxy key from Artifactory Proxies setting.
+  * `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.

--- a/docs/resources/release_bundle_webhook.md
+++ b/docs/resources/release_bundle_webhook.md
@@ -17,13 +17,16 @@ resource "artifactory_release_bundle_webhook" "release-bundle-webhook" {
     include_patterns                = ["foo/**"]
     exclude_patterns                = ["bar/**"]
   }
-  url           = "http://tempurl.org/webhook"
-  secret        = "some-secret"
-  proxy         = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 }
 ```
@@ -43,7 +46,8 @@ The following arguments are supported:
   * `registered_release_bundle_names` - (Required) Trigger on this list of release bundle names.
   * `include_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**".
   * `exclude_patterns` - (Optional) Simple comma separated wildcard patterns for repository artifact paths (with no leading slash).\n Ant-style path expressions are supported (*, *\*, ?).\nFor example: "org/apache/**".
-* `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
-* `secret` - (Optional) Secret authentication token that will be sent to the configured URL.
-* `proxy` - (Optional) Proxy key from Artifactory Proxies setting.
-* `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.
+* `handler` - (Required) At least one is required
+  * `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
+  * `secret` - (Optional) Secret authentication token that will be sent to the configured URL.
+  * `proxy` - (Optional) Proxy key from Artifactory Proxies setting.
+  * `custom_http_headers` - (Optional) Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook.go
@@ -70,6 +70,8 @@ const webhooksUrl = "/event/api/v1/subscriptions"
 
 const WebhookUrl = webhooksUrl + "/{webhookKey}"
 
+const currentSchemaVersion = 2
+
 func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 
 	var domainCriteriaLookup = map[string]interface{}{
@@ -82,14 +84,16 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 		"artifactory_release_bundle": ReleaseBundleWebhookCriteria{},
 	}
 
-	var domainSchemaLookup = map[string]map[string]*schema.Schema{
-		"artifact":                   repoWebhookSchema(webhookType),
-		"artifact_property":          repoWebhookSchema(webhookType),
-		"docker":                     repoWebhookSchema(webhookType),
-		"build":                      buildWebhookSchema(webhookType),
-		"release_bundle":             releaseBundleWebhookSchema(webhookType),
-		"distribution":               releaseBundleWebhookSchema(webhookType),
-		"artifactory_release_bundle": releaseBundleWebhookSchema(webhookType),
+	var domainSchemaLookup = func(version int) map[string]map[string]*schema.Schema {
+		return map[string]map[string]*schema.Schema{
+			"artifact":                   repoWebhookSchema(webhookType, version),
+			"artifact_property":          repoWebhookSchema(webhookType, version),
+			"docker":                     repoWebhookSchema(webhookType, version),
+			"build":                      buildWebhookSchema(webhookType, version),
+			"release_bundle":             releaseBundleWebhookSchema(webhookType, version),
+			"distribution":               releaseBundleWebhookSchema(webhookType, version),
+			"artifactory_release_bundle": releaseBundleWebhookSchema(webhookType, version),
+		}
 	}
 
 	var domainPackLookup = map[string]func(map[string]interface{}) map[string]interface{}{
@@ -135,22 +139,41 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 			return webhookCriteria
 		}
 
-		var unpackCustomHttpHeaders = func(d *util.ResourceData) []WebhookCustomHttpHeader {
-			var customHeaders []WebhookCustomHttpHeader
+		var unpackCustomHttpHeaders = func(customHeaders map[string]interface{}) []WebhookCustomHttpHeader {
+			var headers []WebhookCustomHttpHeader
 
-			if v, ok := d.GetOkExists("custom_http_headers"); ok {
-				headers := v.(map[string]interface{})
-				for key, value := range headers {
-					customHeader := WebhookCustomHttpHeader{
-						Name:  key,
-						Value: value.(string),
+			for key, value := range customHeaders {
+				customHeader := WebhookCustomHttpHeader{
+					Name:  key,
+					Value: value.(string),
+				}
+
+				headers = append(headers, customHeader)
+			}
+
+			return headers
+		}
+
+		var unpackHandlers = func(d *util.ResourceData) []WebhookHandler {
+			var webhookHandlers []WebhookHandler
+
+			if v, ok := d.GetOkExists("handler"); ok {
+				handlers := v.(*schema.Set).List()
+				for _, handler := range handlers {
+					h := handler.(map[string]interface{})
+
+					webhookHandler := WebhookHandler{
+						HandlerType:       "webhook",
+						Url:               h["url"].(string),
+						Secret:            h["secret"].(string),
+						Proxy:             h["proxy"].(string),
+						CustomHttpHeaders: unpackCustomHttpHeaders(h["custom_http_headers"].(map[string]interface{})),
 					}
-
-					customHeaders = append(customHeaders, customHeader)
+					webhookHandlers = append(webhookHandlers, webhookHandler)
 				}
 			}
 
-			return customHeaders
+			return webhookHandlers
 		}
 
 		webhook := WebhookBaseParams{
@@ -162,15 +185,7 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 				EventTypes: d.GetSet("event_types"),
 				Criteria:   unpackCriteria(d, webhookType),
 			},
-			Handlers: []WebhookHandler{
-				{
-					HandlerType:       "webhook",
-					Url:               d.GetString("url", false),
-					Secret:            d.GetString("secret", false),
-					Proxy:             d.GetString("proxy", false),
-					CustomHttpHeaders: unpackCustomHttpHeaders(d),
-				},
-			},
+			Handlers: unpackHandlers(d),
 		}
 
 		return webhook, nil
@@ -179,7 +194,7 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 	var packCriteria = func(d *schema.ResourceData, criteria map[string]interface{}) []error {
 		setValue := util.MkLens(d)
 
-		resource := domainSchemaLookup[webhookType]["criteria"].Elem.(*schema.Resource)
+		resource := domainSchemaLookup(currentSchemaVersion)[webhookType]["criteria"].Elem.(*schema.Resource)
 		packedCriteria := domainPackLookup[webhookType](criteria)
 
 		packedCriteria["include_patterns"] = schema.NewSet(schema.HashString, criteria["includePatterns"].([]interface{}))
@@ -188,15 +203,33 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 		return setValue("criteria", schema.NewSet(schema.HashResource(resource), []interface{}{packedCriteria}))
 	}
 
-	var packCustomHeaders = func(d *schema.ResourceData, customHeaders []WebhookCustomHttpHeader) []error {
-		setValue := util.MkLens(d)
-
+	var packCustomHeaders = func(customHeaders []WebhookCustomHttpHeader) map[string]interface{} {
 		headers := make(map[string]interface{})
 		for _, customHeader := range customHeaders {
 			headers[customHeader.Name] = customHeader.Value
 		}
 
-		return setValue("custom_http_headers", headers)
+		return headers
+	}
+
+	var packHandlers = func(d *schema.ResourceData, handlers []WebhookHandler) []error {
+		setValue := util.MkLens(d)
+
+		resource := domainSchemaLookup(currentSchemaVersion)[webhookType]["handler"].Elem.(*schema.Resource)
+
+		packedHandlers := make([]interface{}, len(handlers))
+
+		for _, handler := range handlers {
+			packedHandler := map[string]interface{}{
+				"url": handler.Url,
+				"secret": handler.Secret,
+				"proxy": handler.Proxy,
+				"custom_http_headers": packCustomHeaders(handler.CustomHttpHeaders),
+			}
+			packedHandlers = append(packedHandlers, packedHandler)
+		}
+
+		return setValue("handler", schema.NewSet(schema.HashResource(resource), packedHandlers))
 	}
 
 	var packWebhook = func(d *schema.ResourceData, webhook WebhookBaseParams) diag.Diagnostics {
@@ -208,15 +241,8 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 		errors = append(errors, setValue("description", webhook.Description)...)
 		errors = append(errors, setValue("enabled", webhook.Enabled)...)
 		errors = append(errors, setValue("event_types", webhook.EventFilter.EventTypes)...)
-
 		errors = append(errors, packCriteria(d, webhook.EventFilter.Criteria.(map[string]interface{}))...)
-
-		handler := webhook.Handlers[0]
-		errors = append(errors, setValue("url", handler.Url)...)
-		errors = append(errors, setValue("secret", handler.Secret)...)
-		errors = append(errors, setValue("proxy", handler.Proxy)...)
-
-		errors = append(errors, packCustomHeaders(d, handler.CustomHttpHeaders)...)
+		errors = append(errors, packHandlers(d, webhook.Handlers)...)
 
 		if len(errors) > 0 {
 			return diag.Errorf("failed to pack webhook %q", errors)
@@ -346,8 +372,15 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 		return domainCriteriaValidationLookup[webhookType](ctx, criteria[0].(map[string]interface{}))
 	}
 
+	// taken from example in https://www.terraform.io/plugin/sdkv2/resources/state-migration#terraform-v0-12-sdk-state-migrations
+	var resourceSchemaV1 = func() *schema.Resource {
+		return &schema.Resource{
+			Schema: domainSchemaLookup(1)[webhookType],
+		}
+	}
+
 	return &schema.Resource{
-		SchemaVersion: 1,
+		SchemaVersion: 2,
 		CreateContext: createWebhook,
 		ReadContext:   readWebhook,
 		UpdateContext: updateWebhook,
@@ -357,11 +390,37 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema:        domainSchemaLookup[webhookType],
+		Schema:         domainSchemaLookup(currentSchemaVersion)[webhookType],
+		StateUpgraders: []schema.StateUpgrader{
+			{
+				Type:    resourceSchemaV1().CoreConfigSchema().ImpliedType(),
+				Upgrade: ResourceStateUpgradeV1,
+				Version: 1,
+			},
+		},
+
 		CustomizeDiff: customdiff.All(
 			eventTypesDiff,
 			criteriaDiff,
 		),
 		Description:   "Provides an Artifactory webhook resource",
 	}
+}
+
+var ResourceStateUpgradeV1 = func(_ context.Context, rawState map[string]interface{}, meta interface{}) (map[string]interface{}, error) {
+	rawState["handler"] = []map[string]interface{}{
+		{
+			"url": rawState["url"],
+			"secret": rawState["secret"],
+			"proxy": rawState["proxy"],
+			"custom_http_headers": rawState["custom_http_headers"],
+		},
+	}
+
+	delete(rawState, "url")
+	delete(rawState, "secret")
+	delete(rawState, "proxy")
+	delete(rawState, "custom_http_headers")
+
+	return rawState, nil
 }

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook_base.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook_base.go
@@ -28,7 +28,19 @@ var baseCriteriaSchema = map[string]*schema.Schema{
 	},
 }
 
-var baseWebhookBaseSchema = func(webhookType string) map[string]*schema.Schema {
+var getBaseSchemaByVersion = func(webhookType string, version int) map[string]*schema.Schema {
+	var baseSchema map[string]*schema.Schema
+
+	if version == 1 {
+		baseSchema = baseWebhookBaseSchemaV1(webhookType)
+	} else {
+		baseSchema = baseWebhookBaseSchemaV2(webhookType)
+	}
+
+	return baseSchema
+}
+
+var baseWebhookBaseSchemaV1 = func(webhookType string) map[string]*schema.Schema {
 	return map[string]*schema.Schema{
 		"key": {
 			Type:             schema.TypeString,
@@ -79,6 +91,71 @@ var baseWebhookBaseSchema = func(webhookType string) map[string]*schema.Schema {
 			Optional:    true,
 			Elem:        &schema.Schema{Type: schema.TypeString},
 			Description: "Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.",
+		},
+	}
+}
+
+
+var baseWebhookBaseSchemaV2 = func(webhookType string) map[string]*schema.Schema {
+	return map[string]*schema.Schema{
+		"key": {
+			Type:             schema.TypeString,
+			Required:         true,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.StringLenBetween(2, 200), validation.StringDoesNotContainAny(" "))),
+			Description:      "Key of webhook. Must be between 2 and 200 characters. Cannot contain spaces.",
+		},
+		"description": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringLenBetween(0, 1000)),
+			Description:      "Description of webhook. Max length 1000 characters.",
+		},
+		"enabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     true,
+			Description: "Status of webhook. Default to 'true'",
+		},
+		"event_types": {
+			Type:     schema.TypeSet,
+			Required: true,
+			MinItems: 1,
+			Elem:     &schema.Schema{Type: schema.TypeString},
+			Description: fmt.Sprintf("List of Events in Artifactory, Distribution, Release Bundle that function as the event trigger for the Webhook.\n"+
+				"Allow values: %v", strings.Trim(strings.Join(DomainEventTypesSupported[webhookType], ", "), "[]")),
+		},
+		"handler": {
+			Type: schema.TypeSet,
+			Required: true,
+			MinItems: 1,
+			Elem: &schema.Resource{
+				Schema: map[string]*schema.Schema{
+					"url": {
+						Type:             schema.TypeString,
+						Required:         true,
+						ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.IsURLWithHTTPorHTTPS, validation.StringIsNotEmpty)),
+						Description:      "Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.",
+					},
+					"secret": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+						Description:      "Secret authentication token that will be sent to the configured URL.",
+					},
+					"proxy": {
+						Type:             schema.TypeString,
+						Optional:         true,
+						ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+						Description:      "Proxy key from Artifactory Proxies setting",
+					},
+					"custom_http_headers": {
+						Type:        schema.TypeMap,
+						Optional:    true,
+						Elem:        &schema.Schema{Type: schema.TypeString},
+						Description: "Custom HTTP headers you wish to use to invoke the Webhook, comprise of key/value pair.",
+					},
+				},
+			},
 		},
 	}
 }

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook_build.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook_build.go
@@ -15,8 +15,8 @@ type BuildWebhookCriteria struct {
 	SelectedBuilds []string `json:"selectedBuilds"`
 }
 
-var buildWebhookSchema = func(webhookType string) map[string]*schema.Schema {
-	return util.MergeSchema(baseWebhookBaseSchema(webhookType), map[string]*schema.Schema{
+var buildWebhookSchema = func(webhookType string, version int) map[string]*schema.Schema {
+	return util.MergeSchema(getBaseSchemaByVersion(webhookType, version), map[string]*schema.Schema{
 		"criteria": {
 			Type:     schema.TypeSet,
 			Required: true,

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook_release_bundle.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook_release_bundle.go
@@ -15,8 +15,8 @@ type ReleaseBundleWebhookCriteria struct {
 	RegisteredReleaseBundlesNames []string `json:"registeredReleaseBundlesNames"`
 }
 
-var releaseBundleWebhookSchema = func(webhookType string) map[string]*schema.Schema {
-	return util.MergeSchema(baseWebhookBaseSchema(webhookType), map[string]*schema.Schema{
+var releaseBundleWebhookSchema = func(webhookType string, version int) map[string]*schema.Schema {
+	return util.MergeSchema(getBaseSchemaByVersion(webhookType, version), map[string]*schema.Schema{
 		"criteria": {
 			Type:     schema.TypeSet,
 			Required: true,

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook_repo.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook_repo.go
@@ -16,8 +16,8 @@ type RepoWebhookCriteria struct {
 	RepoKeys  []string `json:"repoKeys"`
 }
 
-var repoWebhookSchema = func(webhookType string) map[string]*schema.Schema {
-	return util.MergeSchema(baseWebhookBaseSchema(webhookType), map[string]*schema.Schema{
+var repoWebhookSchema = func(webhookType string, version int) map[string]*schema.Schema {
+	return util.MergeSchema(getBaseSchemaByVersion(webhookType, version), map[string]*schema.Schema{
 		"criteria": {
 			Type:     schema.TypeSet,
 			Required: true,

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook_test.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook_test.go
@@ -1,7 +1,9 @@
 package webhook_test
 
 import (
+	"context"
 	"fmt"
+	"reflect"
 	"regexp"
 	"strings"
 	"testing"
@@ -40,7 +42,9 @@ var repoTemplate = `
 			any_remote = false
 			repo_keys = []
 		}
-		url    = "http://tempurl.org"
+		handler {
+			url = "http://tempurl.org"
+		}
 	}
 `
 
@@ -53,7 +57,9 @@ var buildTemplate = `
 			any_build = false
 			selected_builds = []
 		}
-		url    = "http://tempurl.org"
+		handler {
+			url = "http://tempurl.org"
+		}
 	}
 `
 
@@ -66,7 +72,9 @@ var releaseBundleTemplate = `
 			any_release_bundle = false
 			registered_release_bundle_names = []
 		}
-		url    = "http://tempurl.org"
+		handler {
+			url = "http://tempurl.org"
+		}
 	}
 `
 
@@ -135,7 +143,9 @@ func TestAccWebhookEventTypesValidation(t *testing.T) {
 				any_remote = true
 				repo_keys = []
 			}
-			url    = "http://tempurl.org"
+			handler {
+				url = "http://tempurl.org"
+			}
 		}
 	`, params)
 
@@ -197,12 +207,21 @@ func webhookTestCase(webhookType string, t *testing.T) (*testing.T, resource.Tes
 				include_patterns = ["foo/**"]
 				exclude_patterns = ["bar/**"]
 			}
-			url    = "http://tempurl.org"
-			secret = "fake-secret"
-
-			custom_http_headers = {
-				header-1 = "value-1"
-				header-2 = "value-2"
+			handler {
+				url                 = "http://tempurl.org"
+				secret              = "fake-secret"
+				custom_http_headers = {
+					header-1 = "value-1"
+					header-2 = "value-2"
+				}
+			}
+			handler {
+				url                 = "http://tempurl.org"
+				secret              = "fake-secret-2"
+				custom_http_headers = {
+					header-3 = "value-3"
+					header-4 = "value-4"
+				}
 			}
 
 			depends_on = [artifactory_local_{{ .repoType }}_repository.{{ .repoName }}]
@@ -212,8 +231,6 @@ func webhookTestCase(webhookType string, t *testing.T) (*testing.T, resource.Tes
 	testChecks := []resource.TestCheckFunc{
 		resource.TestCheckResourceAttr(fqrn, "key", name),
 		resource.TestCheckResourceAttr(fqrn, "event_types.#", fmt.Sprintf("%d", len(eventTypes))),
-		resource.TestCheckResourceAttr(fqrn, "url", "http://tempurl.org"),
-		resource.TestCheckResourceAttr(fqrn, "secret", "fake-secret"),
 		resource.TestCheckResourceAttr(fqrn, "criteria.#", "1"),
 		resource.TestCheckResourceAttr(fqrn, "criteria.0.any_local", fmt.Sprintf("%t", params["anyLocal"])),
 		resource.TestCheckResourceAttr(fqrn, "criteria.0.any_remote", fmt.Sprintf("%t", params["anyRemote"])),
@@ -222,9 +239,17 @@ func webhookTestCase(webhookType string, t *testing.T) (*testing.T, resource.Tes
 		resource.TestCheckResourceAttr(fqrn, "criteria.0.include_patterns.0", "foo/**"),
 		resource.TestCheckResourceAttr(fqrn, "criteria.0.exclude_patterns.#", "1"),
 		resource.TestCheckResourceAttr(fqrn, "criteria.0.exclude_patterns.0", "bar/**"),
-		resource.TestCheckResourceAttr(fqrn, "custom_http_headers.%", "2"),
-		resource.TestCheckResourceAttr(fqrn, "custom_http_headers.header-1", "value-1"),
-		resource.TestCheckResourceAttr(fqrn, "custom_http_headers.header-2", "value-2"),
+		resource.TestCheckResourceAttr(fqrn, "handler.#", "2"),
+		resource.TestCheckResourceAttr(fqrn, "handler.0.url", "http://tempurl.org"),
+		resource.TestCheckResourceAttr(fqrn, "handler.0.secret", "fake-secret"),
+		resource.TestCheckResourceAttr(fqrn, "handler.0.custom_http_headers.%", "2"),
+		resource.TestCheckResourceAttr(fqrn, "handler.0.custom_http_headers.header-1", "value-1"),
+		resource.TestCheckResourceAttr(fqrn, "handler.0.custom_http_headers.header-2", "value-2"),
+		resource.TestCheckResourceAttr(fqrn, "handler.1.url", "http://tempurl.org"),
+		resource.TestCheckResourceAttr(fqrn, "handler.1.secret", "fake-secret-2"),
+		resource.TestCheckResourceAttr(fqrn, "handler.1.custom_http_headers.%", "2"),
+		resource.TestCheckResourceAttr(fqrn, "handler.1.custom_http_headers.header-3", "value-3"),
+		resource.TestCheckResourceAttr(fqrn, "handler.1.custom_http_headers.header-4", "value-4"),
 	}
 
 	for _, eventType := range eventTypes {
@@ -251,4 +276,40 @@ func testCheckWebhook(id string, request *resty.Request) (*resty.Response, error
 		SetPathParam("webhookKey", id).
 		AddRetryCondition(client.NeverRetry).
 		Get(webhook.WebhookUrl)
+}
+
+// Unit tests for state migration func
+func TestWebhookResourceStateUpgradeV1(t *testing.T) {
+	v1Data := map[string]interface{} {
+		"url": "http://tempurl.org",
+		"secret": "fake-secret",
+		"proxy": "fake-proxy-key",
+		"custom_http_headers": map[string]interface{} {
+			"header-1": "fake-value-1",
+			"header-2": "fake-value-2",
+		},
+	}
+	v2Data := map[string]interface{} {
+		"handler": []map[string]interface{}{
+			{
+				"url": "http://tempurl.org",
+				"secret": "fake-secret",
+				"proxy": "fake-proxy-key",
+				"custom_http_headers": map[string]interface{} {
+					"header-1": "fake-value-1",
+					"header-2": "fake-value-2",
+				},
+			},
+		},
+	}
+
+	actual, err := webhook.ResourceStateUpgradeV1(context.Background(), v1Data, nil)
+
+	if err != nil {
+		t.Fatalf("error migrating state: %s", err)
+	}
+
+	if !reflect.DeepEqual(v2Data, actual) {
+		t.Fatalf("expected: %v\n\ngot: %v", v2Data, actual)
+	}
 }

--- a/sample.tf
+++ b/sample.tf
@@ -669,6 +669,7 @@ resource "artifactory_federated_generic_repository" "generic-federated-1" {
 resource "artifactory_artifact_webhook" "artifact-webhook" {
   key         = "artifact-webhook"
   event_types = ["deployed", "deleted", "moved", "copied"]
+
   criteria {
     any_local        = true
     any_remote       = false
@@ -676,13 +677,16 @@ resource "artifactory_artifact_webhook" "artifact-webhook" {
     include_patterns = ["foo/**"]
     exclude_patterns = ["bar/**"]
   }
-  url    = "http://tempurl.org/webhook"
-  secret = "some-secret"
-  proxy  = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 
   depends_on = [artifactory_local_maven_repository.maven-local]
@@ -691,6 +695,7 @@ resource "artifactory_artifact_webhook" "artifact-webhook" {
 resource "artifactory_artifact_property_webhook" "artifact-property-webhook" {
   key         = "artifact-prop-webhook"
   event_types = ["added", "deleted"]
+
   criteria {
     any_local        = true
     any_remote       = false
@@ -698,13 +703,16 @@ resource "artifactory_artifact_property_webhook" "artifact-property-webhook" {
     include_patterns = ["foo/**"]
     exclude_patterns = ["bar/**"]
   }
-  url    = "http://tempurl.org/webhook"
-  secret = "some-secret"
-  proxy  = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 
   depends_on = [artifactory_local_maven_repository.maven-local]
@@ -713,6 +721,7 @@ resource "artifactory_artifact_property_webhook" "artifact-property-webhook" {
 resource "artifactory_docker_webhook" "docker-webhook" {
   key         = "docker-webhook"
   event_types = ["pushed", "deleted", "promoted"]
+
   criteria {
     any_local        = true
     any_remote       = false
@@ -720,13 +729,16 @@ resource "artifactory_docker_webhook" "docker-webhook" {
     include_patterns = ["foo/**"]
     exclude_patterns = ["bar/**"]
   }
-  url    = "http://tempurl.org/webhook"
-  secret = "some-secret"
-  proxy  = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 
   depends_on = [artifactory_local_docker_v2_repository.docker-v2-local]
@@ -735,38 +747,46 @@ resource "artifactory_docker_webhook" "docker-webhook" {
 resource "artifactory_build_webhook" "build-webhook" {
   key         = "build-webhook"
   event_types = ["uploaded", "deleted", "promoted"]
+
   criteria {
     any_build        = false
     selected_builds  = ["build-id"]
     include_patterns = ["foo/**"]
     exclude_patterns = ["bar/**"]
   }
-  url    = "http://tempurl.org/webhook"
-  secret = "some-secret"
-  proxy  = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 }
 
 resource "artifactory_release_bundle_webhook" "release-bundle-webhook" {
   key         = "release-bundle-webhook"
   event_types = ["created", "signed", "deleted"]
+
   criteria {
     any_release_bundle              = false
     registered_release_bundle_names = ["release-bundle-name"]
     include_patterns                = ["foo/**"]
     exclude_patterns                = ["bar/**"]
   }
-  url    = "http://tempurl.org/webhook"
-  secret = "some-secret"
-  proxy  = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 }
 
@@ -780,37 +800,45 @@ resource "artifactory_distribution_webhook" "release-distribution-webhook" {
     "delete_completed",
     "delete_failed"
   ]
+
   criteria {
     any_release_bundle              = false
     registered_release_bundle_names = ["release-bundle-name"]
     include_patterns                = ["foo/**"]
     exclude_patterns                = ["bar/**"]
   }
-  url    = "http://tempurl.org/webhook"
-  secret = "some-secret"
-  proxy  = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 }
 
 resource "artifactory_artifactory_release_bundle_webhook" "release-distribution-webhook" {
   key         = "artifactory-release-bundle-webhook"
   event_types = ["received", "delete_started", "delete_completed", "delete_failed"]
+
   criteria {
     any_release_bundle              = false
     registered_release_bundle_names = ["release-bundle-name"]
     include_patterns                = ["foo/**"]
     exclude_patterns                = ["bar/**"]
   }
-  url    = "http://tempurl.org/webhook"
-  secret = "some-secret"
-  proxy  = "proxy-key"
 
-  custom_http_headers = {
-    header-1 = "value-1"
-    header-2 = "value-2"
+  handler {
+    url    = "http://tempurl.org/webhook"
+    secret = "some-secret"
+    proxy  = "proxy-key"
+
+    custom_http_headers = {
+      header-1 = "value-1"
+      header-2 = "value-2"
+    }
   }
 }


### PR DESCRIPTION
Fixes #439 

- Add support for multiple handler for webhook
- Add `StateUpgrader` func to migrate from v1 schema to v2 schema automatically