### PR TITLE
Fix broken ApiKey due to new fields

### DIFF
--- a/pkg/artifactory/resource/security/resource_artifactory_api_key_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_api_key_test.go
@@ -40,14 +40,14 @@ func testAccCheckApiKeyDestroy(id string) func(*terraform.State) error {
 			return fmt.Errorf("err: Resource id[%s] not found", id)
 		}
 
-		data := make(map[string]string)
+		data := security.ApiKey{}
 
 		_, err := client.R().SetResult(&data).Get(security.ApiKeyEndpoint)
 		if err != nil {
 			return err
 		}
 
-		if _, ok = data["apiKey"]; ok {
+		if data.ApiKey != "" {
 			return fmt.Errorf("error: API key %s still exists", rs.Primary.ID)
 		}
 		return nil


### PR DESCRIPTION
We weren't using the struct for storing response data for parsing.

The new field `blockCreateApiKey` is only returned by post v7.18.10, hence we don't see this error with local acceptance tests until I upgraded to 7.41.4