### PR TITLE
GH-549 nuget symbol server url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.18.0 (October 21, 2022)
+## 6.18.0 (October 21, 2022). Tested on Artifactory 7.46.6
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.18.0 (October 21, 2022)
+
+* resource/artifactory_remote_nuget_repository: added new attribute `symbol_server_url`. Issue: [#549](https://github.com/jfrog/terraform-provider-artifactory/issues/549)
+ PR: [#567](https://github.com/jfrog/terraform-provider-artifactory/pull/567)
+
 ## 6.17.1 (October 21, 2022)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,19 @@
 ## 6.18.0 (October 21, 2022)
 
+IMPROVEMENTS:
+
 * resource/artifactory_remote_nuget_repository: added new attribute `symbol_server_url`. Issue: [#549](https://github.com/jfrog/terraform-provider-artifactory/issues/549)
  PR: [#567](https://github.com/jfrog/terraform-provider-artifactory/pull/567)
 
 ## 6.17.1 (October 21, 2022)
 
-IMPROVEMENTS:
+BUG FIX:
 
 * Update documentation to change incorrect repository type reference 'gem' to correct type 'gems'. Issue: [#541](https://github.com/jfrog/terraform-provider-artifactory/issues/541) PR: [#566](https://github.com/jfrog/terraform-provider-artifactory/pull/566)
 
 ## 6.17.0 (October 21, 2022). Tested on Artifactory 7.46.6
+
+IMPROVEMENTS:
 
 * resource/artifactory_federated_swift_repository: added new resource. Issue: [#540](https://github.com/jfrog/terraform-provider-artifactory/issues/540)
  PR: [#565](https://github.com/jfrog/terraform-provider-artifactory/pull/565)

--- a/docs/resources/remote_nuget_repository.md
+++ b/docs/resources/remote_nuget_repository.md
@@ -16,6 +16,7 @@ resource "artifactory_remote_nuget_repository" "my-remote-nuget" {
   download_context_path       = "api/v2/package"
   force_nuget_authentication  = true
   v3_feed_url                 = "https://api.nuget.org/v3/index.json"
+  symbol_server_url           = "https://symbols.nuget.org/download/symbols"
 }
 ```
 
@@ -35,6 +36,7 @@ The following arguments are supported, along with the [common list of arguments 
    URL should be configured as 'https://nuget.org' and the download context path should be configured as 'api/v2/package'. Default value is 'api/v2/package'.
 * `v3_feed_url` - (Optional) The URL to the NuGet v3 feed. Default value is 'https://api.nuget.org/v3/index.json'.
 * `force_nuget_authentication` - (Optional) Force basic authentication credentials in order to use this repository. Default value is 'false'.
+* `symbol_server_url` - (Optional) NuGet symbol server URL. Default value is `https://symbols.nuget.org/download/symbols`.
 
 
 

--- a/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_generic_repository.go
+++ b/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_generic_repository.go
@@ -2,15 +2,15 @@ package federated
 
 import (
 	"fmt"
-	"github.com/jfrog/terraform-provider-shared/packer"
-	"github.com/jfrog/terraform-provider-shared/predicate"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/local"
+	"github.com/jfrog/terraform-provider-shared/packer"
+	"github.com/jfrog/terraform-provider-shared/predicate"
 	"github.com/jfrog/terraform-provider-shared/util"
-	"strings"
 )
 
 func ResourceArtifactoryFederatedGenericRepository(repoType string) *schema.Resource {

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository.go
@@ -14,6 +14,7 @@ type NugetRemoteRepo struct {
 	DownloadContextPath      string `json:"downloadContextPath"`
 	V3FeedUrl                string `hcl:"v3_feed_url" json:"v3FeedUrl"` // Forced to specify hcl tag because predicate is not parsed by packer.Universal function.
 	ForceNugetAuthentication bool   `json:"forceNugetAuthentication"`
+	SymbolServerUrl          string `json:"symbolServerUrl"`
 }
 
 func ResourceArtifactoryRemoteNugetRepository() *schema.Resource {
@@ -46,6 +47,13 @@ func ResourceArtifactoryRemoteNugetRepository() *schema.Resource {
 			Default:     false,
 			Description: `Force basic authentication credentials in order to use this repository. Default value is 'false'.`,
 		},
+		"symbol_server_url": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			Default:          "https://symbols.nuget.org/download/symbols",
+			ValidateDiagFunc: validation.ToDiagFunc(validation.Any(validation.IsURLWithHTTPorHTTPS, validation.StringIsEmpty)),
+			Description:      `NuGet symbol server URL.`,
+		},
 	}, repository.RepoLayoutRefSchema("remote", packageType))
 
 	var unpackNugetRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
@@ -56,6 +64,7 @@ func ResourceArtifactoryRemoteNugetRepository() *schema.Resource {
 			DownloadContextPath:      d.GetString("download_context_path", false),
 			V3FeedUrl:                d.GetString("v3_feed_url", false),
 			ForceNugetAuthentication: d.GetBool("force_nuget_authentication", false),
+			SymbolServerUrl:          d.GetString("symbol_server_url", false),
 		}
 		return repo, repo.Id(), nil
 	}

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
@@ -475,6 +475,7 @@ func TestAccRemoteNugetRepository(t *testing.T) {
 		"download_context_path":       "api/v2/package",
 		"force_nuget_authentication":  true,
 		"missed_cache_period_seconds": 1800,
+		"symbol_server_url":           "https://symbols.nuget.org/download/symbols",
 	}))
 }
 


### PR DESCRIPTION
Add a new attribute `symbol_server_url` to NuGet remote repository.