### PR TITLE
GH-431 federated repos not type specific

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.7.1 (May 13, 2022)
+
+BUG FIXES:
+
+* resource/artifactory_federated_*_repository: Fix attributes from corresponding local repository were not used. PR: [#458](https://github.com/jfrog/terraform-provider-artifactory/pull/458). Issue [#431](https://github.com/jfrog/terraform-provider-artifactory/issues/431)
+
 ## 6.7.0 (May 12, 2022). Tested on Artifactory 7.38.8
 
 IMPROVEMENTS:

--- a/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_generic_repository.go
+++ b/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_generic_repository.go
@@ -11,8 +11,9 @@ import (
 )
 
 func ResourceArtifactoryFederatedGenericRepository(repoType string) *schema.Resource {
+	localRepoSchema := local.GetSchemaByRepoType(repoType)
 
-	var federatedSchema = util.MergeSchema(local.BaseLocalRepoSchema, map[string]*schema.Schema{
+	var federatedSchema = util.MergeSchema(localRepoSchema, map[string]*schema.Schema{
 		"member": {
 			Type:     schema.TypeSet,
 			Required: true,

--- a/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_repository_test.go
+++ b/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_repository_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/federated"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/security"
 	"github.com/jfrog/terraform-provider-shared/test"
 )
 
@@ -235,6 +236,629 @@ func TestAccFederatedRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 			{
 				Config:      federatedRepositoryConfig,
 				ExpectError: regexp.MustCompile(".*project_key must be 3 - 10 lowercase alphanumeric characters"),
+			},
+		},
+	})
+}
+
+func TestAccFederatedAlpineRepository(t *testing.T) {
+	_, fqrn, name := acctest.MkNames("terraform-federated-test-repo-basic", "artifactory_federated_alpine_repository")
+	kpId, kpFqrn, kpName := acctest.MkNames("some-keypair", "artifactory_keypair")
+
+	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", acctest.GetArtifactoryUrl(t), name)
+
+	federatedRepositoryBasic := acctest.ExecuteTemplate("keypair", `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+		-----BEGIN RSA PRIVATE KEY-----
+		MIIEpAIBAAKCAQEA2ymVc24BoaZb0ElXoI3X4zUKJGZEetR6F4yT1tJhkPDg7UTm
+		iNoFB5TZJvP6LBrrSwszkpZbxaVOkBrwrGbqFUaXPgud8VabfHl0imXvN746zmpj
+		YEMGqJzm+Gh6aBWOlnPdLuHhds/kcanFAEppj5yN0tVWDnqjOJjR7EpxMSdP3TSd
+		6tNAY73LGNLNJQc6tSxh8nMIb4HhSWQSgfof+FwcLGvs+mmyBq8Jz5Zy4BSCk1fQ
+		FmCnSGyzpyBD0vMd6eLHk2l0tm56DrlonbDMX8KGs7e9ZgjANkT5PnipLOaeLJU4
+		H+OWyBZUAT4hl/iRVvLwV81x7g0/O38kmPYJDQIDAQABAoIBAFb7wyhEIfuhhlE9
+		uryrb2LrGzJlMIq7qBWOouKhLz4SjIM/VGw+c76VkjZGoSU+LeLj+D0W1ie0u2Cw
+		gJM8aW22TbK/c5lksWOO5PVFDdPG+ZoRWY3MLGlhlL5E4UhMPgJyy/eeiRjZ3CZM
+		pja+UfVAwn1KVNR8UinVZYPt680AvEd1FGxoNLxemIPNug46nNqp6Al86Bn+BnkN
+		GXpwyooXVSfo4k+pnFBFIXUdA1dUEXQSVb1AxlTo6g/Ok/+8Gfq8idCdu+5fcZI2
+		1eLeC+FAa92rr1SFX/UWeB4cMyuAqwuxbFFIplT22SaUSsNuOUSH4E00nbP/AuCb
+		1BqrLmECgYEA7tQKfyF9aiXTsOMdOnSAa5OyEaCfsFtcmLd4ykVrwN8O36NoX005
+		VbGuqo87fwIXQIKHU+kOEs/TmaQ8bNcbCD/SfWGTtOnHG4qfIsepJuoMwbQHRhGF
+		JeoXh5yEUKg5pcDBY8PENEtEVKmFuL4bPOdn+9FNLGsjftvXpmGWbGUCgYEA6uuQ
+		7kzO6WD88OsxdJzlJM11hg2SaSBCh3+5tnOhF1ULOUt4tdYXzh3QI6BPX7tkArYf
+		XteVfWoWqn6T7LtCjFm350BqVpPhqfLKnt6fYf1yotsj/cyZXlXquRbxbgakB0n0
+		4PrsZaube0TPPVeirzNyOVHyFc+iW+F+IUYD+4kCgYEApDEjBkP/9PoMj4+UiJuP
+		rmXcBkJnhtdI0bVRVb5kVjUEBLxTBTISONfvPVM7lBXb5n3Wi9mt00EOOJKw+CLq
+		csFt9MUgxz/xov2qaj7aC+bc3k7msUVaRLardpAkZ09AUrQyQGRWf50/XPUu+dO4
+		5iYxVu6OH/uIa664k6qDwAECgYEAslS8oomgEL3VhbWkx1dLA5MMggTPfgpFNsMY
+		4Y4JXcLrUEUgjzjEvW0YUdMiLhP8qapDSiXxj1D3f9myxWSp8g0xc9UMZEjCZ9at
+		RcjNyP8zBLnCKqokSt6B3puyDsnvvrC/ugIBbnTFBOCJSZG7J7CwJx8z3KbQI1ub
+		+fpCj7ECgYAd69soLEybUGMjsdI+OijIGoUTUoZGXJm+0VpBt4QJCe7AMnYPfYzA
+		JnEmN4D7HLTKUBklQnb/FhP/RuiT2bSAd1l+PNeuU7gYROCBBonzxXQ1wEbNrSYA
+		iyoc9g/kvV8HTW8361xEhu7wmuSEEx1gQ/7sdhTkgrTncc8hxVRxuA==
+		-----END RSA PRIVATE KEY-----
+		EOF
+			public_key = <<EOF
+		-----BEGIN PUBLIC KEY-----
+		MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2ymVc24BoaZb0ElXoI3X
+		4zUKJGZEetR6F4yT1tJhkPDg7UTmiNoFB5TZJvP6LBrrSwszkpZbxaVOkBrwrGbq
+		FUaXPgud8VabfHl0imXvN746zmpjYEMGqJzm+Gh6aBWOlnPdLuHhds/kcanFAEpp
+		j5yN0tVWDnqjOJjR7EpxMSdP3TSd6tNAY73LGNLNJQc6tSxh8nMIb4HhSWQSgfof
+		+FwcLGvs+mmyBq8Jz5Zy4BSCk1fQFmCnSGyzpyBD0vMd6eLHk2l0tm56DrlonbDM
+		X8KGs7e9ZgjANkT5PnipLOaeLJU4H+OWyBZUAT4hl/iRVvLwV81x7g0/O38kmPYJ
+		DQIDAQAB
+		-----END PUBLIC KEY-----
+		EOF
+			lifecycle {
+				ignore_changes = [
+					private_key,
+					passphrase,
+				]
+			}
+		}
+		resource "artifactory_federated_alpine_repository" "{{ .repo_name }}" {
+			key 	            = "{{ .repo_name }}"
+			primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+
+			member {
+				url     = "{{ .memberUrl }}"
+				enabled = true
+			}
+
+			depends_on = [artifactory_keypair.{{ .kp_name }}]
+		}
+	`, map[string]interface{}{
+		"kp_id":     kpId,
+		"kp_name":   kpName,
+		"repo_name": name,
+		"memberUrl": federatedMemberUrl,
+	}) // we use randomness so that, in the case of failure and dangle, the next test can run without collision
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
+			acctest.VerifyDeleted(kpFqrn, security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: federatedRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "alpine"),
+					resource.TestCheckResourceAttr(fqrn, "primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("federated", "alpine")(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+				),
+			},
+		},
+	})
+}
+
+func TestAccFederatedCargoRepository(t *testing.T) {
+	_, fqrn, name := acctest.MkNames("cargo-local", "artifactory_federated_cargo_repository")
+	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", acctest.GetArtifactoryUrl(t), name)
+
+	params := map[string]interface{}{
+		"anonymous_access": test.RandBool(),
+		"name":             name,
+		"memberUrl":        federatedMemberUrl,
+	}
+	federatedRepositoryBasic := acctest.ExecuteTemplate("TestAccFederatedCargoRepository", `
+		resource "artifactory_federated_cargo_repository" "{{ .name }}" {
+			key              = "{{ .name }}"
+			anonymous_access = {{ .anonymous_access }}
+			member {
+				url     = "{{ .memberUrl }}"
+				enabled = true
+			}
+		}
+	`, params)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: federatedRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "anonymous_access", fmt.Sprintf("%t", params["anonymous_access"])),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("federated", "cargo")(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+				),
+			},
+		},
+	})
+}
+
+func TestAccFederatedDebianRepository(t *testing.T) {
+	_, fqrn, name := acctest.MkNames("federated-debian-repo", "artifactory_federated_debian_repository")
+	kpId, kpFqrn, kpName := acctest.MkNames("some-keypair1", "artifactory_keypair")
+	kpId2, kpFqrn2, kpName2 := acctest.MkNames("some-keypair2", "artifactory_keypair")
+
+	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", acctest.GetArtifactoryUrl(t), name)
+
+	federatedRepositoryBasic := acctest.ExecuteTemplate("keypair", `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "GPG"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+		-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+		lIYEYYU7tRYJKwYBBAHaRw8BAQdAZ8vVdEyrWGssb7cdreG5GDGv6taHX/vWQdDG
+		jn7zib/+BwMCFjb4odY28+n0NWj7KZ53BkA0qzzqT9IpIfsW/tLNPTxYEFrDVbcF
+		1CuiAgAhyUfBEr9HQaMJBLfIIvo/B3nlWvwWHkiQFuWpsnJ2pj8F8LQqQ2hyaXN0
+		aWFuIEJvbmdpb3JubyA8Y2hyaXN0aWFuYkBqZnJvZy5jb20+iJoEExYKAEIWIQSS
+		w8jt+9pdVC3Gts7AvzSEkhHbJAUCYYU7tQIbAwUJA8JnAAULCQgHAgMiAgEGFQoJ
+		CAsCBBYCAwECHgcCF4AACgkQwL80hJIR2yRQDgD/X1t/hW9+uXdSY59FOClhQw/t
+		AzTYjDW+KLKadYJ3RAIBALD53rj7EnrXsSqv9Vqj3mJ7O38eXu50P57tD8ErpHMD
+		nIsEYYU7tRIKKwYBBAGXVQEFAQEHQCfT+jXHVkslGAJqVafoeWO8Nwz/oPPzNDJb
+		EOASsMRcAwEIB/4HAwK+Wi8OaidLuvQ6yknLUspoRL8KJlQu0JkfLxj6Wl6GrRtf
+		MdUBxaGUQX5UzMIqyYstgHKz2kBYvrJijWdOkkRuL82FySSh4yi/97FBikOBiHgE
+		GBYKACAWIQSSw8jt+9pdVC3Gts7AvzSEkhHbJAUCYYU7tQIbDAAKCRDAvzSEkhHb
+		JNR/AQCQjGWljmP8pYj6ohP8bOwVB4VE5qxjdfWQvBCUA0LFwgEAxLGVeT88pw3+
+		x7Cwd7SsuxlIOOCIJssFnUhA9Qsq2wE=
+		=qCzy
+		-----END PGP PRIVATE KEY BLOCK-----
+		EOF
+			public_key = <<EOF
+		-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+		mDMEYYU7tRYJKwYBBAHaRw8BAQdAZ8vVdEyrWGssb7cdreG5GDGv6taHX/vWQdDG
+		jn7zib+0KkNocmlzdGlhbiBCb25naW9ybm8gPGNocmlzdGlhbmJAamZyb2cuY29t
+		PoiaBBMWCgBCFiEEksPI7fvaXVQtxrbOwL80hJIR2yQFAmGFO7UCGwMFCQPCZwAF
+		CwkIBwIDIgIBBhUKCQgLAgQWAgMBAh4HAheAAAoJEMC/NISSEdskUA4A/19bf4Vv
+		frl3UmOfRTgpYUMP7QM02Iw1viiymnWCd0QCAQCw+d64+xJ617Eqr/Vao95iezt/
+		Hl7udD+e7Q/BK6RzA7g4BGGFO7USCisGAQQBl1UBBQEBB0An0/o1x1ZLJRgCalWn
+		6HljvDcM/6Dz8zQyWxDgErDEXAMBCAeIeAQYFgoAIBYhBJLDyO372l1ULca2zsC/
+		NISSEdskBQJhhTu1AhsMAAoJEMC/NISSEdsk1H8BAJCMZaWOY/yliPqiE/xs7BUH
+		hUTmrGN19ZC8EJQDQsXCAQDEsZV5PzynDf7HsLB3tKy7GUg44IgmywWdSED1Cyrb
+		AQ==
+		=2kMe
+		-----END PGP PUBLIC KEY BLOCK-----
+		EOF
+			lifecycle {
+				ignore_changes = [
+					private_key,
+					passphrase,
+				]
+			}
+		}
+		resource "artifactory_keypair" "{{ .kp_name2 }}" {
+			pair_name  = "{{ .kp_name2 }}"
+			pair_type = "GPG"
+			alias = "foo-alias{{ .kp_id2 }}"
+			private_key = <<EOF
+		-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+		lIYEYYU7tRYJKwYBBAHaRw8BAQdAZ8vVdEyrWGssb7cdreG5GDGv6taHX/vWQdDG
+		jn7zib/+BwMCFjb4odY28+n0NWj7KZ53BkA0qzzqT9IpIfsW/tLNPTxYEFrDVbcF
+		1CuiAgAhyUfBEr9HQaMJBLfIIvo/B3nlWvwWHkiQFuWpsnJ2pj8F8LQqQ2hyaXN0
+		aWFuIEJvbmdpb3JubyA8Y2hyaXN0aWFuYkBqZnJvZy5jb20+iJoEExYKAEIWIQSS
+		w8jt+9pdVC3Gts7AvzSEkhHbJAUCYYU7tQIbAwUJA8JnAAULCQgHAgMiAgEGFQoJ
+		CAsCBBYCAwECHgcCF4AACgkQwL80hJIR2yRQDgD/X1t/hW9+uXdSY59FOClhQw/t
+		AzTYjDW+KLKadYJ3RAIBALD53rj7EnrXsSqv9Vqj3mJ7O38eXu50P57tD8ErpHMD
+		nIsEYYU7tRIKKwYBBAGXVQEFAQEHQCfT+jXHVkslGAJqVafoeWO8Nwz/oPPzNDJb
+		EOASsMRcAwEIB/4HAwK+Wi8OaidLuvQ6yknLUspoRL8KJlQu0JkfLxj6Wl6GrRtf
+		MdUBxaGUQX5UzMIqyYstgHKz2kBYvrJijWdOkkRuL82FySSh4yi/97FBikOBiHgE
+		GBYKACAWIQSSw8jt+9pdVC3Gts7AvzSEkhHbJAUCYYU7tQIbDAAKCRDAvzSEkhHb
+		JNR/AQCQjGWljmP8pYj6ohP8bOwVB4VE5qxjdfWQvBCUA0LFwgEAxLGVeT88pw3+
+		x7Cwd7SsuxlIOOCIJssFnUhA9Qsq2wE=
+		=qCzy
+		-----END PGP PRIVATE KEY BLOCK-----
+		EOF
+			public_key = <<EOF
+		-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+		mDMEYYU7tRYJKwYBBAHaRw8BAQdAZ8vVdEyrWGssb7cdreG5GDGv6taHX/vWQdDG
+		jn7zib+0KkNocmlzdGlhbiBCb25naW9ybm8gPGNocmlzdGlhbmJAamZyb2cuY29t
+		PoiaBBMWCgBCFiEEksPI7fvaXVQtxrbOwL80hJIR2yQFAmGFO7UCGwMFCQPCZwAF
+		CwkIBwIDIgIBBhUKCQgLAgQWAgMBAh4HAheAAAoJEMC/NISSEdskUA4A/19bf4Vv
+		frl3UmOfRTgpYUMP7QM02Iw1viiymnWCd0QCAQCw+d64+xJ617Eqr/Vao95iezt/
+		Hl7udD+e7Q/BK6RzA7g4BGGFO7USCisGAQQBl1UBBQEBB0An0/o1x1ZLJRgCalWn
+		6HljvDcM/6Dz8zQyWxDgErDEXAMBCAeIeAQYFgoAIBYhBJLDyO372l1ULca2zsC/
+		NISSEdskBQJhhTu1AhsMAAoJEMC/NISSEdsk1H8BAJCMZaWOY/yliPqiE/xs7BUH
+		hUTmrGN19ZC8EJQDQsXCAQDEsZV5PzynDf7HsLB3tKy7GUg44IgmywWdSED1Cyrb
+		AQ==
+		=2kMe
+		-----END PGP PUBLIC KEY BLOCK-----
+		EOF
+			lifecycle {
+				ignore_changes = [
+					private_key,
+					passphrase,
+				]
+			}
+		}
+		resource "artifactory_federated_debian_repository" "{{ .repo_name }}" {
+			key 	                  = "{{ .repo_name }}"
+			primary_keypair_ref       = artifactory_keypair.{{ .kp_name }}.pair_name
+			secondary_keypair_ref     = artifactory_keypair.{{ .kp_name2 }}.pair_name
+			index_compression_formats = ["bz2","lzma","xz"]
+			trivial_layout            = true
+
+			member {
+				url     = "{{ .memberUrl }}"
+				enabled = true
+			}
+
+			depends_on = [
+				artifactory_keypair.{{ .kp_name }},
+				artifactory_keypair.{{ .kp_name2 }},
+			]
+		}
+	`, map[string]interface{}{
+		"kp_id":     kpId,
+		"kp_name":   kpName,
+		"kp_id2":    kpId2,
+		"kp_name2":  kpName2,
+		"repo_name": name,
+		"memberUrl": federatedMemberUrl,
+	}) // we use randomness so that, in the case of failure and dangle, the next test can run without collision
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
+			acctest.VerifyDeleted(kpFqrn, security.VerifyKeyPair),
+			acctest.VerifyDeleted(kpFqrn2, security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: federatedRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "debian"),
+					resource.TestCheckResourceAttr(fqrn, "primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "secondary_keypair_ref", kpName2),
+					resource.TestCheckResourceAttr(fqrn, "trivial_layout", "true"),
+					resource.TestCheckResourceAttr(fqrn, "index_compression_formats.0", "bz2"),
+					resource.TestCheckResourceAttr(fqrn, "index_compression_formats.1", "lzma"),
+					resource.TestCheckResourceAttr(fqrn, "index_compression_formats.2", "xz"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("federated", "debian")(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+				),
+			},
+		},
+	})
+}
+
+func TestAccFederatedDockerRepository(t *testing.T) {
+	_, fqrn, name := acctest.MkNames("docker-federated", "artifactory_federated_docker_repository")
+	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", acctest.GetArtifactoryUrl(t), name)
+
+	params := map[string]interface{}{
+		"block":      test.RandBool(),
+		"retention":  test.RandSelect(1, 5, 10),
+		"max_tags":   test.RandSelect(0, 5, 10),
+		"name":       name,
+		"memberUrl":  federatedMemberUrl,
+	}
+	federatedRepositoryBasic := acctest.ExecuteTemplate("TestAccFederatedDockerRepository", `
+		resource "artifactory_federated_docker_repository" "{{ .name }}" {
+			key 	               = "{{ .name }}"
+			tag_retention          = {{ .retention }}
+			max_unique_tags       = {{ .max_tags }}
+			block_pushing_schema1 = {{ .block }}
+
+			member {
+				url     = "{{ .memberUrl }}"
+				enabled = true
+			}
+		}
+	`, params)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: federatedRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "block_pushing_schema1", fmt.Sprintf("%t", params["block"])),
+					resource.TestCheckResourceAttr(fqrn, "tag_retention", fmt.Sprintf("%d", params["retention"])),
+					resource.TestCheckResourceAttr(fqrn, "max_unique_tags", fmt.Sprintf("%d", params["max_tags"])),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("federated", "docker")(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+				),
+			},
+		},
+	})
+}
+
+func TestAccFederatedNugetRepository(t *testing.T) {
+	_, fqrn, name := acctest.MkNames("nuget-local", "artifactory_federated_nuget_repository")
+	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", acctest.GetArtifactoryUrl(t), name)
+
+	params := map[string]interface{}{
+		"force_nuget_authentication": test.RandBool(),
+		"max_unique_snapshots":       test.RandSelect(0, 5, 10),
+		"name":                       name,
+		"memberUrl":                  federatedMemberUrl,
+	}
+	federatedRepositoryBasic := acctest.ExecuteTemplate("TestAccLocalNugetRepository", `
+		resource "artifactory_federated_nuget_repository" "{{ .name }}" {
+			key                        = "{{ .name }}"
+			max_unique_snapshots       = {{ .max_unique_snapshots }}
+			force_nuget_authentication = {{ .force_nuget_authentication }}
+			member {
+				url     = "{{ .memberUrl }}"
+				enabled = true
+			}
+		}
+	`, params)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: federatedRepositoryBasic,
+				Check:  resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "max_unique_snapshots", fmt.Sprintf("%d", params["max_unique_snapshots"])),
+					resource.TestCheckResourceAttr(fqrn, "force_nuget_authentication", fmt.Sprintf("%t", params["force_nuget_authentication"])),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("federated", "nuget")(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+				),
+			},
+		},
+	})
+}
+
+var commonJavaParams = map[string]interface{}{
+	"name":                            "",
+	"checksum_policy_type":            "client-checksums",
+	"snapshot_version_behavior":       "unique",
+	"max_unique_snapshots":            test.RandSelect(0, 5, 10),
+	"handle_releases":                 true,
+	"handle_snapshots":                true,
+	"suppress_pom_consistency_checks": false,
+}
+
+const federatedJavaRepositoryBasic = `
+	resource "{{ .resource_name }}" "{{ .name }}" {
+		key                             = "{{ .name }}"
+		checksum_policy_type            = "{{ .checksum_policy_type }}"
+		snapshot_version_behavior       = "{{ .snapshot_version_behavior }}"
+		max_unique_snapshots            = {{ .max_unique_snapshots }}
+		handle_releases                 = {{ .handle_releases }}
+		handle_snapshots                = {{ .handle_snapshots }}
+		suppress_pom_consistency_checks = {{ .suppress_pom_consistency_checks }}
+		member {
+			url     = "{{ .memberUrl }}"
+			enabled = true
+		}
+	}
+`
+
+func TestAccFederatedMavenRepository(t *testing.T) {
+	_, fqrn, name := acctest.MkNames("maven-federated", "artifactory_federated_maven_repository")
+	tempStruct := make(map[string]interface{})
+	acctest.CopyInterfaceMap(commonJavaParams, tempStruct)
+
+	tempStruct["name"] = name
+	tempStruct["resource_name"] = strings.Split(fqrn, ".")[0]
+	tempStruct["suppress_pom_consistency_checks"] = false
+	tempStruct["memberUrl"] = fmt.Sprintf("%s/artifactory/%s", acctest.GetArtifactoryUrl(t), name)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ExecuteTemplate(fqrn, federatedJavaRepositoryBasic, tempStruct),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "checksum_policy_type", fmt.Sprintf("%s", tempStruct["checksum_policy_type"])),
+					resource.TestCheckResourceAttr(fqrn, "snapshot_version_behavior", fmt.Sprintf("%s", tempStruct["snapshot_version_behavior"])),
+					resource.TestCheckResourceAttr(fqrn, "max_unique_snapshots", fmt.Sprintf("%d", tempStruct["max_unique_snapshots"])),
+					resource.TestCheckResourceAttr(fqrn, "handle_releases", fmt.Sprintf("%v", tempStruct["handle_releases"])),
+					resource.TestCheckResourceAttr(fqrn, "handle_snapshots", fmt.Sprintf("%v", tempStruct["handle_snapshots"])),
+					resource.TestCheckResourceAttr(fqrn, "suppress_pom_consistency_checks", fmt.Sprintf("%v", tempStruct["suppress_pom_consistency_checks"])),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("federated", "maven")(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+				),
+			},
+		},
+	})
+}
+
+func makeFederatedGradleLikeRepoTestCase(repoType string, t *testing.T) (*testing.T, resource.TestCase) {
+	name := fmt.Sprintf("%s-federated", repoType)
+	resourceName := fmt.Sprintf("artifactory_federated_%s_repository", repoType)
+	_, fqrn, name := acctest.MkNames(name, resourceName)
+	tempStruct := make(map[string]interface{})
+	acctest.CopyInterfaceMap(commonJavaParams, tempStruct)
+
+	tempStruct["name"] = name
+	tempStruct["resource_name"] = strings.Split(fqrn, ".")[0]
+	tempStruct["suppress_pom_consistency_checks"] = true
+	tempStruct["memberUrl"] = fmt.Sprintf("%s/artifactory/%s", acctest.GetArtifactoryUrl(t), name)
+
+	return t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: acctest.ExecuteTemplate(fqrn, federatedJavaRepositoryBasic, tempStruct),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "checksum_policy_type", fmt.Sprintf("%s", tempStruct["checksum_policy_type"])),
+					resource.TestCheckResourceAttr(fqrn, "snapshot_version_behavior", fmt.Sprintf("%s", tempStruct["snapshot_version_behavior"])),
+					resource.TestCheckResourceAttr(fqrn, "max_unique_snapshots", fmt.Sprintf("%d", tempStruct["max_unique_snapshots"])),
+					resource.TestCheckResourceAttr(fqrn, "handle_releases", fmt.Sprintf("%v", tempStruct["handle_releases"])),
+					resource.TestCheckResourceAttr(fqrn, "handle_snapshots", fmt.Sprintf("%v", tempStruct["handle_snapshots"])),
+					resource.TestCheckResourceAttr(fqrn, "suppress_pom_consistency_checks", fmt.Sprintf("%v", tempStruct["suppress_pom_consistency_checks"])),
+				),
+			},
+		},
+	}
+}
+
+func TestAccFederatedAllGradleLikeRepoTypes(t *testing.T) {
+	for _, repoType := range repository.GradleLikeRepoTypes {
+		t.Run(fmt.Sprintf("TestFederated%sRepo", strings.Title(strings.ToLower(repoType))), func(t *testing.T) {
+			resource.Test(makeFederatedGradleLikeRepoTestCase(repoType, t))
+		})
+	}
+}
+
+func TestAccFederatedRpmRepository(t *testing.T) {
+	_, fqrn, name := acctest.MkNames("federated-rpm-repo", "artifactory_federated_rpm_repository")
+	kpId, kpFqrn, kpName := acctest.MkNames("some-keypair1", "artifactory_keypair")
+	kpId2, kpFqrn2, kpName2 := acctest.MkNames("some-keypair2", "artifactory_keypair")
+
+	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", acctest.GetArtifactoryUrl(t), name)
+
+	federatedRepositoryBasic := acctest.ExecuteTemplate("keypair", `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "GPG"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+		-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+		lIYEYYU7tRYJKwYBBAHaRw8BAQdAZ8vVdEyrWGssb7cdreG5GDGv6taHX/vWQdDG
+		jn7zib/+BwMCFjb4odY28+n0NWj7KZ53BkA0qzzqT9IpIfsW/tLNPTxYEFrDVbcF
+		1CuiAgAhyUfBEr9HQaMJBLfIIvo/B3nlWvwWHkiQFuWpsnJ2pj8F8LQqQ2hyaXN0
+		aWFuIEJvbmdpb3JubyA8Y2hyaXN0aWFuYkBqZnJvZy5jb20+iJoEExYKAEIWIQSS
+		w8jt+9pdVC3Gts7AvzSEkhHbJAUCYYU7tQIbAwUJA8JnAAULCQgHAgMiAgEGFQoJ
+		CAsCBBYCAwECHgcCF4AACgkQwL80hJIR2yRQDgD/X1t/hW9+uXdSY59FOClhQw/t
+		AzTYjDW+KLKadYJ3RAIBALD53rj7EnrXsSqv9Vqj3mJ7O38eXu50P57tD8ErpHMD
+		nIsEYYU7tRIKKwYBBAGXVQEFAQEHQCfT+jXHVkslGAJqVafoeWO8Nwz/oPPzNDJb
+		EOASsMRcAwEIB/4HAwK+Wi8OaidLuvQ6yknLUspoRL8KJlQu0JkfLxj6Wl6GrRtf
+		MdUBxaGUQX5UzMIqyYstgHKz2kBYvrJijWdOkkRuL82FySSh4yi/97FBikOBiHgE
+		GBYKACAWIQSSw8jt+9pdVC3Gts7AvzSEkhHbJAUCYYU7tQIbDAAKCRDAvzSEkhHb
+		JNR/AQCQjGWljmP8pYj6ohP8bOwVB4VE5qxjdfWQvBCUA0LFwgEAxLGVeT88pw3+
+		x7Cwd7SsuxlIOOCIJssFnUhA9Qsq2wE=
+		=qCzy
+		-----END PGP PRIVATE KEY BLOCK-----
+		EOF
+			public_key = <<EOF
+		-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+		mDMEYYU7tRYJKwYBBAHaRw8BAQdAZ8vVdEyrWGssb7cdreG5GDGv6taHX/vWQdDG
+		jn7zib+0KkNocmlzdGlhbiBCb25naW9ybm8gPGNocmlzdGlhbmJAamZyb2cuY29t
+		PoiaBBMWCgBCFiEEksPI7fvaXVQtxrbOwL80hJIR2yQFAmGFO7UCGwMFCQPCZwAF
+		CwkIBwIDIgIBBhUKCQgLAgQWAgMBAh4HAheAAAoJEMC/NISSEdskUA4A/19bf4Vv
+		frl3UmOfRTgpYUMP7QM02Iw1viiymnWCd0QCAQCw+d64+xJ617Eqr/Vao95iezt/
+		Hl7udD+e7Q/BK6RzA7g4BGGFO7USCisGAQQBl1UBBQEBB0An0/o1x1ZLJRgCalWn
+		6HljvDcM/6Dz8zQyWxDgErDEXAMBCAeIeAQYFgoAIBYhBJLDyO372l1ULca2zsC/
+		NISSEdskBQJhhTu1AhsMAAoJEMC/NISSEdsk1H8BAJCMZaWOY/yliPqiE/xs7BUH
+		hUTmrGN19ZC8EJQDQsXCAQDEsZV5PzynDf7HsLB3tKy7GUg44IgmywWdSED1Cyrb
+		AQ==
+		=2kMe
+		-----END PGP PUBLIC KEY BLOCK-----
+		EOF
+			lifecycle {
+				ignore_changes = [
+					private_key,
+					passphrase,
+				]
+			}
+		}
+		resource "artifactory_keypair" "{{ .kp_name2 }}" {
+			pair_name  = "{{ .kp_name2 }}"
+			pair_type = "GPG"
+			alias = "foo-alias{{ .kp_id2 }}"
+			private_key = <<EOF
+		-----BEGIN PGP PRIVATE KEY BLOCK-----
+
+		lIYEYYU7tRYJKwYBBAHaRw8BAQdAZ8vVdEyrWGssb7cdreG5GDGv6taHX/vWQdDG
+		jn7zib/+BwMCFjb4odY28+n0NWj7KZ53BkA0qzzqT9IpIfsW/tLNPTxYEFrDVbcF
+		1CuiAgAhyUfBEr9HQaMJBLfIIvo/B3nlWvwWHkiQFuWpsnJ2pj8F8LQqQ2hyaXN0
+		aWFuIEJvbmdpb3JubyA8Y2hyaXN0aWFuYkBqZnJvZy5jb20+iJoEExYKAEIWIQSS
+		w8jt+9pdVC3Gts7AvzSEkhHbJAUCYYU7tQIbAwUJA8JnAAULCQgHAgMiAgEGFQoJ
+		CAsCBBYCAwECHgcCF4AACgkQwL80hJIR2yRQDgD/X1t/hW9+uXdSY59FOClhQw/t
+		AzTYjDW+KLKadYJ3RAIBALD53rj7EnrXsSqv9Vqj3mJ7O38eXu50P57tD8ErpHMD
+		nIsEYYU7tRIKKwYBBAGXVQEFAQEHQCfT+jXHVkslGAJqVafoeWO8Nwz/oPPzNDJb
+		EOASsMRcAwEIB/4HAwK+Wi8OaidLuvQ6yknLUspoRL8KJlQu0JkfLxj6Wl6GrRtf
+		MdUBxaGUQX5UzMIqyYstgHKz2kBYvrJijWdOkkRuL82FySSh4yi/97FBikOBiHgE
+		GBYKACAWIQSSw8jt+9pdVC3Gts7AvzSEkhHbJAUCYYU7tQIbDAAKCRDAvzSEkhHb
+		JNR/AQCQjGWljmP8pYj6ohP8bOwVB4VE5qxjdfWQvBCUA0LFwgEAxLGVeT88pw3+
+		x7Cwd7SsuxlIOOCIJssFnUhA9Qsq2wE=
+		=qCzy
+		-----END PGP PRIVATE KEY BLOCK-----
+		EOF
+			public_key = <<EOF
+		-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+		mDMEYYU7tRYJKwYBBAHaRw8BAQdAZ8vVdEyrWGssb7cdreG5GDGv6taHX/vWQdDG
+		jn7zib+0KkNocmlzdGlhbiBCb25naW9ybm8gPGNocmlzdGlhbmJAamZyb2cuY29t
+		PoiaBBMWCgBCFiEEksPI7fvaXVQtxrbOwL80hJIR2yQFAmGFO7UCGwMFCQPCZwAF
+		CwkIBwIDIgIBBhUKCQgLAgQWAgMBAh4HAheAAAoJEMC/NISSEdskUA4A/19bf4Vv
+		frl3UmOfRTgpYUMP7QM02Iw1viiymnWCd0QCAQCw+d64+xJ617Eqr/Vao95iezt/
+		Hl7udD+e7Q/BK6RzA7g4BGGFO7USCisGAQQBl1UBBQEBB0An0/o1x1ZLJRgCalWn
+		6HljvDcM/6Dz8zQyWxDgErDEXAMBCAeIeAQYFgoAIBYhBJLDyO372l1ULca2zsC/
+		NISSEdskBQJhhTu1AhsMAAoJEMC/NISSEdsk1H8BAJCMZaWOY/yliPqiE/xs7BUH
+		hUTmrGN19ZC8EJQDQsXCAQDEsZV5PzynDf7HsLB3tKy7GUg44IgmywWdSED1Cyrb
+		AQ==
+		=2kMe
+		-----END PGP PUBLIC KEY BLOCK-----
+		EOF
+			lifecycle {
+				ignore_changes = [
+					private_key,
+					passphrase,
+				]
+			}
+		}
+		resource "artifactory_federated_rpm_repository" "{{ .repo_name }}" {
+			key 	                   = "{{ .repo_name }}"
+			primary_keypair_ref        = artifactory_keypair.{{ .kp_name }}.pair_name
+			secondary_keypair_ref      = artifactory_keypair.{{ .kp_name2 }}.pair_name
+			yum_root_depth             = 1
+			enable_file_lists_indexing = true
+			calculate_yum_metadata     = true
+
+			member {
+				url     = "{{ .memberUrl }}"
+				enabled = true
+			}
+
+			depends_on = [
+				artifactory_keypair.{{ .kp_name }},
+				artifactory_keypair.{{ .kp_name2 }},
+			]
+		}
+	`, map[string]interface{}{
+		"kp_id":     kpId,
+		"kp_name":   kpName,
+		"kp_id2":    kpId2,
+		"kp_name2":  kpName2,
+		"repo_name": name,
+		"memberUrl": federatedMemberUrl,
+	}) // we use randomness so that, in the case of failure and dangle, the next test can run without collision
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
+			acctest.VerifyDeleted(kpFqrn, security.VerifyKeyPair),
+			acctest.VerifyDeleted(kpFqrn2, security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: federatedRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "rpm"),
+					resource.TestCheckResourceAttr(fqrn, "primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "secondary_keypair_ref", kpName2),
+					resource.TestCheckResourceAttr(fqrn, "enable_file_lists_indexing", "true"),
+					resource.TestCheckResourceAttr(fqrn, "calculate_yum_metadata", "true"),
+					resource.TestCheckResourceAttr(fqrn, "yum_root_depth", "1"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("federated", "rpm")(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+				),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/repository/local/local.go
+++ b/pkg/artifactory/resource/repository/local/local.go
@@ -163,3 +163,26 @@ func UnpackBaseRepo(rclassType string, s *schema.ResourceData, packageType strin
 		PriorityResolution:     d.GetBool("priority_resolution", false),
 	}
 }
+
+var schemaRepoTypeLookup = map[string]map[string]*schema.Schema {
+	"alpine": alpineLocalSchema,
+	"cargo":  cargoLocalSchema,
+	"debian": debianLocalSchema,
+	"docker": dockerV2LocalSchema,
+	"gradle": getJavaRepoSchema("gradle", true),
+	"ivy":    getJavaRepoSchema("ivy", false),
+	"maven":  getJavaRepoSchema("maven", false),
+	"nuget":  nugetLocalSchema,
+	"rpm":    rpmLocalSchema,
+	"sbt":    getJavaRepoSchema("sbt", false),
+}
+
+func init() {
+	for _, repoType := range RepoTypesLikeGeneric {
+		schemaRepoTypeLookup[repoType] = getGenericRepoSchema(repoType)
+	}
+}
+
+func GetSchemaByRepoType(repoType string) map[string]*schema.Schema {
+	return schemaRepoTypeLookup[repoType]
+}

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_alpine_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_alpine_repository.go
@@ -6,17 +6,16 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-func ResourceArtifactoryLocalAlpineRepository() *schema.Resource {
-	const packageType = "alpine"
+var alpineLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
+	"primary_keypair_ref": {
+		Type:     schema.TypeString,
+		Optional: true,
+		Description: "Used to sign index files in Alpine Linux repositories. " +
+			"See: https://www.jfrog.com/confluence/display/JFROG/Alpine+Linux+Repositories#AlpineLinuxRepositories-SigningAlpineLinuxIndex",
+	},
+}, repository.RepoLayoutRefSchema("local", "alpine"), repository.CompressionFormats)
 
-	var alpineLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-		"primary_keypair_ref": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Description: "Used to sign index files in Alpine Linux repositories. " +
-				"See: https://www.jfrog.com/confluence/display/JFROG/Alpine+Linux+Repositories#AlpineLinuxRepositories-SigningAlpineLinuxIndex",
-		},
-	}, repository.RepoLayoutRefSchema("local", packageType), repository.CompressionFormats)
+func ResourceArtifactoryLocalAlpineRepository() *schema.Resource {
 
 	type AlpineLocalRepo struct {
 		LocalRepositoryBaseParams
@@ -26,7 +25,7 @@ func ResourceArtifactoryLocalAlpineRepository() *schema.Resource {
 	var unPackLocalAlpineRepository = func(data *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: data}
 		repo := AlpineLocalRepo{
-			LocalRepositoryBaseParams: UnpackBaseRepo("local", data, packageType),
+			LocalRepositoryBaseParams: UnpackBaseRepo("local", data, "alpine"),
 			PrimaryKeyPairRef:         d.GetString("primary_keypair_ref", false),
 		}
 
@@ -36,7 +35,7 @@ func ResourceArtifactoryLocalAlpineRepository() *schema.Resource {
 	return repository.MkResourceSchema(alpineLocalSchema, repository.DefaultPacker(alpineLocalSchema), unPackLocalAlpineRepository, func() interface{} {
 		return &AlpineLocalRepo{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
-				PackageType: packageType,
+				PackageType: "alpine",
 				Rclass:      "local",
 			},
 		}

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_alpine_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_alpine_repository.go
@@ -6,14 +6,19 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-var alpineLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-	"primary_keypair_ref": {
-		Type:     schema.TypeString,
-		Optional: true,
-		Description: "Used to sign index files in Alpine Linux repositories. " +
-			"See: https://www.jfrog.com/confluence/display/JFROG/Alpine+Linux+Repositories#AlpineLinuxRepositories-SigningAlpineLinuxIndex",
+var alpineLocalSchema = util.MergeSchema(
+	BaseLocalRepoSchema,
+	map[string]*schema.Schema{
+		"primary_keypair_ref": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Used to sign index files in Alpine Linux repositories. " +
+				"See: https://www.jfrog.com/confluence/display/JFROG/Alpine+Linux+Repositories#AlpineLinuxRepositories-SigningAlpineLinuxIndex",
+		},
 	},
-}, repository.RepoLayoutRefSchema("local", "alpine"), repository.CompressionFormats)
+	repository.RepoLayoutRefSchema("local", "alpine"),
+	repository.CompressionFormats,
+)
 
 func ResourceArtifactoryLocalAlpineRepository() *schema.Resource {
 

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_cargo_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_cargo_repository.go
@@ -6,17 +6,16 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-func ResourceArtifactoryLocalCargoRepository() *schema.Resource {
-	const packageType = "cargo"
+var cargoLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
+	"anonymous_access": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+		Description: `Cargo client does not send credentials when performing download and search for crates. Enable this to allow anonymous access to these resources (only), note that this will override the security anonymous access option. Default value is 'false'.`,
+	},
+}, repository.RepoLayoutRefSchema("local", "cargo"), repository.CompressionFormats)
 
-	var cargoLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-		"anonymous_access": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: `Cargo client does not send credentials when performing download and search for crates. Enable this to allow anonymous access to these resources (only), note that this will override the security anonymous access option. Default value is 'false'.`,
-		},
-	}, repository.RepoLayoutRefSchema("local", packageType), repository.CompressionFormats)
+func ResourceArtifactoryLocalCargoRepository() *schema.Resource {
 
 	type CargoLocalRepo struct {
 		LocalRepositoryBaseParams
@@ -26,7 +25,7 @@ func ResourceArtifactoryLocalCargoRepository() *schema.Resource {
 	var unPackLocalCargoRepository = func(data *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: data}
 		repo := CargoLocalRepo{
-			LocalRepositoryBaseParams: UnpackBaseRepo("local", data, packageType),
+			LocalRepositoryBaseParams: UnpackBaseRepo("local", data, "cargo"),
 			AnonymousAccess:           d.GetBool("anonymous_access", false),
 		}
 
@@ -36,7 +35,7 @@ func ResourceArtifactoryLocalCargoRepository() *schema.Resource {
 	return repository.MkResourceSchema(cargoLocalSchema, repository.DefaultPacker(cargoLocalSchema), unPackLocalCargoRepository, func() interface{} {
 		return &CargoLocalRepo{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
-				PackageType: packageType,
+				PackageType: "cargo",
 				Rclass:      "local",
 			},
 		}

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_cargo_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_cargo_repository.go
@@ -6,14 +6,19 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-var cargoLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-	"anonymous_access": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Default:     false,
-		Description: `Cargo client does not send credentials when performing download and search for crates. Enable this to allow anonymous access to these resources (only), note that this will override the security anonymous access option. Default value is 'false'.`,
+var cargoLocalSchema = util.MergeSchema(
+	BaseLocalRepoSchema,
+	map[string]*schema.Schema{
+		"anonymous_access": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: `Cargo client does not send credentials when performing download and search for crates. Enable this to allow anonymous access to these resources (only), note that this will override the security anonymous access option. Default value is 'false'.`,
+		},
 	},
-}, repository.RepoLayoutRefSchema("local", "cargo"), repository.CompressionFormats)
+	repository.RepoLayoutRefSchema("local", "cargo"),
+	repository.CompressionFormats,
+)
 
 func ResourceArtifactoryLocalCargoRepository() *schema.Resource {
 

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_debian_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_debian_repository.go
@@ -6,27 +6,26 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-func ResourceArtifactoryLocalDebianRepository() *schema.Resource {
-	const packageType = "debian"
+var debianLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
+	"primary_keypair_ref": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Used to sign index files in Debian artifacts. ",
+	},
+	"secondary_keypair_ref": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Used to sign index files in Debian artifacts. ",
+	},
+	"trivial_layout": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Description: "When set, the repository will use the deprecated trivial layout.",
+		Deprecated:  "You shouldn't be using this",
+	},
+}, repository.RepoLayoutRefSchema("local", "debian"), repository.CompressionFormats)
 
