### PR TITLE
Fix binary version linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ vendor/
 .github/
 .modules/
 .terraform*
+terraform.d/
 terraform.tfstate
 terraform.tfstate.backup
 lib/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -14,7 +14,7 @@ builds:
   flags:
     - -trimpath
   ldflags:
-    - '-s -w -X main.version={{.Version}} -X main.commit={{.Commit}}'
+    - '-s -w -X github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/provider.Version={{.Version}}'
   goos:
     - freebsd
     - windows
@@ -38,7 +38,7 @@ checksum:
 signs:
   - artifacts: checksum
     args:
-      # if you are using this is a GitHub action or some other automated pipeline, you 
+      # if you are using this is a GitHub action or some other automated pipeline, you
       # need to pass the batch flag to indicate its not interactive.
       - "--batch"
       - "--local-user"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,6 +16,7 @@ BUILD_PATH=terraform.d/plugins/registry.terraform.io/jfrog/artifactory/${NEXT_VE
 default: build
 
 install:
+	rm -fR .terraform.d && \
 	mkdir -p ${BUILD_PATH} && \
 		(test -f terraform-provider-artifactory || GORELEASER_CURRENT_TAG=${NEXT_VERSION} GoReleaser build --single-target --rm-dist --snapshot) && \
 		mv -v dist/terraform-provider-artifactory_${GORELEASER_ARCH}/terraform-provider-artifactory_v${NEXT_VERSION}* ${BUILD_PATH} && \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -5,6 +5,10 @@ ifeq ($(GO_ARCH), amd64)
 GORELEASER_ARCH=${TARGET_ARCH}_$(shell go env GOAMD64)
 endif
 PKG_NAME=pkg/artifactory
+
+# if this path ever changes, you need to also update the 'ldflags' value in .goreleaser.yml
+PKG_VERSION_PATH=github.com/jfrog/terraform-provider-artifactory/v6/${PKG_NAME}/provider
+
 VERSION := $(shell git tag --sort=-creatordate | head -1 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')
 NEXT_VERSION := $(shell echo ${VERSION}| awk -F '.' '{print $$1 "." $$2 "." $$3 +1 }' )
 BUILD_PATH=terraform.d/plugins/registry.terraform.io/jfrog/artifactory/${NEXT_VERSION}/${TARGET_ARCH}
@@ -43,7 +47,7 @@ attach:
 
 acceptance: fmtcheck
 	export TF_ACC=true && \
-		go test -v -p 1 -parallel 20 -timeout 20m ./pkg/...
+		go test -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}-test'" -v -p 1 -parallel 20 -timeout 20m ./pkg/...
 
 acceptance_federated:
 	export TF_ACC=true && \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -18,7 +18,7 @@ default: build
 install:
 	rm -fR .terraform.d && \
 	mkdir -p ${BUILD_PATH} && \
-		(test -f terraform-provider-artifactory || GORELEASER_CURRENT_TAG=${NEXT_VERSION} GoReleaser build --single-target --rm-dist --snapshot) && \
+		(test -f terraform-provider-artifactory || GORELEASER_CURRENT_TAG=${NEXT_VERSION} goreleaser build --single-target --rm-dist --snapshot) && \
 		mv -v dist/terraform-provider-artifactory_${GORELEASER_ARCH}/terraform-provider-artifactory_v${NEXT_VERSION}* ${BUILD_PATH} && \
 		rm -f .terraform.lock.hcl && \
 		sed -i.bak 's/version = ".*"/version = "${NEXT_VERSION}"/' sample.tf && rm sample.tf.bak && \
@@ -37,7 +37,7 @@ update_pkg_cache:
 	GOPROXY=https://proxy.golang.org GO111MODULE=on go get github.com/jfrog/terraform-provider-artifactory@v${VERSION}
 
 build: fmtcheck
-	GORELEASER_CURRENT_TAG=${NEXT_VERSION} GoReleaser build --single-target --rm-dist --snapshot
+	GORELEASER_CURRENT_TAG=${NEXT_VERSION} goreleaser build --single-target --rm-dist --snapshot
 
 test:
 	@echo "==> Starting unit tests"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,10 @@
 TEST?=./...
-TARGET_ARCH=$(shell go env GOOS)_$(shell go env GOARCH)
+GO_ARCH=$(shell go env GOARCH)
+TARGET_ARCH=$(shell go env GOOS)_${GO_ARCH}
+ifeq ($(GO_ARCH), amd64)
+GORELEASER_ARCH=${TARGET_ARCH}_$(shell go env GOAMD64)
+endif
 PKG_NAME=pkg/artifactory
-PKG_VERSION_PATH=github.com/jfrog/terraform-provider-artifactory/v6/${PKG_NAME}/provider
 VERSION := $(shell git tag --sort=-creatordate | head -1 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')
 NEXT_VERSION := $(shell echo ${VERSION}| awk -F '.' '{print $$1 "." $$2 "." $$3 +1 }' )
 BUILD_PATH=terraform.d/plugins/registry.terraform.io/jfrog/artifactory/${NEXT_VERSION}/${TARGET_ARCH}
@@ -10,8 +13,8 @@ default: build
 
 install:
 	mkdir -p ${BUILD_PATH} && \
-		(test -f terraform-provider-artifactory || go build -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}'") && \
-		mv terraform-provider-artifactory ${BUILD_PATH} && \
+		(test -f terraform-provider-artifactory || GORELEASER_CURRENT_TAG=${NEXT_VERSION} GoReleaser build --single-target --rm-dist --snapshot) && \
+		mv -v dist/terraform-provider-artifactory_${GORELEASER_ARCH}/terraform-provider-artifactory_v${NEXT_VERSION}* ${BUILD_PATH} && \
 		rm -f .terraform.lock.hcl && \
 		sed -i.bak 's/version = ".*"/version = "${NEXT_VERSION}"/' sample.tf && rm sample.tf.bak && \
 		terraform init
@@ -29,15 +32,7 @@ update_pkg_cache:
 	GOPROXY=https://proxy.golang.org GO111MODULE=on go get github.com/jfrog/terraform-provider-artifactory@v${VERSION}
 
 build: fmtcheck
-	go build -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}'"
-
-debug_install:
-	mkdir -p ${BUILD_PATH} && \
-		(test -f terraform-provider-artifactory || go build -gcflags "all=-N -l" -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}-develop'") && \
-		mv terraform-provider-artifactory ${BUILD_PATH} && \
-		rm .terraform.lock.hcl && \
-		sed -i.bak 's/version = ".*"/version = "${NEXT_VERSION}"/' sample.tf && rm sample.tf.bak  && \
-		terraform init
+	GORELEASER_CURRENT_TAG=${NEXT_VERSION} GoReleaser build --single-target --rm-dist --snapshot
 
 test:
 	@echo "==> Starting unit tests"
@@ -48,7 +43,7 @@ attach:
 
 acceptance: fmtcheck
 	export TF_ACC=true && \
-		go test -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_VERSION}-test'" -v -p 1 -parallel 20 -timeout 20m ./pkg/...
+		go test -v -p 1 -parallel 20 -timeout 20m ./pkg/...
 
 acceptance_federated:
 	export TF_ACC=true && \

--- a/pkg/artifactory/provider/provider.go
+++ b/pkg/artifactory/provider/provider.go
@@ -168,6 +168,8 @@ func Provider() *schema.Provider {
 
 	p.ConfigureContextFunc = func(ctx context.Context, d *schema.ResourceData) (interface{}, diag.Diagnostics) {
 		tflog.Debug(ctx, "ConfigureContextFunc")
+		tflog.Info(ctx, fmt.Sprintf("Provider version: %s", Version))
+
 		terraformVersion := p.TerraformVersion
 		if terraformVersion == "" {
 			terraformVersion = "0.11+compatible"

--- a/sample.tf
+++ b/sample.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     artifactory = {
       source  = "registry.terraform.io/jfrog/artifactory"
-      version = "6.9.0"
+      version = "6.9.4"
     }
   }
 }


### PR DESCRIPTION
Replace 'go build' with 'GoReleaser build' so the 'ldflags' is set in only one place at .goreleaser.yml

Tested by:
- run `make install` and then `TF_LOG=INFO terraform plan` and checks for log with `Provider version: x.y.z`
- also verify the call home request using Charles