### PR TITLE
GH-480 Check for file existence before verifying checksum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.9.3 (June 10, 2022)
+## 6.9.3 (June 10, 2022). Tested on Artifactory 7.38.10
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.9.3 (June 10, 2022)
+
+BUG FIXES:
+
+* resource/artifactory_file: Check for file existence before verifying checksum. PR: [#481](https://github.com/jfrog/terraform-provider-artifactory/pull/481). Issue: [#480](https://github.com/jfrog/terraform-provider-artifactory/issues/480)
+
 ## 6.9.2 (June 7, 2022). Tested on Artifactory 7.38.10
 
 BUG FIXES:

--- a/pkg/artifactory/datasource/datasource_artifactory_file.go
+++ b/pkg/artifactory/datasource/datasource_artifactory_file.go
@@ -154,10 +154,14 @@ func dataSourceFileReader(ctx context.Context, d *schema.ResourceData, m interfa
 			return diag.FromErr(err)
 		}
 
+		chksMatches := false
 		fileExists := FileExists(outputPath)
-		chksMatches, err := VerifySha256Checksum(outputPath, fileInfo.Checksums.Sha256)
-		if err != nil {
-			return diag.FromErr(err)
+		if fileExists {
+			chksMatches, err = VerifySha256Checksum(outputPath, fileInfo.Checksums.Sha256)
+			if err != nil {
+				tflog.Error(ctx, fmt.Sprintf("Failed to verify checksum for %s", outputPath))
+				return diag.FromErr(err)
+			}
 		}
 
 		tflog.Debug(ctx, "File info fetched", map[string]interface{}{


### PR DESCRIPTION
Fixes #480 

- Only verify checksum if file exists
- Add logging when checksum fails

Thanks @evan-cleary for pointing out the logic flaw.