-	var debianLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-		"primary_keypair_ref": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Used to sign index files in Debian artifacts. ",
-		},
-		"secondary_keypair_ref": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Used to sign index files in Debian artifacts. ",
-		},
-		"trivial_layout": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Description: "When set, the repository will use the deprecated trivial layout.",
-			Deprecated:  "You shouldn't be using this",
-		},
-	}, repository.RepoLayoutRefSchema("local", packageType), repository.CompressionFormats)
+func ResourceArtifactoryLocalDebianRepository() *schema.Resource {
 
 	type DebianLocalRepositoryParams struct {
 		LocalRepositoryBaseParams
@@ -39,7 +38,7 @@ func ResourceArtifactoryLocalDebianRepository() *schema.Resource {
 	var unPackLocalDebianRepository = func(data *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: data}
 		repo := DebianLocalRepositoryParams{
-			LocalRepositoryBaseParams: UnpackBaseRepo("local", data, packageType),
+			LocalRepositoryBaseParams: UnpackBaseRepo("local", data, "debian"),
 			PrimaryKeyPairRef:         d.GetString("primary_keypair_ref", false),
 			SecondaryKeyPairRef:       d.GetString("secondary_keypair_ref", false),
 			TrivialLayout:             d.GetBool("trivial_layout", false),
@@ -51,7 +50,7 @@ func ResourceArtifactoryLocalDebianRepository() *schema.Resource {
 	return repository.MkResourceSchema(debianLocalSchema, repository.DefaultPacker(debianLocalSchema), unPackLocalDebianRepository, func() interface{} {
 		return &DebianLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
-				PackageType: packageType,
+				PackageType: "debian",
 				Rclass:      "local",
 			},
 		}

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_debian_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_debian_repository.go
@@ -6,24 +6,29 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-var debianLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-	"primary_keypair_ref": {
-		Type:        schema.TypeString,
-		Optional:    true,
-		Description: "Used to sign index files in Debian artifacts. ",
+var debianLocalSchema = util.MergeSchema(
+	BaseLocalRepoSchema,
+	map[string]*schema.Schema{
+		"primary_keypair_ref": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Used to sign index files in Debian artifacts. ",
+		},
+		"secondary_keypair_ref": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Description: "Used to sign index files in Debian artifacts. ",
+		},
+		"trivial_layout": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "When set, the repository will use the deprecated trivial layout.",
+			Deprecated:  "You shouldn't be using this",
+		},
 	},
-	"secondary_keypair_ref": {
-		Type:        schema.TypeString,
-		Optional:    true,
-		Description: "Used to sign index files in Debian artifacts. ",
-	},
-	"trivial_layout": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When set, the repository will use the deprecated trivial layout.",
-		Deprecated:  "You shouldn't be using this",
-	},
-}, repository.RepoLayoutRefSchema("local", "debian"), repository.CompressionFormats)
+	repository.RepoLayoutRefSchema("local", "debian"),
+	repository.CompressionFormats,
+)
 
 func ResourceArtifactoryLocalDebianRepository() *schema.Resource {
 

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_docker_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_docker_repository.go
@@ -7,35 +7,39 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-var dockerV2LocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-	"max_unique_tags": {
-		Type:     schema.TypeInt,
-		Optional: true,
-		Default:  0,
-		Description: "The maximum number of unique tags of a single Docker image to store in this repository.\n" +
-			"Once the number tags for an image exceeds this setting, older tags are removed. A value of 0 (default) indicates there is no limit.\n" +
-			"This only applies to manifest v2",
-		ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
+var dockerV2LocalSchema = util.MergeSchema(
+	BaseLocalRepoSchema,
+	map[string]*schema.Schema{
+		"max_unique_tags": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Default:     0,
+			Description: "The maximum number of unique tags of a single Docker image to store in this repository.\n" +
+				"Once the number tags for an image exceeds this setting, older tags are removed. A value of 0 (default) indicates there is no limit.\n" +
+				"This only applies to manifest v2",
+			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
+		},
+		"tag_retention": {
+			Type:             schema.TypeInt,
+			Optional:         true,
+			Computed:         false,
+			Description:      "If greater than 1, overwritten tags will be saved by their digest, up to the set up number. This only applies to manifest V2",
+			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
+		},
+		"block_pushing_schema1": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Computed:    true,
+			Description: "When set, Artifactory will block the pushing of Docker images with manifest v2 schema 1 to this repository.",
+		},
+		"api_version": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "The Docker API version to use. This cannot be set",
+		},
 	},
