### PR TITLE
Set `sensitive` on `access_token` and `refresh_token`

### DIFF
--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
@@ -180,10 +180,12 @@ func ResourceArtifactoryScopedToken() *schema.Resource {
 		"access_token": {
 			Type:     schema.TypeString,
 			Computed: true,
+			Sensitive: true,
 		},
 		"refresh_token": {
 			Type:     schema.TypeString,
 			Computed: true,
+			Sensitive: true,
 		},
 		"token_type": {
 			Type:     schema.TypeString,


### PR DESCRIPTION
Adding the `sensitive` attribute to the `access_token` and `refresh_token` properties, which appear to have been overlooked with the newer scoped token (they exist on the deprecated access token resource).

This was a surprise when the tokens appeared in the Terraform logs during a change and presents a serious security risk.

Adding the `sensitive` attribute should resolve the issue.