### PR TITLE
GH-329 Use projects API to assign/unassign repo to project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.16.0 (September 14, 2022)
+## 6.16.0 (September 14, 2022). Tested on Artifactory 7.41.12
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.16.0 (September 14, 2022)
+
+IMPROVEMENTS:
+
+* resource/artifactory_*_repostiory: Use projects API to assign/unassign to project when project_key is set/unset for existing repo. Issue: [#329](https://github.com/jfrog/terraform-provider-artifactory/issues/329) PR: [#537](https://github.com/jfrog/terraform-provider-artifactory/pull/537)
+
 ## 6.15.0 (August 31, 2022)
 
 IMPROVEMENTS:

--- a/pkg/artifactory/resource/repository/local/local.go
+++ b/pkg/artifactory/resource/repository/local/local.go
@@ -77,6 +77,7 @@ var BaseLocalRepoSchema = map[string]*schema.Schema{
 		MaxItems:    2,
 		Set:         schema.HashString,
 		Optional:    true,
+		Computed:    true,
 		Description: `Project environment for assigning this repository to. Allow values: "DEV" or "PROD"`,
 	},
 	"package_type": {

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_repository_test.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_repository_test.go
@@ -2,9 +2,6 @@ package local_test
 
 import (
 	"fmt"
-	"github.com/jfrog/terraform-provider-shared/util"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"math/rand"
 	"regexp"
 	"strings"
@@ -18,6 +15,9 @@ import (
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/local"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/security"
 	"github.com/jfrog/terraform-provider-shared/test"
+	"github.com/jfrog/terraform-provider-shared/util"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func TestAccLocalAlpineRepository(t *testing.T) {

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -115,6 +115,7 @@ var BaseRemoteRepoSchema = map[string]*schema.Schema{
 		MaxItems:    2,
 		Set:         schema.HashString,
 		Optional:    true,
+		Computed:    true,
 		Description: `Project environment for assigning this repository to. Allow values: "DEV" or "PROD"`,
 	},
 	"package_type": {

--- a/pkg/artifactory/resource/repository/repository_test.go
+++ b/pkg/artifactory/resource/repository/repository_test.go
@@ -1,0 +1,124 @@
+package repository_test
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/go-resty/resty/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
+	"github.com/jfrog/terraform-provider-shared/test"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccRepository_assign_project_key_gh_329(t *testing.T) {
+
+	rand.Seed(time.Now().UnixNano())
+	projectKey := fmt.Sprintf("t%d", test.RandomInt())
+	repoName := fmt.Sprintf("%s-generic-local", projectKey)
+
+	_, fqrn, name := test.MkNames(repoName, "artifactory_local_generic_repository")
+
+	localRepositoryBasic := util.ExecuteTemplate("TestAccLocalGenericRepository", `
+		resource "artifactory_local_generic_repository" "{{ .name }}" {
+		  key = "{{ .name }}"
+		}
+	`, map[string]interface{}{
+		"name": name,
+	})
+
+	localRepositoryWithProjectKey := util.ExecuteTemplate("TestAccLocalGenericRepository", `
+		resource "artifactory_local_generic_repository" "{{ .name }}" {
+		  key         = "{{ .name }}"
+	 	  project_key = "{{ .projectKey }}"
+		}
+	`, map[string]interface{}{
+		"name":       name,
+		"projectKey": projectKey,
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.CreateProject(t, projectKey)
+		},
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy: acctest.VerifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
+			acctest.DeleteProject(t, projectKey)
+			return acctest.CheckRepo(id, request)
+		}),
+		Steps: []resource.TestStep{
+			{
+				Config: localRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+				),
+			},
+			{
+				Config: localRepositoryWithProjectKey,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "project_key", projectKey),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRepository_unassign_project_key_gh_329(t *testing.T) {
+
+	rand.Seed(time.Now().UnixNano())
+	projectKey := fmt.Sprintf("t%d", test.RandomInt())
+	repoName := fmt.Sprintf("%s-generic-local", projectKey)
+
+	_, fqrn, name := test.MkNames(repoName, "artifactory_local_generic_repository")
+
+	localRepositoryWithProjectKey := util.ExecuteTemplate("TestAccLocalGenericRepository", `
+		resource "artifactory_local_generic_repository" "{{ .name }}" {
+		  key         = "{{ .name }}"
+	 	  project_key = "{{ .projectKey }}"
+		  project_environments = ["DEV"]
+		}
+	`, map[string]interface{}{
+		"name":       name,
+		"projectKey": projectKey,
+	})
+
+	localRepositoryNoProjectKey := util.ExecuteTemplate("TestAccLocalGenericRepository", `
+		resource "artifactory_local_generic_repository" "{{ .name }}" {
+		  key = "{{ .name }}"
+		}
+	`, map[string]interface{}{
+		"name": name,
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.CreateProject(t, projectKey)
+		},
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy: acctest.VerifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
+			acctest.DeleteProject(t, projectKey)
+			return acctest.CheckRepo(id, request)
+		}),
+		Steps: []resource.TestStep{
+			{
+				Config: localRepositoryWithProjectKey,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "project_key", projectKey),
+				),
+			},
+			{
+				Config: localRepositoryNoProjectKey,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "project_key", ""),
+				),
+			},
+		},
+	})
+}

--- a/pkg/artifactory/resource/repository/virtual/virtual.go
+++ b/pkg/artifactory/resource/repository/virtual/virtual.go
@@ -73,6 +73,7 @@ var BaseVirtualRepoSchema = map[string]*schema.Schema{
 		MaxItems:    2,
 		Set:         schema.HashString,
 		Optional:    true,
+		Computed:    true,
 		Description: `Project environment for assigning this repository to. Allow values: "DEV" or "PROD"`,
 	},
 	"package_type": {


### PR DESCRIPTION
Closes #329

* Use projects API to assign/unassign to project when `project_key` is set/unset for existing repo.
* Add `computed` attribute to repo `project_environment` attribute so default env will be stored in TF state, if it is not set originally in TF configuration.