-	"tag_retention": {
-		Type:             schema.TypeInt,
-		Optional:         true,
-		Computed:         false,
-		Description:      "If greater than 1, overwritten tags will be saved by their digest, up to the set up number. This only applies to manifest V2",
-		ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
-	},
-	"block_pushing_schema1": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Computed:    true,
-		Description: "When set, Artifactory will block the pushing of Docker images with manifest v2 schema 1 to this repository.",
-	},
-	"api_version": {
-		Type:        schema.TypeString,
-		Computed:    true,
-		Description: "The Docker API version to use. This cannot be set",
-	},
-}, repository.RepoLayoutRefSchema("local", "docker"))
+	repository.RepoLayoutRefSchema("local", "docker"),
+)
 
 func ResourceArtifactoryLocalDockerV2Repository() *schema.Resource {
 	packer := repository.DefaultPacker(dockerV2LocalSchema)
@@ -67,25 +71,29 @@ func ResourceArtifactoryLocalDockerV2Repository() *schema.Resource {
 	})
 }
 
-var dockerV1LocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-	"max_unique_tags": {
-		Type:     schema.TypeInt,
-		Optional: true,
-		Computed: true,
+var dockerV1LocalSchema = util.MergeSchema(
+	BaseLocalRepoSchema,
+	map[string]*schema.Schema{
+		"max_unique_tags": {
+			Type:     schema.TypeInt,
+			Optional: true,
+			Computed: true,
+		},
+		"tag_retention": {
+			Type:     schema.TypeInt,
+			Computed: true,
+		},
+		"block_pushing_schema1": {
+			Type:     schema.TypeBool,
+			Computed: true,
+		},
+		"api_version": {
+			Type:     schema.TypeString,
+			Computed: true,
+		},
 	},
-	"tag_retention": {
-		Type:     schema.TypeInt,
-		Computed: true,
-	},
-	"block_pushing_schema1": {
-		Type:     schema.TypeBool,
-		Computed: true,
-	},
-	"api_version": {
-		Type:     schema.TypeString,
-		Computed: true,
-	},
-}, repository.RepoLayoutRefSchema("local", "docker"))
+	repository.RepoLayoutRefSchema("local", "docker"),
+)
 
 func ResourceArtifactoryLocalDockerV1Repository() *schema.Resource {
 

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_docker_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_docker_repository.go
@@ -7,46 +7,43 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
+var dockerV2LocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
+	"max_unique_tags": {
+		Type:     schema.TypeInt,
+		Optional: true,
+		Default:  0,
+		Description: "The maximum number of unique tags of a single Docker image to store in this repository.\n" +
+			"Once the number tags for an image exceeds this setting, older tags are removed. A value of 0 (default) indicates there is no limit.\n" +
+			"This only applies to manifest v2",
+		ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
+	},
+	"tag_retention": {
+		Type:             schema.TypeInt,
+		Optional:         true,
+		Computed:         false,
+		Description:      "If greater than 1, overwritten tags will be saved by their digest, up to the set up number. This only applies to manifest V2",
+		ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
+	},
+	"block_pushing_schema1": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Computed:    true,
+		Description: "When set, Artifactory will block the pushing of Docker images with manifest v2 schema 1 to this repository.",
+	},
+	"api_version": {
+		Type:        schema.TypeString,
+		Computed:    true,
+		Description: "The Docker API version to use. This cannot be set",
+	},
+}, repository.RepoLayoutRefSchema("local", "docker"))
+
 func ResourceArtifactoryLocalDockerV2Repository() *schema.Resource {
-
-	const packageType = "docker"
-
-	var dockerV2LocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-		"max_unique_tags": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Default:  0,
-			Description: "The maximum number of unique tags of a single Docker image to store in this repository.\n" +
-				"Once the number tags for an image exceeds this setting, older tags are removed. A value of 0 (default) indicates there is no limit.\n" +
-				"This only applies to manifest v2",
-			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
-		},
-		"tag_retention": {
-			Type:             schema.TypeInt,
-			Optional:         true,
-			Computed:         false,
-			Description:      "If greater than 1, overwritten tags will be saved by their digest, up to the set up number. This only applies to manifest V2",
-			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(1)),
-		},
-		"block_pushing_schema1": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Computed:    true,
-			Description: "When set, Artifactory will block the pushing of Docker images with manifest v2 schema 1 to this repository.",
-		},
-		"api_version": {
-			Type:        schema.TypeString,
-			Computed:    true,
-			Description: "The Docker API version to use. This cannot be set",
-		},
-	}, repository.RepoLayoutRefSchema("local", packageType))
-
 	packer := repository.DefaultPacker(dockerV2LocalSchema)
 
 	var unPackLocalDockerV2Repository = func(data *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: data}
 		repo := DockerLocalRepositoryParams{
-			LocalRepositoryBaseParams: UnpackBaseRepo("local", data, packageType),
+			LocalRepositoryBaseParams: UnpackBaseRepo("local", data, "docker"),
 			MaxUniqueTags:             d.GetInt("max_unique_tags", false),
 			DockerApiVersion:          "V2",
 			TagRetention:              d.GetInt("tag_retention", false),
@@ -59,7 +56,7 @@ func ResourceArtifactoryLocalDockerV2Repository() *schema.Resource {
 	return repository.MkResourceSchema(dockerV2LocalSchema, packer, unPackLocalDockerV2Repository, func() interface{} {
 		return &DockerLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
-				PackageType: packageType,
+				PackageType: "docker",
 				Rclass:      "local",
 			},
 			DockerApiVersion:    "V2",
@@ -70,36 +67,34 @@ func ResourceArtifactoryLocalDockerV2Repository() *schema.Resource {
 	})
 }
 
+var dockerV1LocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
+	"max_unique_tags": {
+		Type:     schema.TypeInt,
+		Optional: true,
+		Computed: true,
+	},
+	"tag_retention": {
+		Type:     schema.TypeInt,
+		Computed: true,
+	},
+	"block_pushing_schema1": {
+		Type:     schema.TypeBool,
+		Computed: true,
+	},
+	"api_version": {
+		Type:     schema.TypeString,
+		Computed: true,
+	},
+}, repository.RepoLayoutRefSchema("local", "docker"))
+
 func ResourceArtifactoryLocalDockerV1Repository() *schema.Resource {
-
-	const packageType = "docker"
-
-	var dockerV1LocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-		"max_unique_tags": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Computed: true,
-		},
-		"tag_retention": {
-			Type:     schema.TypeInt,
-			Computed: true,
-		},
-		"block_pushing_schema1": {
-			Type:     schema.TypeBool,
-			Computed: true,
-		},
-		"api_version": {
-			Type:     schema.TypeString,
-			Computed: true,
-		},
-	}, repository.RepoLayoutRefSchema("local", packageType))
 
 	// this is necessary because of the pointers
 	skeema := util.MergeSchema(map[string]*schema.Schema{}, dockerV1LocalSchema)
 
 	var unPackLocalDockerV1Repository = func(data *schema.ResourceData) (interface{}, string, error) {
 		repo := DockerLocalRepositoryParams{
-			LocalRepositoryBaseParams: UnpackBaseRepo("local", data, packageType),
+			LocalRepositoryBaseParams: UnpackBaseRepo("local", data, "docker"),
 			MaxUniqueTags:             0,
 			DockerApiVersion:          "V1",
 			TagRetention:              1,
@@ -112,7 +107,7 @@ func ResourceArtifactoryLocalDockerV1Repository() *schema.Resource {
 	return repository.MkResourceSchema(skeema, repository.DefaultPacker(dockerV1LocalSchema), unPackLocalDockerV1Repository, func() interface{} {
 		return &DockerLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
-				PackageType: packageType,
+				PackageType: "docker",
 				Rclass:      "local",
 			},
 			DockerApiVersion:    "V1",

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_generic_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_generic_repository.go
@@ -6,17 +6,24 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-func ResourceArtifactoryLocalGenericRepository(pkt string) *schema.Resource {
+func getGenericRepoSchema(repoType string) map[string]*schema.Schema {
+	return util.MergeSchema(BaseLocalRepoSchema, repository.RepoLayoutRefSchema("local", repoType))
+}
+
+func ResourceArtifactoryLocalGenericRepository(repoType string) *schema.Resource {
 	constructor := func() interface{} {
 		return &LocalRepositoryBaseParams{
-			PackageType: pkt,
+			PackageType: repoType,
 			Rclass:      "local",
 		}
 	}
+
 	unpack := func(data *schema.ResourceData) (interface{}, string, error) {
-		repo := UnpackBaseRepo("local", data, pkt)
+		repo := UnpackBaseRepo("local", data, repoType)
 		return repo, repo.Id(), nil
 	}
-	mergedLocalRepoSchema := util.MergeSchema(BaseLocalRepoSchema, repository.RepoLayoutRefSchema("local", pkt))
-	return repository.MkResourceSchema(mergedLocalRepoSchema, repository.DefaultPacker(mergedLocalRepoSchema), unpack, constructor)
+
+	genericRepoSchema := getGenericRepoSchema(repoType)
+
+	return repository.MkResourceSchema(genericRepoSchema, repository.DefaultPacker(genericRepoSchema), unpack, constructor)
 }

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_java_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_java_repository.go
@@ -8,58 +8,62 @@ import (
 )
 
 func getJavaRepoSchema(repoType string, suppressPom bool) map[string]*schema.Schema {
-	return util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-		"checksum_policy_type": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			Default:          "client-checksums",
-			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"client-checksums", "generated-checksums"}, true)),
-			Description: "Checksum policy determines how Artifactory behaves when a client checksum for a deployed " +
-				"resource is missing or conflicts with the locally calculated checksum (bad checksum).\nFor more details, " +
-				"please refer to Checksum Policy - " +
-				"https://www.jfrog.com/confluence/display/JFROG/Local+Repositories#LocalRepositories-ChecksumPolicy",
+	return util.MergeSchema(
+		BaseLocalRepoSchema,
+		map[string]*schema.Schema{
+			"checksum_policy_type": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "client-checksums",
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"client-checksums", "generated-checksums"}, true)),
+				Description:      "Checksum policy determines how Artifactory behaves when a client checksum for a deployed " +
+					"resource is missing or conflicts with the locally calculated checksum (bad checksum).\nFor more details, " +
+					"please refer to Checksum Policy - " +
+					"https://www.jfrog.com/confluence/display/JFROG/Local+Repositories#LocalRepositories-ChecksumPolicy",
+			},
+			"snapshot_version_behavior": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "unique",
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"unique", "non-unique", "deployer"}, true)),
+				Description:      "Specifies the naming convention for Maven SNAPSHOT versions.\nThe options are " +
+					"-\nUnique: Version number is based on a time-stamp (default)\nNon-unique: Version number uses a" +
+					" self-overriding naming pattern of artifactId-version-SNAPSHOT.type\nDeployer: Respects the settings " +
+					"in the Maven client that is deploying the artifact.",
+			},
+			"max_unique_snapshots": {
+				Type:             schema.TypeInt,
+				Optional:         true,
+				Default:          0,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
+				Description:      "The maximum number of unique snapshots of a single artifact to store.\nOnce the number of " +
+					"snapshots exceeds this setting, older versions are removed.\nA value of 0 (default) indicates there is " +
+					"no limit, and unique snapshots are not cleaned up.",
+			},
+			"handle_releases": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "If set, Artifactory allows you to deploy release artifacts into this repository.",
+			},
+			"handle_snapshots": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     true,
+				Description: "If set, Artifactory allows you to deploy snapshot artifacts into this repository.",
+			},
+			"suppress_pom_consistency_checks": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     suppressPom,
+				Description: "By default, Artifactory keeps your repositories healthy by refusing POMs with incorrect " +
+					"coordinates (path).\n  If the groupId:artifactId:version information inside the POM does not match the " +
+					"deployed path, Artifactory rejects the deployment with a \"409 Conflict\" error.\n  You can disable this " +
+					"behavior by setting the Suppress POM Consistency Checks checkbox.",
+			},
 		},
