### PR TITLE
Gh-542 remote repo layout is deprecated

### DIFF
--- a/docs/resources/remote.md
+++ b/docs/resources/remote.md
@@ -47,7 +47,7 @@ All generic repo arguments are supported, in addition to:
 * `excludes_pattern` - (Optional) List of comma-separated artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*. By default no artifacts are excluded.
 * `repo_layout_ref` - (Optional) Sets the layout that the repository should use for storing and identifying modules. A recommended layout that corresponds to the package type defined is suggested, and index packages uploaded and calculate metadata accordingly.
 * `remote_repo_layout_ref` - (Optional) Deprecated field. This field has currently no effect, because there is no no corresponding field in the API body, and it's not returned by the GET call.
-* `hard_fail` - (Optional) When set, Artifactory will return an error to the client that causes the build to fail if there is a failure to communicate with this repository.
+* `hard_fail` - (Optional) When set, Artifactory will return an error to the client that causes the build to fail if there is a failure to communicate with this repository. It is also 'Computed', so, if used, Terraform will try to re-apply it on the next apply command.
 * `offline` - (Optional) If set, Artifactory does not try to fetch remote artifacts. Only locally-cached artifacts are retrieved.
 * `blacked_out` - (Optional) (A.K.A 'Ignore Repository' on the UI) When set, the repository or its local cache do not participate in artifact resolution.
 * `xray_index` - (Optional, Default: false) Enable Indexing In Xray. Repository will be indexed with the default retention period. You will be able to change it via Xray settings.

--- a/docs/resources/remote.md
+++ b/docs/resources/remote.md
@@ -46,7 +46,7 @@ All generic repo arguments are supported, in addition to:
 * `includes_pattern` - (Optional) List of comma-separated artifact patterns to include when evaluating artifact requests in the form of x/y/\**/z/*. When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included (**/*).
 * `excludes_pattern` - (Optional) List of comma-separated artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*. By default no artifacts are excluded.
 * `repo_layout_ref` - (Optional) Sets the layout that the repository should use for storing and identifying modules. A recommended layout that corresponds to the package type defined is suggested, and index packages uploaded and calculate metadata accordingly.
-* `remote_repo_layout_ref` - (Optional) Repository layout key for the remote layout mapping.
+* `remote_repo_layout_ref` - (Optional) Deprecated field. This field has currently no effect, because there is no no corresponding field in the API body, and it's not returned by the GET call.
 * `hard_fail` - (Optional) When set, Artifactory will return an error to the client that causes the build to fail if there is a failure to communicate with this repository.
 * `offline` - (Optional) If set, Artifactory does not try to fetch remote artifacts. Only locally-cached artifacts are retrieved.
 * `blacked_out` - (Optional) (A.K.A 'Ignore Repository' on the UI) When set, the repository or its local cache do not participate in artifact resolution.

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -179,6 +179,7 @@ var BaseRemoteRepoSchema = map[string]*schema.Schema{
 		Optional:    true,
 		Computed:    true,
 		Description: "Repository layout key for the remote layout mapping",
+		Deprecated:  "This field has currently no effect, because there is no no corresponding field in the API body, and it's not returned by the GET call.",
 	},
 	"hard_fail": {
 		Type:     schema.TypeBool,

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
@@ -2,9 +2,6 @@ package remote_test
 
 import (
 	"fmt"
-	"github.com/jfrog/terraform-provider-shared/util"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"io/ioutil"
 	"math/rand"
 	"regexp"
@@ -21,6 +18,9 @@ import (
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/security"
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/test"
+	"github.com/jfrog/terraform-provider-shared/util"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func TestAccRemoteAllowDotsUnderscorersAndDashesInKeyGH129(t *testing.T) {


### PR DESCRIPTION
`remote_repo_layout_ref` is ignored in the Artifactory API call. Also, it's computed and creates confusion for the users. 
[JSON body](https://www.jfrog.com/confluence/display/JFROG/Repository+Configuration+JSON#RepositoryConfigurationJSON-RemoteRepository) for the [Create repository](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateRepository) call doesn't have this field. 