### PR TITLE
Fix tests

### DIFF
--- a/docs/resources/unmanaged_user.md
+++ b/docs/resources/unmanaged_user.md
@@ -25,7 +25,7 @@ The following arguments are supported:
 
 * `name` - (Required) Username for user.
 * `email` - (Required) Email for user.
-* `password` - (Optional) Password for the user. When omitted, a random password is generated using the following password policy: 10 characters with 1 digit, 1 symbol, with upper and lower case letters.
+* `password` - (Optional) Password for the user. When omitted, a random password is generated using the following password policy: 12 characters with 1 digit, 1 symbol, with upper and lower case letters.
 * `admin` - (Optional) When enabled, this user is an administrator with all the ensuing privileges. Default value is `false`.
 * `profile_updatable` - (Optional) When set, this user can update his profile details (except for the password. Only an administrator can update the password). Default value is `true`.
 * `disable_ui_access` - (Optional) When set, this user can only access Artifactory through the REST API. This option cannot be set if the user has Admin privileges. Default value is `true`.

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -25,7 +25,7 @@ The following arguments are supported:
 
 * `name` - (Required) Username for user.
 * `email` - (Required) Email for user.
-* `password` - (Optional) Password for the user. When omitted, a random password is generated using the following password policy: 10 characters with 1 digit, 1 symbol, with upper and lower case letters.
+* `password` - (Optional) Password for the user. When omitted, a random password is generated using the following password policy: 12 characters with 1 digit, 1 symbol, with upper and lower case letters.
 * `admin` - (Optional) When enabled, this user is an administrator with all the ensuing privileges. Default value is `false`.
 * `profile_updatable` - (Optional) When set, this user can update his profile details (except for the password. Only an administrator can update the password). Default value is `true`.
 * `disable_ui_access` - (Optional) When set, this user can only access Artifactory through the REST API. This option cannot be set if the user has Admin privileges. Default value is `true`.

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
@@ -81,6 +81,7 @@ func TestAccScopedToken_WithAttributes(t *testing.T) {
 			scopes      = ["applied-permissions/admin", "system:metrics:r"]
 			description = "test description"
 			refreshable = true
+			expires_in  = 31536000
 			audiences   = ["jfrt@1", "jfxr@*"]
 		}`,
 		map[string]interface{}{
@@ -100,6 +101,7 @@ func TestAccScopedToken_WithAttributes(t *testing.T) {
 					resource.TestCheckTypeSetElemAttr(fqrn, "scopes.*", "applied-permissions/admin"),
 					resource.TestCheckTypeSetElemAttr(fqrn, "scopes.*", "system:metrics:r"),
 					resource.TestCheckResourceAttr(fqrn, "refreshable", "true"),
+					resource.TestCheckResourceAttr(fqrn, "expires_in", "31536000"),
 					resource.TestCheckResourceAttr(fqrn, "description", "test description"),
 					resource.TestCheckResourceAttr(fqrn, "audiences.#", "2"),
 					resource.TestCheckTypeSetElemAttr(fqrn, "audiences.*", "jfrt@1"),

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
@@ -2,11 +2,11 @@ package security_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/security"
 	"github.com/jfrog/terraform-provider-shared/test"
 	"github.com/jfrog/terraform-provider-shared/util"
@@ -46,7 +46,6 @@ func TestAccScopedToken_WithDefaults(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "username", "testuser"),
 					resource.TestCheckResourceAttr(fqrn, "scopes.#", "1"),
 					resource.TestCheckTypeSetElemAttr(fqrn, "scopes.*", "applied-permissions/user"),
-					resource.TestCheckResourceAttr(fqrn, "expires_in", "31536000"),
 					resource.TestCheckResourceAttr(fqrn, "refreshable", "false"),
 					resource.TestCheckResourceAttr(fqrn, "description", "test description"),
 					resource.TestCheckNoResourceAttr(fqrn, "audiences"),

--- a/pkg/artifactory/resource/user/resource_artifactory_user.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_user.go
@@ -16,7 +16,7 @@ func ResourceArtifactoryUser() *schema.Resource {
 			Sensitive: true,
 			Optional:  true,
 			Description: "(Optional, Sensitive) Password for the user. When omitted, a random password is generated using the following password policy: " +
-				"10 characters with 1 digit, 1 symbol, with upper and lower case letters",
+				"12 characters with 1 digit, 1 symbol, with upper and lower case letters",
 		},
 	}
 	maps.Copy(userSchema, baseUserSchema)
@@ -46,12 +46,12 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m interface
 			diags = append(diags, diag.Diagnostic{
 				Severity: diag.Warning,
 				Summary:  "No password supplied",
-				Detail:   "One will be generated (10 characters with 1 digit, 1 symbol, with upper and lower case letters) and this may fail as your Artifactory password policy can't be determined by the provider.",
+				Detail:   "One will be generated (12 characters with 1 digit, 1 symbol, with upper and lower case letters) and this may fail as your Artifactory password policy can't be determined by the provider.",
 			})
 
-			// Generate a password that is 10 characters long with 1 digit, 1 symbol,
+			// Generate a password that is 12 characters long with 1 digit, 1 symbol,
 			// allowing upper and lower case letters, disallowing repeat characters.
-			randomPassword, err := password.Generate(10, 1, 1, false, false)
+			randomPassword, err := password.Generate(12, 1, 1, false, false)
 			if err != nil {
 				return diag.Errorf("failed to generate password. %v", err)
 			}

--- a/scripts/run-artifactory-container.sh
+++ b/scripts/run-artifactory-container.sh
@@ -4,7 +4,7 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 source "${SCRIPT_DIR}/get-access-key.sh"
 source "${SCRIPT_DIR}/wait-for-rt.sh"
 
-export ARTIFACTORY_VERSION=${ARTIFACTORY_VERSION:-7.37.15}
+export ARTIFACTORY_VERSION=${ARTIFACTORY_VERSION:-7.46.3}
 echo "ARTIFACTORY_VERSION=${ARTIFACTORY_VERSION}" > /dev/stderr
 
 set -euf

--- a/scripts/run-artifactory.sh
+++ b/scripts/run-artifactory.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 source "${SCRIPT_DIR}/get-access-key.sh"
 source "${SCRIPT_DIR}/wait-for-rt.sh"
-export ARTIFACTORY_VERSION=${ARTIFACTORY_VERSION:-7.41.12}
+export ARTIFACTORY_VERSION=${ARTIFACTORY_VERSION:-7.46.3}
 echo "ARTIFACTORY_VERSION=${ARTIFACTORY_VERSION}"
 
 set -euf


### PR DESCRIPTION
In Artifactory 7.46.3 we don't have the `expires_in` attribute for the scoped token if it was not set explicitly. That change caused the test to fail because we expected that attribute. I've removed it from `TestAccScopedToken_WithDefaults` and added the attribute verification to `TestAccScopedToken_WithAttributes`. 
Also, sometimes password generator fails to generate the password matching Artifactory requirements. I've increased the length of the generated password. 