-		"snapshot_version_behavior": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			Default:          "unique",
-			ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"unique", "non-unique", "deployer"}, true)),
-			Description: "Specifies the naming convention for Maven SNAPSHOT versions.\nThe options are " +
-				"-\nUnique: Version number is based on a time-stamp (default)\nNon-unique: Version number uses a" +
-				" self-overriding naming pattern of artifactId-version-SNAPSHOT.type\nDeployer: Respects the settings " +
-				"in the Maven client that is deploying the artifact.",
-		},
-		"max_unique_snapshots": {
-			Type:             schema.TypeInt,
-			Optional:         true,
-			Default:          0,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
-			Description: "The maximum number of unique snapshots of a single artifact to store.\nOnce the number of " +
-				"snapshots exceeds this setting, older versions are removed.\nA value of 0 (default) indicates there is " +
-				"no limit, and unique snapshots are not cleaned up.",
-		},
-		"handle_releases": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     true,
-			Description: "If set, Artifactory allows you to deploy release artifacts into this repository.",
-		},
-		"handle_snapshots": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     true,
-			Description: "If set, Artifactory allows you to deploy snapshot artifacts into this repository.",
-		},
-		"suppress_pom_consistency_checks": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  suppressPom,
-			Description: "By default, Artifactory keeps your repositories healthy by refusing POMs with incorrect " +
-				"coordinates (path).\n  If the groupId:artifactId:version information inside the POM does not match the " +
-				"deployed path, Artifactory rejects the deployment with a \"409 Conflict\" error.\n  You can disable this " +
-				"behavior by setting the Suppress POM Consistency Checks checkbox.",
-		},
-	}, repository.RepoLayoutRefSchema("local", repoType))
+		repository.RepoLayoutRefSchema("local", repoType),
+	)
 }
 
 func ResourceArtifactoryLocalJavaRepository(repoType string, suppressPom bool) *schema.Resource {

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_java_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_java_repository.go
@@ -7,9 +7,8 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-func ResourceArtifactoryLocalJavaRepository(repoType string, suppressPom bool) *schema.Resource {
-
-	var javaLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
+func getJavaRepoSchema(repoType string, suppressPom bool) map[string]*schema.Schema {
+	return util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
 		"checksum_policy_type": {
 			Type:             schema.TypeString,
 			Optional:         true,
@@ -61,6 +60,9 @@ func ResourceArtifactoryLocalJavaRepository(repoType string, suppressPom bool) *
 				"behavior by setting the Suppress POM Consistency Checks checkbox.",
 		},
 	}, repository.RepoLayoutRefSchema("local", repoType))
+}
+
+func ResourceArtifactoryLocalJavaRepository(repoType string, suppressPom bool) *schema.Resource {
 	type JavaLocalRepositoryParams struct {
 		LocalRepositoryBaseParams
 		ChecksumPolicyType           string `hcl:"checksum_policy_type" json:"checksumPolicyType"`
@@ -85,6 +87,9 @@ func ResourceArtifactoryLocalJavaRepository(repoType string, suppressPom bool) *
 
 		return repo, repo.Id(), nil
 	}
+
+	javaLocalSchema := getJavaRepoSchema(repoType, suppressPom)
+
 	return repository.MkResourceSchema(javaLocalSchema, repository.DefaultPacker(javaLocalSchema), unPackLocalJavaRepository, func() interface{} {
 		return &JavaLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_nuget_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_nuget_repository.go
@@ -6,22 +6,26 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-var nugetLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-	"max_unique_snapshots": {
-		Type:     schema.TypeInt,
-		Optional: true,
-		Default:  0,
-		Description: "The maximum number of unique snapshots of a single artifact to store.\nOnce the number of " +
-			"snapshots exceeds this setting, older versions are removed.\nA value of 0 (default) indicates there is no limit, and unique snapshots are not cleaned up.",
-	},
+var nugetLocalSchema = util.MergeSchema(
+	BaseLocalRepoSchema,
+	map[string]*schema.Schema{
+		"max_unique_snapshots": {
+			Type:        schema.TypeInt,
+			Optional:    true,
+			Default:     0,
+			Description: "The maximum number of unique snapshots of a single artifact to store.\nOnce the number of " +
+				"snapshots exceeds this setting, older versions are removed.\nA value of 0 (default) indicates there is no limit, and unique snapshots are not cleaned up.",
+		},
 
-	"force_nuget_authentication": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Default:     false,
-		Description: "Force basic authentication credentials in order to use this repository.",
+		"force_nuget_authentication": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Force basic authentication credentials in order to use this repository.",
+		},
 	},
-}, repository.RepoLayoutRefSchema("local", "nuget"))
+	repository.RepoLayoutRefSchema("local", "nuget"),
+)
 
 func ResourceArtifactoryLocalNugetRepository() *schema.Resource {
 

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_nuget_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_nuget_repository.go
@@ -6,26 +6,24 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
+var nugetLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
+	"max_unique_snapshots": {
+		Type:     schema.TypeInt,
+		Optional: true,
+		Default:  0,
+		Description: "The maximum number of unique snapshots of a single artifact to store.\nOnce the number of " +
+			"snapshots exceeds this setting, older versions are removed.\nA value of 0 (default) indicates there is no limit, and unique snapshots are not cleaned up.",
+	},
+
+	"force_nuget_authentication": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+		Description: "Force basic authentication credentials in order to use this repository.",
+	},
+}, repository.RepoLayoutRefSchema("local", "nuget"))
+
 func ResourceArtifactoryLocalNugetRepository() *schema.Resource {
-
-	const packageType = "nuget"
-
-	var nugetLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-		"max_unique_snapshots": {
-			Type:     schema.TypeInt,
-			Optional: true,
-			Default:  0,
-			Description: "The maximum number of unique snapshots of a single artifact to store.\nOnce the number of " +
-				"snapshots exceeds this setting, older versions are removed.\nA value of 0 (default) indicates there is no limit, and unique snapshots are not cleaned up.",
-		},
-
-		"force_nuget_authentication": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "Force basic authentication credentials in order to use this repository.",
-		},
-	}, repository.RepoLayoutRefSchema("local", packageType))
 
 	type NugetLocalRepositoryParams struct {
 		LocalRepositoryBaseParams
@@ -36,7 +34,7 @@ func ResourceArtifactoryLocalNugetRepository() *schema.Resource {
 	var unPackLocalNugetRepository = func(data *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: data}
 		repo := NugetLocalRepositoryParams{
-			LocalRepositoryBaseParams: UnpackBaseRepo("local", data, packageType),
+			LocalRepositoryBaseParams: UnpackBaseRepo("local", data, "nuget"),
 			MaxUniqueSnapshots:        d.GetInt("max_unique_snapshots", false),
 			ForceNugetAuthentication:  d.GetBool("force_nuget_authentication", false),
 		}
@@ -47,7 +45,7 @@ func ResourceArtifactoryLocalNugetRepository() *schema.Resource {
 	return repository.MkResourceSchema(nugetLocalSchema, repository.DefaultPacker(nugetLocalSchema), unPackLocalNugetRepository, func() interface{} {
 		return &NugetLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
-				PackageType: packageType,
+				PackageType: "nuget",
 				Rclass:      "local",
 			},
 			MaxUniqueSnapshots:       0,

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_rpm_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_rpm_repository.go
@@ -8,51 +8,50 @@ import (
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
-func ResourceArtifactoryLocalRpmRepository() *schema.Resource {
-	const packageType = "rpm"
+var rpmLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
+	"yum_root_depth": {
+		Type:             schema.TypeInt,
+		Optional:         true,
+		Default:          0,
+		ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
+		Description: "The depth, relative to the repository's root folder, where RPM metadata is created. " +
+			"This is useful when your repository contains multiple RPM repositories under parallel hierarchies. " +
+			"For example, if your RPMs are stored under 'fedora/linux/$releasever/$basearch', specify a depth of 4.",
+		},
+	"calculate_yum_metadata": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	},
+	"enable_file_lists_indexing": {
+		Type:     schema.TypeBool,
+		Optional: true,
+		Default:  false,
+	},
+	"yum_group_file_names": {
+		Type:             schema.TypeString,
+		Optional:         true,
+		Default:          "",
+		ValidateDiagFunc: validator.CommaSeperatedList,
+		Description: "A comma separated list of XML file names containing RPM group component definitions. Artifactory includes " +
+			"the group definitions as part of the calculated RPM metadata, as well as automatically generating a " +
+			"gzipped version of the group files, if required.",
+	},
+	"primary_keypair_ref": {
+		Type:             schema.TypeString,
+		Optional:         true,
+		ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+		Description:      "Primary keypair used to sign artifacts.",
+	},
+	"secondary_keypair_ref": {
+		Type:             schema.TypeString,
+		Optional:         true,
+		ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+		Description:      "Secondary keypair used to sign artifacts.",
+	},
+}, repository.RepoLayoutRefSchema("local", "rpm"))
 
-	var rpmLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-		"yum_root_depth": {
-			Type:             schema.TypeInt,
-			Optional:         true,
-			Default:          0,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
-			Description: "The depth, relative to the repository's root folder, where RPM metadata is created. " +
-				"This is useful when your repository contains multiple RPM repositories under parallel hierarchies. " +
-				"For example, if your RPMs are stored under 'fedora/linux/$releasever/$basearch', specify a depth of 4.",
-		},
-		"calculate_yum_metadata": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-		},
-		"enable_file_lists_indexing": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-		},
-		"yum_group_file_names": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			Default:          "",
-			ValidateDiagFunc: validator.CommaSeperatedList,
-			Description: "A comma separated list of XML file names containing RPM group component definitions. Artifactory includes " +
-				"the group definitions as part of the calculated RPM metadata, as well as automatically generating a " +
-				"gzipped version of the group files, if required.",
-		},
-		"primary_keypair_ref": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
-			Description:      "Primary keypair used to sign artifacts.",
-		},
-		"secondary_keypair_ref": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
-			Description:      "Secondary keypair used to sign artifacts.",
-		},
-	}, repository.RepoLayoutRefSchema("local", packageType))
+func ResourceArtifactoryLocalRpmRepository() *schema.Resource {
 
 	type RpmLocalRepositoryParams struct {
 		LocalRepositoryBaseParams
@@ -82,7 +81,7 @@ func ResourceArtifactoryLocalRpmRepository() *schema.Resource {
 	return repository.MkResourceSchema(rpmLocalSchema, repository.DefaultPacker(rpmLocalSchema), unPackLocalRpmRepository, func() interface{} {
 		return &RpmLocalRepositoryParams{
 			LocalRepositoryBaseParams: LocalRepositoryBaseParams{
-				PackageType: packageType,
+				PackageType: "rpm",
 				Rclass:      "local",
 			},
 			RootDepth:               0,

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_rpm_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_rpm_repository.go
@@ -8,48 +8,52 @@ import (
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
-var rpmLocalSchema = util.MergeSchema(BaseLocalRepoSchema, map[string]*schema.Schema{
-	"yum_root_depth": {
-		Type:             schema.TypeInt,
-		Optional:         true,
-		Default:          0,
-		ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
-		Description: "The depth, relative to the repository's root folder, where RPM metadata is created. " +
-			"This is useful when your repository contains multiple RPM repositories under parallel hierarchies. " +
-			"For example, if your RPMs are stored under 'fedora/linux/$releasever/$basearch', specify a depth of 4.",
+var rpmLocalSchema = util.MergeSchema(
+	BaseLocalRepoSchema,
+	map[string]*schema.Schema{
+		"yum_root_depth": {
+			Type:             schema.TypeInt,
+			Optional:         true,
+			Default:          0,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.IntAtLeast(0)),
+			Description:      "The depth, relative to the repository's root folder, where RPM metadata is created. " +
+				"This is useful when your repository contains multiple RPM repositories under parallel hierarchies. " +
+				"For example, if your RPMs are stored under 'fedora/linux/$releasever/$basearch', specify a depth of 4.",
+			},
+		"calculate_yum_metadata": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
 		},
-	"calculate_yum_metadata": {
-		Type:     schema.TypeBool,
-		Optional: true,
-		Default:  false,
+		"enable_file_lists_indexing": {
+			Type:     schema.TypeBool,
+			Optional: true,
+			Default:  false,
+		},
+		"yum_group_file_names": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          "",
+			ValidateDiagFunc: validator.CommaSeperatedList,
+			Description:      "A comma separated list of XML file names containing RPM group component definitions. Artifactory includes " +
+				"the group definitions as part of the calculated RPM metadata, as well as automatically generating a " +
+				"gzipped version of the group files, if required.",
+		},
+		"primary_keypair_ref": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+			Description:      "Primary keypair used to sign artifacts.",
+		},
+		"secondary_keypair_ref": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+			Description:      "Secondary keypair used to sign artifacts.",
+		},
 	},
-	"enable_file_lists_indexing": {
-		Type:     schema.TypeBool,
-		Optional: true,
-		Default:  false,
-	},
-	"yum_group_file_names": {
-		Type:             schema.TypeString,
-		Optional:         true,
-		Default:          "",
-		ValidateDiagFunc: validator.CommaSeperatedList,
-		Description: "A comma separated list of XML file names containing RPM group component definitions. Artifactory includes " +
-			"the group definitions as part of the calculated RPM metadata, as well as automatically generating a " +
-			"gzipped version of the group files, if required.",
-	},
-	"primary_keypair_ref": {
-		Type:             schema.TypeString,
-		Optional:         true,
-		ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
-		Description:      "Primary keypair used to sign artifacts.",
-	},
-	"secondary_keypair_ref": {
-		Type:             schema.TypeString,
-		Optional:         true,
-		ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
-		Description:      "Secondary keypair used to sign artifacts.",
-	},
-}, repository.RepoLayoutRefSchema("local", "rpm"))
+	repository.RepoLayoutRefSchema("local", "rpm"),
+)
 
 func ResourceArtifactoryLocalRpmRepository() *schema.Resource {
 

--- a/scripts/run-artifactory-container.sh
+++ b/scripts/run-artifactory-container.sh
@@ -19,4 +19,4 @@ export ARTIFACTORY_UI_URL=http://localhost:8082
 waitForArtifactory "${ARTIFACTORY_URL}" "${ARTIFACTORY_UI_URL}"
 
 # With this trick you can do $(./run-artifactory-container.sh) and it will directly be setup for you without the terminal output
-echo "export JFROG_ACCESS_KEY=$(getAccessKey "${ARTIFACTORY_UI_URL}")"
+echo "export JFROG_ACCESS_TOKEN=$(getAccessKey "${ARTIFACTORY_UI_URL}")"

--- a/scripts/run-artifactory.sh
+++ b/scripts/run-artifactory.sh
@@ -42,4 +42,4 @@ echo "Circle-of-Trust is setup between artifactory-1 and artifactory-2 instances
 
 echo "Generate Admin Access Keys for both instances"
 
-echo "export JFROG_ACCESS_KEY=$(getAccessKey "${ARTIFACTORY_UI_URL_1}")"
+echo "export JFROG_ACCESS_TOKEN=$(getAccessKey "${ARTIFACTORY_UI_URL_1}")"


### PR DESCRIPTION
Fixes #431 

Fix repo type specific attributes from local repo schema were not used for federated repo schemas.

Also fix the Artifactory auth token env var name in test scripts.