### PR TITLE
Remove 'doc' command from makefile

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -54,7 +54,4 @@ fmt:
 	@echo "==> Fixing source code with gofmt..."
 	@go fmt ./...
 
-doc:
-	go generate
-
 .PHONY: build fmt


### PR DESCRIPTION
Until https://github.com/hashicorp/terraform-plugin-docs is updated with bug fixes and other features, and we can use it on this repo.

Fixes #552 