### PR TITLE
GH-574 signing issue with the keypair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.19.2 (November 11, 2022).
+
+IMPROVEMENTS:
+
+* resources/artifactory_keypair: add `passphrase` attribute to the JSON body. No API errors in Artifactory 7.41.13 and up. Issue: [#574](https://github.com/jfrog/terraform-provider-artifactory/issues/574)
+PR: [#]()
+
 ## 6.19.1 (November 11, 2022). Tested on Artifactory 7.46.11
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 IMPROVEMENTS:
 
 * resources/artifactory_keypair: add `passphrase` attribute to the JSON body. No API errors in Artifactory 7.41.13 and up. Issue: [#574](https://github.com/jfrog/terraform-provider-artifactory/issues/574)
-PR: [#]()
+PR: [#581](https://github.com/jfrog/terraform-provider-artifactory/pull/581)
 
 ## 6.19.1 (November 11, 2022). Tested on Artifactory 7.46.11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 6.19.2 (November 11, 2022).
 
-IMPROVEMENTS:
+BUG FIX:
 
 * resources/artifactory_keypair: add `passphrase` attribute to the JSON body. No API errors in Artifactory 7.41.13 and up. Issue: [#574](https://github.com/jfrog/terraform-provider-artifactory/issues/574)
 PR: [#581](https://github.com/jfrog/terraform-provider-artifactory/pull/581)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.19.2 (November 11, 2022).
+## 6.19.2 (November 11, 2022). Tested on Artifactory 7.46.11
 
 BUG FIX:
 

--- a/docs/resources/keypair.md
+++ b/docs/resources/keypair.md
@@ -8,8 +8,6 @@ used to sign and validate packages integrity in JFrog Distribution. The JFrog Pl
 RSA and GPG signing keys through the Keys Management UI and REST API. The JFrog Platform supports managing multiple 
 pairs of GPG signing keys to sign packages for authentication of several package types such as Debian, Opkg, and RPM 
 through the Keys Management UI and REST API.
-Passphrases are not currently supported, though they exist in the API.
-
 
 ## Example Usage
 
@@ -28,6 +26,7 @@ resource "artifactory_keypair" "some-keypair6543461672124900137" {
   alias       = "foo-alias6543461672124900137"
   private_key = file("samples/rsa.priv")
   public_key  = file("samples/rsa.pub")
+  passphrase  = "PASSPHRASE"
   
   lifecycle {
     ignore_changes = [

--- a/pkg/artifactory/resource/security/resource_artifactory_keypair.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_keypair.go
@@ -197,7 +197,7 @@ func unpackKeyPair(s *schema.ResourceData) (interface{}, string, error) {
 
 var keyPairPacker = packer.Universal(
 	predicate.All(
-		predicate.Ignore("private_key"),
+		predicate.Ignore("private_key", "passphrase"),
 		predicate.SchemaHasKey(keyPairSchema),
 	),
 )

--- a/pkg/artifactory/resource/security/resource_artifactory_keypair.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_keypair.go
@@ -7,15 +7,14 @@ import (
 	"encoding/pem"
 	"strings"
 
-	"github.com/jfrog/terraform-provider-shared/packer"
-	"github.com/jfrog/terraform-provider-shared/predicate"
-
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/jfrog/terraform-provider-shared/client"
+	"github.com/jfrog/terraform-provider-shared/packer"
+	"github.com/jfrog/terraform-provider-shared/predicate"
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 

--- a/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
@@ -2,9 +2,10 @@ package security_test
 
 import (
 	"fmt"
-	"github.com/jfrog/terraform-provider-shared/test"
 	"regexp"
 	"testing"
+
+	"github.com/jfrog/terraform-provider-shared/test"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
@@ -106,6 +107,7 @@ func TestAccKeyPairRSA(t *testing.T) {
 			pair_name  = "%s"
 			pair_type = "RSA"
 			alias = "foo-alias%d"
+			passphrase = "password"
 			private_key = <<EOF
 		-----BEGIN RSA PRIVATE KEY-----
 		MIIEpAIBAAKCAQEA2ymVc24BoaZb0ElXoI3X4zUKJGZEetR6F4yT1tJhkPDg7UTm
@@ -169,6 +171,7 @@ func TestAccKeyPairRSA(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "alias", fmt.Sprintf("foo-alias%d", id)),
 					resource.TestCheckResourceAttr(fqrn, "pair_type", "RSA"),
 					resource.TestCheckResourceAttr(fqrn, "unavailable", "false"),
+					resource.TestCheckResourceAttr(fqrn, "passphrase", "password"),
 				),
 			},
 		},
@@ -182,6 +185,7 @@ func TestAccKeyPairGPG(t *testing.T) {
 			pair_name  = "%s"
 			pair_type = "GPG"
 			alias = "foo-alias%d"
+			passphrase = "password"
 			private_key = <<EOF
 		-----BEGIN PGP PRIVATE KEY BLOCK-----
 		Version: Keybase OpenPGP v1.0.0
@@ -276,6 +280,12 @@ func TestAccKeyPairGPG(t *testing.T) {
 		=fot9
 		-----END PGP PUBLIC KEY BLOCK-----
 		EOF
+			lifecycle {
+			ignore_changes = [
+					private_key,
+					passphrase,
+					]
+			}
 		}
 	`, name, name, id)
 
@@ -293,6 +303,7 @@ func TestAccKeyPairGPG(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "alias", fmt.Sprintf("foo-alias%d", id)),
 					resource.TestCheckResourceAttr(fqrn, "pair_type", "GPG"),
 					resource.TestCheckResourceAttr(fqrn, "unavailable", "false"),
+					resource.TestCheckResourceAttr(fqrn, "passphrase", "password"),
 				),
 			},
 		},

--- a/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
@@ -5,11 +5,10 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/jfrog/terraform-provider-shared/test"
-
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/security"
+	"github.com/jfrog/terraform-provider-shared/test"
 )
 
 func TestAccKeyPairFailPrivateCertCheck(t *testing.T) {

--- a/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
@@ -147,12 +147,6 @@ func TestAccKeyPairRSA(t *testing.T) {
 		DQIDAQAB
 		-----END PUBLIC KEY-----
 		EOF
-			lifecycle {
-				ignore_changes = [
-					private_key,
-					passphrase,
-				]
-			}
 		}
 	`, name, name, id)
 
@@ -279,12 +273,6 @@ func TestAccKeyPairGPG(t *testing.T) {
 		=fot9
 		-----END PGP PUBLIC KEY BLOCK-----
 		EOF
-			lifecycle {
-			ignore_changes = [
-					private_key,
-					passphrase,
-					]
-			}
 		}
 	`, name, name, id)
 

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
@@ -178,13 +178,13 @@ func ResourceArtifactoryScopedToken() *schema.Resource {
 				"Options: jfrt, jfxr, jfpip, jfds, jfmc, jfac, jfevt, jfmd, jfcon, or *",
 		},
 		"access_token": {
-			Type:     schema.TypeString,
-			Computed: true,
+			Type:      schema.TypeString,
+			Computed:  true,
 			Sensitive: true,
 		},
 		"refresh_token": {
-			Type:     schema.TypeString,
-			Computed: true,
+			Type:      schema.TypeString,
+			Computed:  true,
 			Sensitive: true,
 		},
 		"token_type": {

--- a/sample.tf
+++ b/sample.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     artifactory = {
       source  = "registry.terraform.io/jfrog/artifactory"
-      version = "6.16.0"
+      version = "6.19.2"
     }
   }
 }


### PR DESCRIPTION
'passphrase' attribute was not in the unpack function and thus was never in the API call body. After the change, the Provider can successfully send the attribute value, and it's saved in the state.
I also added attribute verification to the RSA and GPG tests.