### PR TITLE
Add deprecation notice for `artifactory_api_key` resource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.16.3 (October 12, 2022)
+## 6.16.3 (October 12, 2022). Tested on Artifactory 7.46.3
 
 DEPRECATION:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.16.3 (October 12, 2022)
+
+DEPRECATION:
+
+* resource/artifactory_api_key: added deprecation notice. The API key support will be removed in upcoming versions of Artifactory. 
+
+
 ## 6.16.2 (October 11, 2022)
 
 IMPROVEMENTS:

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -22,7 +22,7 @@ The following attributes are exported:
 * `api_key` - The API key. Deprecated. An upcoming version will support the option to block the usage/creation of API Keys (for admins to set on their platform).
   In September 2022, the option to block the usage/creation of API Keys will be enabled by default, with the option for admins to change it back to enable API Keys.
   In January 2023, API Keys will be deprecated all together and the option to use them will no longer be available.
-  It is recommended to use scoped tokens instead - `artifactory_access_token` resource.
+  It is recommended to use scoped tokens instead - `artifactory_scoped_token` resource.
   Please check the [release notes](https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.38.4).
 
 ## Import

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -22,6 +22,7 @@ The following attributes are exported:
 * `api_key` - The API key. Deprecated. An upcoming version will support the option to block the usage/creation of API Keys (for admins to set on their platform).
   In September 2022, the option to block the usage/creation of API Keys will be enabled by default, with the option for admins to change it back to enable API Keys.
   In January 2023, API Keys will be deprecated all together and the option to use them will no longer be available.
+  It is recommended to use scoped tokens instead - `artifactory_access_token` resource.
   Please check the [release notes](https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.38.4).
 
 ## Import

--- a/docs/resources/api_key.md
+++ b/docs/resources/api_key.md
@@ -19,7 +19,10 @@ resource "artifactory_api_key" "ci" {}
 
 The following attributes are exported:
 
-* `api_key` - The API key.
+* `api_key` - The API key. Deprecated. An upcoming version will support the option to block the usage/creation of API Keys (for admins to set on their platform).
+  In September 2022, the option to block the usage/creation of API Keys will be enabled by default, with the option for admins to change it back to enable API Keys.
+  In January 2023, API Keys will be deprecated all together and the option to use them will no longer be available.
+  Please check the [release notes](https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.38.4).
 
 ## Import
 

--- a/pkg/artifactory/resource/security/resource_artifactory_api_key.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_api_key.go
@@ -22,6 +22,11 @@ func ResourceArtifactoryApiKey() *schema.Resource {
 		CreateContext: resourceApiKeyCreate,
 		ReadContext:   resourceApiKeyRead,
 		DeleteContext: apiKeyRevoke,
+		DeprecationMessage: "An upcoming version will support the option to block the usage/creation of API Keys (for admins to set on their platform).\n" +
+			"In September 2022, the option to block the usage/creation of API Keys will be enabled by default, with the option for admins to change it back to enable API Keys.\n" +
+			"In January 2023, API Keys will be deprecated all together and the option to use them will no longer be available.\n" +
+			"It is recommended to use scoped tokens instead - `artifactory_access_token` resource.\n" +
+			"Please check the release notes: https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.38.4",
 
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
@@ -32,10 +37,6 @@ func ResourceArtifactoryApiKey() *schema.Resource {
 				Type:      schema.TypeString,
 				Computed:  true,
 				Sensitive: true,
-				Deprecated: "An upcoming version will support the option to block the usage/creation of API Keys (for admins to set on their platform).\n" +
-					"In September 2022, the option to block the usage/creation of API Keys will be enabled by default, with the option for admins to change it back to enable API Keys.\n" +
-					"In January 2023, API Keys will be deprecated all together and the option to use them will no longer be available.\n" +
-					"Please check the release notes: https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.38.4",
 			},
 		},
 	}

--- a/pkg/artifactory/resource/security/resource_artifactory_api_key.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_api_key.go
@@ -25,7 +25,7 @@ func ResourceArtifactoryApiKey() *schema.Resource {
 		DeprecationMessage: "An upcoming version will support the option to block the usage/creation of API Keys (for admins to set on their platform).\n" +
 			"In September 2022, the option to block the usage/creation of API Keys will be enabled by default, with the option for admins to change it back to enable API Keys.\n" +
 			"In January 2023, API Keys will be deprecated all together and the option to use them will no longer be available.\n" +
-			"It is recommended to use scoped tokens instead - `artifactory_access_token` resource.\n" +
+			"It is recommended to use scoped tokens instead - `artifactory_scoped_token` resource.\n" +
 			"Please check the release notes: https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.38.4",
 
 		Importer: &schema.ResourceImporter{

--- a/pkg/artifactory/resource/security/resource_artifactory_api_key.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_api_key.go
@@ -32,6 +32,10 @@ func ResourceArtifactoryApiKey() *schema.Resource {
 				Type:      schema.TypeString,
 				Computed:  true,
 				Sensitive: true,
+				Deprecated: "An upcoming version will support the option to block the usage/creation of API Keys (for admins to set on their platform).\n" +
+					"In September 2022, the option to block the usage/creation of API Keys will be enabled by default, with the option for admins to change it back to enable API Keys.\n" +
+					"In January 2023, API Keys will be deprecated all together and the option to use them will no longer be available.\n" +
+					"Please check the release notes: https://www.jfrog.com/confluence/display/JFROG/Artifactory+Release+Notes#ArtifactoryReleaseNotes-Artifactory7.38.4",
 			},
 		},
 	}


### PR DESCRIPTION
The support for API key will be removed in upcoming versions of Artifactory.