### PR TITLE
Add check to read func and check for resource existence

### DIFF
--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/jfrog/terraform-provider-shared/packer"
 	"github.com/jfrog/terraform-provider-shared/predicate"
+	"net/http"
 	"regexp"
 	"strings"
 	"time"
@@ -239,12 +240,16 @@ func ResourceArtifactoryScopedToken() *schema.Resource {
 	var accessTokenRead = func(_ context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
 		accessToken := AccessTokenGet{}
 
-		_, err := m.(*resty.Client).R().
+		resp, err := m.(*resty.Client).R().
 			SetPathParam("id", data.Id()).
 			SetResult(&accessToken).
 			Get("access/api/v1/tokens/{id}")
 
 		if err != nil {
+			if resp != nil && resp.StatusCode() == http.StatusNotFound {
+				data.SetId("")
+				return nil
+			}
 			return diag.FromErr(err)
 		}
 


### PR DESCRIPTION
Fixes #576 

Will merge after #588 

- Fix resource's ID not reset if token no long exists on Artifactory.
- Attempted to find a way to create an acceptance test for this but no luck. Manually tested it and TF recognizes the state drift and prompts to recreate the resource.