### PR TITLE
Add download_direct parameter to remote repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.15.0 (August 31, 2022)
+
+IMPROVEMENTS:
+
+* resource/artifactory_remote_*_repostiory: Add attribute `download_direct`. PR: [#528](https://github.com/jfrog/terraform-provider-artifactory/pull/528)
+
 ## 6.14.1 (August 26, 2022). Tested on Artifactory 7.41.7
 
 BUG FIXES:

--- a/docs/resources/remote.md
+++ b/docs/resources/remote.md
@@ -77,3 +77,5 @@ All generic repo arguments are supported, in addition to:
   * `source_origin_absence_detection` - (Optional) If set, Artifactory displays an indication on cached items if they have been deleted from the corresponding repository in the remote Artifactory instance. Default value is 'false'.
 * `propagate_query_params` - (Optional, Default: false) When set, if query params are included in the request to Artifactory, they will be passed on to the remote repository.
 * `list_remote_folder_items` - (Optional, Default: false) Lists the items of remote folders in simple and list browsing. The remote content is cached according to the value of the 'Retrieval Cache Period'. This field exists in the API but not in the UI.
+* `download_direct` - (Optional, Default: false) When set, download requests to this repository will redirect the client to download 
+the artifact directly from the cloud storage provider. Available in Enterprise+ and Edge licenses only.

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -53,6 +53,7 @@ type RepositoryBaseParams struct {
 	ContentSynchronisation            *repository.ContentSynchronisation `hcl:"content_synchronisation" json:"contentSynchronisation,omitempty"`
 	MismatchingMimeTypeOverrideList   string                             `hcl:"mismatching_mime_types_override_list" json:"mismatchingMimeTypesOverrideList"`
 	ListRemoteFolderItems             bool                               `json:"listRemoteFolderItems"`
+	DownloadRedirect                  bool                               `hcl:"download_direct" json:"downloadRedirect,omitempty"`
 }
 
 type JavaRemoteRepo struct {
@@ -364,6 +365,12 @@ var BaseRemoteRepoSchema = map[string]*schema.Schema{
 		StateFunc:        util.FormatCommaSeparatedString,
 		Description:      `The set of mime types that should override the block_mismatching_mime_types setting. Eg: "application/json,application/xml". Default value is empty.`,
 	},
+	"download_direct": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+		Description: "When set, download requests to this repository will redirect the client to download the artifact directly from the cloud storage provider. Available in Enterprise+ and Edge licenses only. Default value is 'false'.",
+	},
 }
 
 var VcsRemoteRepoSchema = map[string]*schema.Schema{
@@ -461,6 +468,7 @@ func UnpackBaseRemoteRepo(s *schema.ResourceData, packageType string) Repository
 		Offline:                  d.GetBoolRef("offline", true),
 		BlackedOut:               d.GetBoolRef("blacked_out", true),
 		XrayIndex:                d.GetBool("xray_index", true),
+		DownloadRedirect:         d.GetBool("download_direct", false),
 		PropagateQueryParams:     d.GetBool("propagate_query_params", true),
 		StoreArtifactsLocally:    d.GetBoolRef("store_artifacts_locally", true),
 		SocketTimeoutMillis:      d.GetInt("socket_timeout_millis", true),

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
@@ -615,6 +615,7 @@ func mkNewRemoteTestCase(repoType string, t *testing.T, extraFields map[string]i
 		"content_synchronisation": map[string]interface{}{
 			"enabled": false, // even when set to true, it seems to come back as false on the wire
 		},
+		"download_direct": true,
 	}
 	allFields := util.MergeMaps(defaultFields, extraFields)
 	allFieldsHcl := util.FmtMapToHcl(allFields)


### PR DESCRIPTION
Adds support for setting the `download_direct` parameter on remote repositories. This parameter was already available on local repositories.