### PR TITLE
Cannot reset repo repository excludes_pattern attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.12.1 (August 23, 2022)
+## 6.12.1 (August 23, 2022). Tested on Artifactory 7.41.7
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.12.1 (August 23, 2022)
+
+BUG FIXES:
+
+* resource/artifactory_remote_*_repository: Fix unable to reset `excludes_pattern` attribute using empty string. PR: [#527](https://github.com/jfrog/terraform-provider-artifactory/pull/527).
+
 ## 6.12.0 (August 17, 2022). Tested on Artifactory 7.41.7
 
 IMPROVEMENTS:

--- a/docs/resources/remote.md
+++ b/docs/resources/remote.md
@@ -43,8 +43,8 @@ All generic repo arguments are supported, in addition to:
 * `username` - (Optional)
 * `password` - (Optional)
 * `proxy` - (Optional) Proxy key from Artifactory Proxies settings.
-* `includes_pattern` - (Optional) List of artifact patterns to include when evaluating artifact requests in the form of x/y/\**/z/*. When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included (**/*).
-* `excludes_pattern` - (Optional) List of artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*. By default no artifacts are excluded.
+* `includes_pattern` - (Optional) List of comma-separated artifact patterns to include when evaluating artifact requests in the form of x/y/\**/z/*. When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included (**/*).
+* `excludes_pattern` - (Optional) List of comma-separated artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*. By default no artifacts are excluded.
 * `repo_layout_ref` - (Optional) Sets the layout that the repository should use for storing and identifying modules. A recommended layout that corresponds to the package type defined is suggested, and index packages uploaded and calculate metadata accordingly.
 * `remote_repo_layout_ref` - (Optional) Repository layout key for the remote layout mapping.
 * `hard_fail` - (Optional) When set, Artifactory will return an error to the client that causes the build to fail if there is a failure to communicate with this repository.

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -23,7 +23,7 @@ type RepositoryBaseParams struct {
 	Description              string   `hcl:"description" json:"description,omitempty"`
 	Notes                    string   `hcl:"notes" json:"notes,omitempty"`
 	IncludesPattern          string   `hcl:"includes_pattern" json:"includesPattern,omitempty"`
-	ExcludesPattern          string   `hcl:"excludes_pattern" json:"excludesPattern,omitempty"`
+	ExcludesPattern          string   `json:"excludesPattern"`
 	RepoLayoutRef            string   `hcl:"repo_layout_ref" json:"repoLayoutRef,omitempty"`
 	RemoteRepoLayoutRef      string   `json:"remoteRepoLayoutRef"`
 	HardFail                 *bool    `hcl:"hard_fail" json:"hardFail,omitempty"`
@@ -159,13 +159,12 @@ var BaseRemoteRepoSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
 		Computed:    true,
-		Description: "List of artifact patterns to include when evaluating artifact requests in the form of x/y/**/z/*. When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included (**/*).",
+		Description: "List of comma-separated artifact patterns to include when evaluating artifact requests in the form of x/y/**/z/*. When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included (**/*).",
 	},
 	"excludes_pattern": {
 		Type:        schema.TypeString,
 		Optional:    true,
-		Computed:    true,
-		Description: "List of artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*. By default no artifacts are excluded.",
+		Description: "List of comma-separated artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*. By default no artifacts are excluded.",
 	},
 	"repo_layout_ref": {
 		Type:             schema.TypeString,
@@ -456,7 +455,7 @@ func UnpackBaseRemoteRepo(s *schema.ResourceData, packageType string) Repository
 		Description:              d.GetString("description", true),
 		Notes:                    d.GetString("notes", true),
 		IncludesPattern:          d.GetString("includes_pattern", true),
-		ExcludesPattern:          d.GetString("excludes_pattern", true),
+		ExcludesPattern:          d.GetString("excludes_pattern", false),
 		RepoLayoutRef:            d.GetString("repo_layout_ref", true),
 		HardFail:                 d.GetBoolRef("hard_fail", true),
 		Offline:                  d.GetBoolRef("offline", true),


### PR DESCRIPTION
* Set 'Computed' to false for excludes_pattern so that the attribute can be reset to empty string. TF SDK ignores empty string for computed attribute.
* Remove 'omitempty' tag for json marshaller so empty string will be emitted in json payload.
* Update documentation with clearer description.