### PR TITLE
GH-563, GH-564 add an attribute to docker virtual repo, add cron tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.19.0 (October 25, 2022)
+
+IMPROVEMENTS:
+
+* resource/artifactory_virtual_docker_repository: added new attribute `resolve_docker_tags_by_timestamp`. Issue: [#563](https://github.com/jfrog/terraform-provider-artifactory/issues/563)
+ [#PR]()
+
 ## 6.18.0 (October 21, 2022). Tested on Artifactory 7.46.6
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 IMPROVEMENTS:
 
 * resource/artifactory_virtual_docker_repository: added new attribute `resolve_docker_tags_by_timestamp`. Issue: [#563](https://github.com/jfrog/terraform-provider-artifactory/issues/563)
- [#PR]()
+ PR: [#PR](https://github.com/jfrog/terraform-provider-artifactory/pull/569)
+* resource/artifactory_backup: added a format note to the documentation.Issue: [#564](https://github.com/jfrog/terraform-provider-artifactory/issues/564) 
 
 ## 6.18.0 (October 21, 2022). Tested on Artifactory 7.46.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.19.0 (October 25, 2022)
+## 6.19.0 (October 25, 2022). Tested on Artifactory 7.46.8
 
 IMPROVEMENTS:
 

--- a/docs/resources/backup.md
+++ b/docs/resources/backup.md
@@ -17,7 +17,7 @@ The backup process creates a time-stamped directory in the target backup directo
 resource "artifactory_backup" "backup_config_name" {
   key                       = "backup_config_name"
   enabled                   = true
-  cron_exp                  = "0 0 12 * * ?"
+  cron_exp                  = "0 0 12 * * ? *"
   retention_period_hours    = 1000
   excluded_repositories     = []
   create_archive            = false
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `key`                          - (Required) The unique ID of the artifactory backup config.
 * `enabled`                      - (Optional) Flag to enable or disable the backup config. Default value is `true`.
-* `cron_exp`                     - (Required) A valid CRON expression that you can use to control backup frequency. Eg: "0 0 12 * * ? ".
+* `cron_exp`                     - (Required) A valid CRON expression that you can use to control backup frequency. Eg: "0 0 12 * * ? *", "0 0 2 ? * MON-SAT *". Note: please use 7 character format - Seconds,	Minutes	Hours, Day Of Month, Month, Day Of Week, Year.
 * `retention_period_hours`       - (Optional) The number of hours to keep a backup before Artifactory will clean it up to free up disk space. Applicable only to non-incremental backups. Default value is 168 hours ie: 7 days.
 * `excluded_repositories`        - (Optional) A list of excluded repositories from the backup. Default is empty list.
 * `create_archive`               - (Optional) If set, backups will be created within a Zip archive (Slow and CPU intensive). Default value is `false`.

--- a/docs/resources/virtual_docker_repository.md
+++ b/docs/resources/virtual_docker_repository.md
@@ -10,12 +10,13 @@ Official documentation can be found [here](https://www.jfrog.com/confluence/disp
 
 ```hcl
 resource "artifactory_virtual_docker_repository" "foo-docker" {
-  key                 = "foo-docker"
-  repositories        = []
-  description         = "A test virtual repo"
-  notes               = "Internal description"
-  includes_pattern    = "com/jfrog/**,cloud/jfrog/**"
-  excludes_pattern    = "com/google/**"
+  key                               = "foo-docker"
+  repositories                      = []
+  description                       = "A test virtual repo"
+  notes                             = "Internal description"
+  includes_pattern                  = "com/jfrog/**,cloud/jfrog/**"
+  excludes_pattern                  = "com/google/**"
+  resolve_docker_tags_by_timestamp  = true
 }
 ```
 
@@ -29,6 +30,7 @@ The following arguments are supported, along with the [common list of arguments 
 * `repositories` - (Optional) The effective list of actual repositories included in this virtual repository.
 * `description` - (Optional)
 * `notes` - (Optional)
+* `resolve_docker_tags_by_timestamp` - (Optional) When enabled, in cases where the same Docker tag exists in two or more of the aggregated repositories, Artifactory will return the tag that has the latest timestamp. Default values is `false`.
 
 ## Import
 

--- a/pkg/artifactory/provider/provider.go
+++ b/pkg/artifactory/provider/provider.go
@@ -56,6 +56,7 @@ func Provider() *schema.Provider {
 		"artifactory_virtual_alpine_repository":           virtual.ResourceArtifactoryVirtualAlpineRepository(),
 		"artifactory_virtual_bower_repository":            virtual.ResourceArtifactoryVirtualBowerRepository(),
 		"artifactory_virtual_debian_repository":           virtual.ResourceArtifactoryVirtualDebianRepository(),
+		"artifactory_virtual_docker_repository":           virtual.ResourceArtifactoryVirtualDockerRepository(),
 		"artifactory_virtual_maven_repository":            virtual.ResourceArtifactoryVirtualJavaRepository("maven"),
 		"artifactory_virtual_npm_repository":              virtual.ResourceArtifactoryVirtualNpmRepository(),
 		"artifactory_virtual_nuget_repository":            virtual.ResourceArtifactoryVirtualNugetRepository(),

--- a/pkg/artifactory/resource/configuration/resource_artifactory_backup_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_backup_test.go
@@ -9,6 +9,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/configuration"
+	"github.com/jfrog/terraform-provider-shared/util"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func TestAccBackup_full(t *testing.T) {
@@ -16,7 +19,7 @@ func TestAccBackup_full(t *testing.T) {
 resource "artifactory_backup" "backuptest" {
     key = "backuptest"
     enabled = true
-    cron_exp = "0 0 12 * * ?"
+    cron_exp = "0 0 2 ? * MON-SAT *"
 }`
 
 	const BackupTemplateUpdate = `
@@ -31,7 +34,7 @@ resource "artifactory_local_generic_repository" "test-backup-local2" {
 resource "artifactory_backup" "backuptest" {
     key                    = "backuptest"
     enabled                = false
-    cron_exp               = "0 0 12 * * ?"
+    cron_exp               = "0 0 12 * * ? *"
     retention_period_hours = 1000
     excluded_repositories  = [ "test-backup-local1", "test-backup-local2" ]
 	create_archive         = true
@@ -67,6 +70,54 @@ resource "artifactory_backup" "backuptest" {
 			},
 		},
 	})
+}
+
+func TestAccCronExpressions(t *testing.T) {
+	cronExpressions := [...]string{
+		"10/20 15 14 5-10 * ? *",
+		"* 5,7,9 14-16 * * ? *",
+		"* 5,7,9 14/2 * * WED,Sat *",
+		"* * * * * ? *",
+		"* * 14/2 * * mon/3 *",
+		"* 5-9 14/2 * * 1-3 *",
+		"*/3 */51 */12 */2 */4 ? *",
+		"* 5 22-23 * * Sun *",
+	}
+	for _, cron := range cronExpressions {
+		title := fmt.Sprintf("TestBackupCronExpression_%s", cases.Title(language.AmericanEnglish).String(cron))
+		t.Run(title, func(t *testing.T) {
+			resource.Test(cronTestCase(cron, t))
+		})
+	}
+}
+
+func cronTestCase(cronExpression string, t *testing.T) (*testing.T, resource.TestCase) {
+	resourceName := fmt.Sprintf("artifactory_backup.backuptest")
+
+	fields := map[string]interface{}{
+		"cron_exp": cronExpression,
+	}
+
+	const BackupTemplateFull = `
+	resource "artifactory_backup" "backuptest" {
+		key = "backuptest"
+		enabled = true
+		cron_exp = "{{ .cron_exp }}"
+	}`
+
+	return t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      acctest.VerifyDeleted(resourceName, acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: util.ExecuteTemplate("backup", BackupTemplateFull, fields),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "cron_exp", cronExpression),
+				),
+			},
+		},
+	}
 }
 
 func testAccBackupDestroy(id string) func(*terraform.State) error {

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_docker_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_docker_repository.go
@@ -1,0 +1,48 @@
+package virtual
+
+import (
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-shared/packer"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func ResourceArtifactoryVirtualDockerRepository() *schema.Resource {
+
+	const packageType = "docker"
+
+	dockerVirtualSchema := util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
+		"resolve_docker_tags_by_timestamp": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "When enabled, in cases where the same Docker tag exists in two or more of the aggregated repositories, Artifactory will return the tag that has the latest timestamp.",
+		},
+	}, repository.RepoLayoutRefSchema("virtual", packageType))
+
+	type DockerVirtualRepositoryParams struct {
+		RepositoryBaseParams
+		ResolveDockerTagsByTimestamp bool `json:"resolveDockerTagsByTimestamp"`
+	}
+
+	unpackDockerVirtualRepository := func(data *schema.ResourceData) (interface{}, string, error) {
+		d := &util.ResourceData{ResourceData: data}
+		repo := DockerVirtualRepositoryParams{
+			RepositoryBaseParams:         UnpackBaseVirtRepo(data, "docker"),
+			ResolveDockerTagsByTimestamp: d.GetBool("resolve_docker_tags_by_timestamp", false),
+		}
+
+		return repo, repo.Id(), nil
+	}
+
+	constructor := func() interface{} {
+		return &DockerVirtualRepositoryParams{
+			RepositoryBaseParams: RepositoryBaseParams{
+				Rclass:      "virtual",
+				PackageType: packageType,
+			},
+		}
+	}
+
+	return repository.MkResourceSchema(dockerVirtualSchema, packer.Default(dockerVirtualSchema), unpackDockerVirtualRepository, constructor)
+}

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
@@ -2,22 +2,22 @@ package virtual_test
 
 import (
 	"fmt"
-	"github.com/go-resty/resty/v2"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"golang.org/x/text/cases"
-	"golang.org/x/text/language"
 	"math/rand"
 	"regexp"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/go-resty/resty/v2"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/security"
 	"github.com/jfrog/terraform-provider-shared/test"
 	"github.com/jfrog/terraform-provider-shared/util"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func TestAccVirtualRepository_basic(t *testing.T) {
@@ -686,8 +686,8 @@ func TestAccAllVirtualGradleLikeRepository(t *testing.T) {
 
 // if you wish to override any of the default fields, just pass it as "extraFields" as these will overwrite
 func mkNewVirtualTestCase(repoType string, t *testing.T, extraFields map[string]interface{}) (*testing.T, resource.TestCase) {
-	_, fqrn, name := test.MkNames("terraform-virtual-test-repo-full", fmt.Sprintf("artifactory_virtual_%s_repository", repoType))
-	remoteRepoName := fmt.Sprintf("%s-local", name)
+	_, fqrn, name := test.MkNames("terraform-virtual-test-repo-full-", fmt.Sprintf("artifactory_virtual_%s_repository", repoType))
+	remoteRepoName := fmt.Sprintf("%s-remote", name)
 	defaultFields := map[string]interface{}{
 		"key":         name,
 		"description": "A test virtual repo",
@@ -736,6 +736,13 @@ func TestAccVirtualNugetRepository(t *testing.T) {
 	resource.Test(mkNewVirtualTestCase("nuget", t, map[string]interface{}{
 		"description":                "nuget virtual repository public description testing.",
 		"force_nuget_authentication": true,
+	}))
+}
+
+func TestAccVirtualDockerRepository(t *testing.T) {
+	resource.Test(mkNewVirtualTestCase("docker", t, map[string]interface{}{
+		"description":                      "docker virtual repository public description testing.",
+		"resolve_docker_tags_by_timestamp": true,
 	}))
 }
 

--- a/pkg/artifactory/resource/repository/virtual/virtual.go
+++ b/pkg/artifactory/resource/repository/virtual/virtual.go
@@ -34,7 +34,6 @@ func (bp RepositoryBaseParams) Id() string {
 }
 
 var RepoTypesLikeGeneric = []string{
-	"docker",
 	"gems",
 	"generic",
 	"gitlfs",


### PR DESCRIPTION
resource_artifactory_virtual_docker_repository.go - add `resolve_docker_tags_by_timestamp` attribute and tests. 
resource_artifactory_backup.go - added more cron tests, and clarified cron format info in the doc file.