### PR TITLE
GH-475 Add comprehensive list of JFrog service types for audience validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.9.2 (June 7, 2022)
+## 6.9.2 (June 7, 2022). Tested on Artifactory 7.38.10
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 BUG FIXES:
 
-* resource/artifactory_scoped_token: Expand `audiences` validation to include all valid JFrog service types. PR: [#477](https://github.com/jfrog/terraform-provider-artifactory/pull/477). Issue: [#475](https://github.com/jfrog/terraform-provider-artifactory/issues/475)
+* resource/artifactory_scoped_token:
+  * Expand `audiences` validation to include all valid JFrog service types. PR: [#477](https://github.com/jfrog/terraform-provider-artifactory/pull/477). Issue: [#475](https://github.com/jfrog/terraform-provider-artifactory/issues/475)
+  * Fix incorrect validation for `applied-permissions/groups` scope. PR: [#477](https://github.com/jfrog/terraform-provider-artifactory/pull/477). Issue: [#478](https://github.com/jfrog/terraform-provider-artifactory/issues/478)
 
 ## 6.9.1 (June 3, 2022). Tested on Artifactory 7.38.10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.9.2 (June 7, 2022)
+
+BUG FIXES:
+
+* resource/artifactory_scoped_token: Expand `audiences` validation to include all valid JFrog service types. PR: [#477](https://github.com/jfrog/terraform-provider-artifactory/pull/477). Issue: [#475](https://github.com/jfrog/terraform-provider-artifactory/issues/475)
+
 ## 6.9.1 (June 3, 2022). Tested on Artifactory 7.38.10
 
 BUG FIXES:

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
@@ -90,11 +90,14 @@ func ResourceArtifactoryScopedToken() *schema.Resource {
 							[]string{
 								"applied-permissions/user",
 								"applied-permissions/admin",
-								"applied-permissions/groups",
 								"system:metrics:r",
 								"system:livelogs:r",
 							},
 							true,
+						),
+						validation.StringMatch(
+							regexp.MustCompile(`^applied-permissions/groups:.+$`),
+							"must be 'applied-permissions/groups:<group-name>[,<group-name>...]'",
 						),
 						validation.StringMatch(
 							regexp.MustCompile(`^artifact:.+:([rwdam\*]|([rwdam]+(,[rwdam]+)))$`),

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
@@ -79,7 +79,7 @@ func TestAccScopedToken_WithAttributes(t *testing.T) {
 			scopes      = ["applied-permissions/admin", "system:metrics:r"]
 			description = "test description"
 			refreshable = true
-			audiences   = ["jfrt@1", "jfrt@2"]
+			audiences   = ["jfrt@1", "jfxr@*"]
 		}`,
 		map[string]interface{}{
 			"name": name,
@@ -101,7 +101,7 @@ func TestAccScopedToken_WithAttributes(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "description", "test description"),
 					resource.TestCheckResourceAttr(fqrn, "audiences.#", "2"),
 					resource.TestCheckTypeSetElemAttr(fqrn, "audiences.*", "jfrt@1"),
-					resource.TestCheckTypeSetElemAttr(fqrn, "audiences.*", "jfrt@2"),
+					resource.TestCheckTypeSetElemAttr(fqrn, "audiences.*", "jfxr@*"),
 					resource.TestCheckResourceAttrSet(fqrn, "access_token"),
 					resource.TestCheckResourceAttr(fqrn, "token_type", "Bearer"),
 					resource.TestCheckResourceAttrSet(fqrn, "subject"),
@@ -119,41 +119,8 @@ func TestAccScopedToken_WithInvalidScopes(t *testing.T) {
 
 	scopedTokenConfig := acctest.ExecuteTemplate(
 		"TestAccScopedToken",
-		`resource "artifactory_local_generic_repository" "generic-local-1" {
-			key = "generic-local-1"
-		}
-
-		resource "artifactory_local_generic_repository" "generic-local-2" {
-			key = "generic-local-2"
-		}
-
-		resource "artifactory_local_generic_repository" "generic-local-3" {
-			key = "generic-local-3"
-		}
-
-		resource "artifactory_local_generic_repository" "generic-local-4" {
-			key = "generic-local-4"
-		}
-
-		resource "artifactory_user" "test-user" {
-			name              = "testuser"
-		    email             = "testuser@tempurl.org"
-			admin             = true
-			disable_ui_access = false
-			groups            = ["readers"]
-			password          = "Passw0rd!"
-		}
-
-		resource "artifactory_scoped_token" "{{ .name }}" {
-			username    = artifactory_user.test-user.name
+		`resource "artifactory_scoped_token" "{{ .name }}" {
 			scopes      = ["foo"]
-
-			depends_on = [
-				artifactory_local_generic_repository.generic-local-1,
-				artifactory_local_generic_repository.generic-local-2,
-				artifactory_local_generic_repository.generic-local-3,
-				artifactory_local_generic_repository.generic-local-4,
-			]
 		}`,
 		map[string]interface{}{
 			"name": name,
@@ -193,17 +160,7 @@ func TestAccScopedToken_WithTooLongScopes(t *testing.T) {
 			key = "generic-local-4"
 		}
 
-		resource "artifactory_user" "test-user" {
-			name              = "testuser"
-		    email             = "testuser@tempurl.org"
-			admin             = true
-			disable_ui_access = false
-			groups            = ["readers"]
-			password          = "Passw0rd!"
-		}
-
 		resource "artifactory_scoped_token" "{{ .name }}" {
-			username    = artifactory_user.test-user.name
 			scopes      = [
 				"applied-permissions/admin",
 				"applied-permissions/user",
@@ -255,28 +212,51 @@ func TestAccScopedToken_WithTooLongScopes(t *testing.T) {
 	})
 }
 
+func TestAccScopedToken_WithAudience(t *testing.T) {
+
+	for _, prefix := range []string{"jfrt", "jfxr", "jfpip", "jfds", "jfmc", "jfac", "jfevt", "jfmd", "jfcon", "*"} {
+		t.Run(prefix, func(t *testing.T) {
+			resource.Test(mkAudienceTestCase(prefix, t))
+		})
+	}
+}
+
+func mkAudienceTestCase(prefix string, t *testing.T) (*testing.T, resource.TestCase) {
+	_, fqrn, name := acctest.MkNames("test-access-token", "artifactory_scoped_token")
+
+	accessTokenConfig := acctest.ExecuteTemplate(
+		"TestAccScopedToken",
+		`resource "artifactory_scoped_token" "{{ .name }}" {
+			audiences = ["{{ .prefix }}@*"]
+		}`,
+		map[string]interface{}{
+			"name":   name,
+			"prefix": prefix,
+		},
+	)
+
+	return t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: accessTokenConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "audiences.#", "1"),
+					resource.TestCheckTypeSetElemAttr(fqrn, "audiences.*", fmt.Sprintf("%s@*", prefix)),
+				),
+			},
+		},
+	}
+}
+
 func TestAccScopedToken_WithInvalidAudiences(t *testing.T) {
 	_, _, name := acctest.MkNames("test-scoped-token", "artifactory_scoped_token")
 
 	scopedTokenConfig := acctest.ExecuteTemplate(
 		"TestAccScopedToken",
-		`resource "artifactory_user" "test-user" {
-			name              = "testuser"
-		    email             = "testuser@tempurl.org"
-			admin             = true
-			disable_ui_access = false
-			groups            = ["readers"]
-			password          = "Passw0rd!"
-		}
-
-		resource "artifactory_scoped_token" "{{ .name }}" {
-			username    = artifactory_user.test-user.name
-			scopes      = [
-				"applied-permissions/admin",
-				"applied-permissions/user",
-			]
-
-			audiences = ["foo"]
+		`resource "artifactory_scoped_token" "{{ .name }}" {
+			audiences = ["foo@*"]
 		}`,
 		map[string]interface{}{
 			"name":      name,
@@ -289,7 +269,7 @@ func TestAccScopedToken_WithInvalidAudiences(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      scopedTokenConfig,
-				ExpectError: regexp.MustCompile(".*must begin with 'jfrt@'.*"),
+				ExpectError: regexp.MustCompile(`.*must either begin with jfrt, jfxr, jfpip, jfds, jfmc, jfac, jfevt, jfmd, jfcon, or \*.*`),
 			},
 		},
 	})
@@ -305,22 +285,7 @@ func TestAccScopedToken_WithTooLongAudiences(t *testing.T) {
 
 	scopedTokenConfig := acctest.ExecuteTemplate(
 		"TestAccScopedToken",
-		`resource "artifactory_user" "test-user" {
-			name              = "testuser"
-		    email             = "testuser@tempurl.org"
-			admin             = true
-			disable_ui_access = false
-			groups            = ["readers"]
-			password          = "Passw0rd!"
-		}
-
-		resource "artifactory_scoped_token" "{{ .name }}" {
-			username    = artifactory_user.test-user.name
-			scopes      = [
-				"applied-permissions/admin",
-				"applied-permissions/user",
-			]
-
+		`resource "artifactory_scoped_token" "{{ .name }}" {
 			audiences    = [
 				{{range .audiences}}"{{.}}",{{end}}
 			]


### PR DESCRIPTION
Fixes #475 and #478