### PR TITLE
GH-455 fix license checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.6.2 (May 11, 2022)
+
+BUG FIXES:
+
+* provider: Fix license checking only works with 'Enterprise' license type. PR: [#456](https://github.com/jfrog/terraform-provider-artifactory/pull/456). Issue [#455](https://github.com/jfrog/terraform-provider-artifactory/issues/455)
+
 ## 6.6.1 (May 5, 2022). Tested on Artifactory 7.37.16
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.6.2 (May 11, 2022)
+## 6.6.2 (May 11, 2022). Tested on Artifactory 7.38.8
 
 BUG FIXES:
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jfrog/terraform-provider-artifactory/v6
 
-replace github.com/jfrog/terraform-provider-shared => ../terraform-provider-shared
+// replace github.com/jfrog/terraform-provider-shared => ../terraform-provider-shared
 
 require (
 	github.com/go-resty/resty/v2 v2.7.0

--- a/go.mod
+++ b/go.mod
@@ -1,12 +1,14 @@
 module github.com/jfrog/terraform-provider-artifactory/v6
 
+replace github.com/jfrog/terraform-provider-shared => ../terraform-provider-shared
+
 require (
 	github.com/go-resty/resty/v2 v2.7.0
 	github.com/google/go-querystring v1.1.0
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-log v0.3.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.14.0
-	github.com/jfrog/terraform-provider-shared v0.5.0
+	github.com/jfrog/terraform-provider-shared v0.7.0
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v0.5.0 h1:1TEHe3ZkLSNBcxcQ5Ba9X05WiXJpbScRR7eaeXW00CA=
-github.com/jfrog/terraform-provider-shared v0.5.0/go.mod h1:2ueIlfizwfDAkL1jm3hmvYBqbMusQtHz33ZpDiPOyxA=
+github.com/jfrog/terraform-provider-shared v0.7.0 h1:x8qLXyptP35KC1vLaqN2AWJC7/eMNZE2jabiBx07JSY=
+github.com/jfrog/terraform-provider-shared v0.7.0/go.mod h1:2ueIlfizwfDAkL1jm3hmvYBqbMusQtHz33ZpDiPOyxA=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/pkg/artifactory/provider/provider.go
+++ b/pkg/artifactory/provider/provider.go
@@ -196,7 +196,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVer
 
 	checkLicense := d.Get("check_license").(bool)
 	if checkLicense {
-		licenseErr := util.CheckArtifactoryLicense(restyBase)
+		licenseErr := util.CheckArtifactoryLicense(restyBase, "Enterprise", "Commercial", "Edge")
 		if licenseErr != nil {
 			return nil, licenseErr
 		}


### PR DESCRIPTION
Fixes #455

Uses updated `CheckArtifactoryLicense()` in https://github.com/jfrog/terraform-provider-shared/pull/11

Tested through using Charles' rewrite feature and overwrite the API response to contain either `Enterprise`, `Commercial`, or `Edge` license type in the payload.