### PR TITLE
Virtual repos default value for 'retrieval_cache_period_seconds'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 6.20.3 (November 28, 2022).
+
+BUG FIX:
+
+* resource/artifactory_virtual_*_repository: removed incorrect default value for the attribute `retrieval_cache_period_seconds`, which was set to 7200 for all package types.
+Now the attribute can only be set for the package types, that supports it in the UI: Alpine, Chef, Conan, Conda, Cran, Debian, Helm and Npm.
+PR: [#]()
+
 ## 6.20.2 (November 23, 2022). Tested on Artifactory 7.46.11
 
 BUG FIX:

--- a/docs/resources/general_security.md
+++ b/docs/resources/general_security.md
@@ -32,5 +32,5 @@ Current general security settings can be imported using `security` as the `ID`, 
 $ terraform import artifactory_general_security.security security
 ```
 
-**NOTE:** The `artifactory_general_security` resource uses endpoints that are undocumented and may not work with SaaS
+~>The `artifactory_general_security` resource uses endpoints that are undocumented and may not work with SaaS
 environments, or may change without notice.

--- a/docs/resources/virtual.md
+++ b/docs/resources/virtual.md
@@ -37,7 +37,6 @@ The following arguments are supported:
 * `repo_layout_ref` - (Optional) Repository layout key for the virtual repository.
 * `artifactory_requests_can_retrieve_remote_artifacts` - (Optional, Default: false) Whether the virtual repository should search through remote repositories when trying to resolve an artifact requested by another Artifactory instance.
 * `default_deployment_repo` - (Optional) Default repository to deploy artifacts.
-* `retrieval_cache_period_seconds` - (Optional, Default: 7200) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching. Default: 7200 seconds.
 
 ## Import
 

--- a/docs/resources/virtual_alpine_repository.md
+++ b/docs/resources/virtual_alpine_repository.md
@@ -30,6 +30,7 @@ The following arguments are supported, along with the [common list of arguments 
 * `description` - (Optional)
 * `notes` - (Optional)
 * `primary_keypair_ref` - (Optional) Primary keypair used to sign artifacts. Default value is empty.
+* `retrieval_cache_period_seconds` - (Optional, Default: 7200) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.
 
 ## Import
 

--- a/docs/resources/virtual_chef_repository.md
+++ b/docs/resources/virtual_chef_repository.md
@@ -29,6 +29,7 @@ The following arguments are supported, along with the [common list of arguments 
 * `repositories` - (Optional) The effective list of actual repositories included in this virtual repository.
 * `description` - (Optional)
 * `notes` - (Optional)
+* `retrieval_cache_period_seconds` - (Optional, Default: 7200) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.
 
 ## Import
 

--- a/docs/resources/virtual_conan_repository.md
+++ b/docs/resources/virtual_conan_repository.md
@@ -30,6 +30,7 @@ The following arguments are supported, along with the [common list of arguments 
 * `repositories` - (Optional) The effective list of actual repositories included in this virtual repository.
 * `description` - (Optional)
 * `notes` - (Optional)
+* `retrieval_cache_period_seconds` - (Optional, Default: 7200) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.
 
 ## Import
 

--- a/docs/resources/virtual_conda_repository.md
+++ b/docs/resources/virtual_conda_repository.md
@@ -29,7 +29,7 @@ The following arguments are supported, along with the [common list of arguments 
 * `repositories` - (Optional) The effective list of actual repositories included in this virtual repository.
 * `description` - (Optional)
 * `notes` - (Optional)
-
+* `retrieval_cache_period_seconds` - (Optional, Default: 7200) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.
 
 ## Import
 

--- a/docs/resources/virtual_cran_repository.md
+++ b/docs/resources/virtual_cran_repository.md
@@ -29,6 +29,7 @@ The following arguments are supported, along with the [common list of arguments 
 * `repositories` - (Optional) The effective list of actual repositories included in this virtual repository.
 * `description` - (Optional)
 * `notes` - (Optional)
+* `retrieval_cache_period_seconds` - (Optional, Default: 7200) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.
 
 ## Import
 

--- a/docs/resources/virtual_debian_repository.md
+++ b/docs/resources/virtual_debian_repository.md
@@ -30,6 +30,7 @@ Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/c
 * `repositories` - (Optional) The effective list of actual repositories included in this virtual repository.
 * `description` - (Optional)
 * `notes` - (Optional)
+* `retrieval_cache_period_seconds` - (Optional, Default: 7200) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.
 * `primary_keypair_ref` - (Optional) Primary keypair used to sign artifacts. Default is empty.
 * `secondary_keypair_ref` - (Optional) Secondary keypair used to sign artifacts. Default is empty.
 * `optional_index_compression_formats` - (Optional) Index file formats you would like to create in addition to the default Gzip (.gzip extension). Supported values are 'bz2','lzma' and 'xz'. Default value is 'bz2'.

--- a/docs/resources/virtual_helm_repository.md
+++ b/docs/resources/virtual_helm_repository.md
@@ -25,6 +25,7 @@ The following arguments are supported, along with the [common list of arguments 
 * `repositories` - (Optional) The effective list of actual repositories included in this virtual repository.
 * `description` - (Optional)
 * `notes` - (Optional)
+* `retrieval_cache_period_seconds` - (Optional, Default: 7200) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.
 * `use_namespaces` - (Optional) From Artifactory 7.24.1 (SaaS Version), you can explicitly state a specific aggregated local or remote repository to fetch from a virtual by assigning namespaces to local and remote repositories. See the documentation [here](https://www.jfrog.com/confluence/display/JFROG/Kubernetes+Helm+Chart+Repositories#KubernetesHelmChartRepositories-NamespaceSupportforHelmVirtualRepositories). Default is 'false'.
 
 ## Import

--- a/docs/resources/virtual_npm_repository.md
+++ b/docs/resources/virtual_npm_repository.md
@@ -29,6 +29,7 @@ The following arguments are supported, along with the [common list of arguments 
 * `repositories` - (Optional) The effective list of actual repositories included in this virtual repository.
 * `description` - (Optional)
 * `notes` - (Optional)
+* `retrieval_cache_period_seconds` - (Optional, Default: 7200) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.
 
 ## Import
 

--- a/pkg/artifactory/resource/configuration/resource_artifactory_proxy.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_proxy.go
@@ -101,7 +101,7 @@ func ResourceArtifactoryProxy() *schema.Resource {
 			Description: "An optional list of services names to which this proxy be the default of. The options are jfrt, jfmc, jfxr, jfds",
 			Elem: &schema.Schema{
 				Type: schema.TypeString,
-				Set: schema.HashString,
+				Set:  schema.HashString,
 				ValidateDiagFunc: validation.ToDiagFunc(
 					validation.StringInSlice(
 						[]string{

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -10,7 +10,7 @@ import (
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
-type RepositoryBaseParams struct {
+type RepositoryRemoteBaseParams struct {
 	Key                      string   `hcl:"key" json:"key,omitempty"`
 	ProjectKey               string   `json:"projectKey"`
 	ProjectEnvironments      []string `json:"environments"`
@@ -57,7 +57,7 @@ type RepositoryBaseParams struct {
 }
 
 type JavaRemoteRepo struct {
-	RepositoryBaseParams
+	RepositoryRemoteBaseParams
 	FetchJarsEagerly             bool   `json:"fetchJarsEagerly"`
 	FetchSourcesEagerly          bool   `json:"fetchSourcesEagerly"`
 	RemoteRepoChecksumPolicyType string `json:"remoteRepoChecksumPolicyType"`
@@ -72,7 +72,7 @@ type RepositoryVcsParams struct {
 	VcsGitDownloadUrl string `json:"vcsGitDownloadUrl"`
 }
 
-func (bp RepositoryBaseParams) Id() string {
+func (bp RepositoryRemoteBaseParams) Id() string {
 	return bp.Key
 }
 
@@ -227,7 +227,7 @@ var BaseRemoteRepoSchema = map[string]*schema.Schema{
 		Computed:    true,
 		Description: "The metadataRetrievalTimeoutSecs field not allowed to be bigger then retrievalCachePeriodSecs field.",
 		DefaultFunc: func() (interface{}, error) {
-			return 7200, nil
+			return 7300, nil
 		},
 		ValidateFunc: validation.IntAtLeast(0),
 	},
@@ -448,10 +448,10 @@ func getJavaRemoteSchema(repoType string, suppressPom bool) map[string]*schema.S
 	)
 }
 
-func UnpackBaseRemoteRepo(s *schema.ResourceData, packageType string) RepositoryBaseParams {
+func UnpackBaseRemoteRepo(s *schema.ResourceData, packageType string) RepositoryRemoteBaseParams {
 	d := &util.ResourceData{ResourceData: s}
 
-	repo := RepositoryBaseParams{
+	repo := RepositoryRemoteBaseParams{
 		Rclass:                   "remote",
 		Key:                      d.GetString("key", false),
 		ProjectKey:               d.GetString("project_key", false),
@@ -527,7 +527,7 @@ func UnpackVcsRemoteRepo(s *schema.ResourceData) RepositoryVcsParams {
 func UnpackJavaRemoteRepo(s *schema.ResourceData, repoType string) JavaRemoteRepo {
 	d := &util.ResourceData{ResourceData: s}
 	return JavaRemoteRepo{
-		RepositoryBaseParams:         UnpackBaseRemoteRepo(s, repoType),
+		RepositoryRemoteBaseParams:   UnpackBaseRemoteRepo(s, repoType),
 		FetchJarsEagerly:             d.GetBool("fetch_jars_eagerly", false),
 		FetchSourcesEagerly:          d.GetBool("fetch_sources_eagerly", false),
 		RemoteRepoChecksumPolicyType: d.GetString("remote_repo_checksum_policy_type", false),

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_bower_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_bower_repository.go
@@ -9,7 +9,7 @@ import (
 )
 
 type BowerRemoteRepo struct {
-	RepositoryBaseParams
+	RepositoryRemoteBaseParams
 	RepositoryVcsParams
 	BowerRegistryUrl string `json:"bowerRegistryUrl"`
 }
@@ -30,9 +30,9 @@ func ResourceArtifactoryRemoteBowerRepository() *schema.Resource {
 	var unpackBowerRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: s}
 		repo := BowerRemoteRepo{
-			RepositoryBaseParams: UnpackBaseRemoteRepo(s, packageType),
-			RepositoryVcsParams:  UnpackVcsRemoteRepo(s),
-			BowerRegistryUrl:     d.GetString("bower_registry_url", false),
+			RepositoryRemoteBaseParams: UnpackBaseRemoteRepo(s, packageType),
+			RepositoryVcsParams:        UnpackVcsRemoteRepo(s),
+			BowerRegistryUrl:           d.GetString("bower_registry_url", false),
 		}
 		return repo, repo.Id(), nil
 	}
@@ -40,7 +40,7 @@ func ResourceArtifactoryRemoteBowerRepository() *schema.Resource {
 	return repository.MkResourceSchema(bowerRemoteSchema, packer.Default(bowerRemoteSchema), unpackBowerRemoteRepo, func() interface{} {
 		repoLayout, _ := repository.GetDefaultRepoLayoutRef("remote", packageType)()
 		return &BowerRemoteRepo{
-			RepositoryBaseParams: RepositoryBaseParams{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 				Rclass:              "remote",
 				PackageType:         packageType,
 				RemoteRepoLayoutRef: repoLayout.(string),

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_cargo_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_cargo_repository.go
@@ -9,7 +9,7 @@ import (
 )
 
 type CargoRemoteRepo struct {
-	RepositoryBaseParams
+	RepositoryRemoteBaseParams
 	RegistryUrl     string `hcl:"git_registry_url" json:"gitRegistryUrl"`
 	AnonymousAccess bool   `hcl:"anonymous_access" json:"cargoAnonymousAccess"`
 }
@@ -35,16 +35,16 @@ func ResourceArtifactoryRemoteCargoRepository() *schema.Resource {
 	var unpackCargoRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: s}
 		repo := CargoRemoteRepo{
-			RepositoryBaseParams: UnpackBaseRemoteRepo(s, packageType),
-			RegistryUrl:          d.GetString("git_registry_url", false),
-			AnonymousAccess:      d.GetBool("anonymous_access", false),
+			RepositoryRemoteBaseParams: UnpackBaseRemoteRepo(s, packageType),
+			RegistryUrl:                d.GetString("git_registry_url", false),
+			AnonymousAccess:            d.GetBool("anonymous_access", false),
 		}
 		return repo, repo.Id(), nil
 	}
 
 	return repository.MkResourceSchema(cargoRemoteSchema, packer.Default(cargoRemoteSchema), unpackCargoRemoteRepo, func() interface{} {
 		return &CargoRemoteRepo{
-			RepositoryBaseParams: RepositoryBaseParams{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 				Rclass:      "remote",
 				PackageType: packageType,
 			},

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_cocoapods_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_cocoapods_repository.go
@@ -9,7 +9,7 @@ import (
 )
 
 type CocoapodsRemoteRepo struct {
-	RepositoryBaseParams
+	RepositoryRemoteBaseParams
 	RepositoryVcsParams
 	PodsSpecsRepoUrl string `json:"podsSpecsRepoUrl"`
 }
@@ -30,9 +30,9 @@ func ResourceArtifactoryRemoteCocoapodsRepository() *schema.Resource {
 	var unpackCocoapodsRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: s}
 		repo := CocoapodsRemoteRepo{
-			RepositoryBaseParams: UnpackBaseRemoteRepo(s, packageType),
-			RepositoryVcsParams:  UnpackVcsRemoteRepo(s),
-			PodsSpecsRepoUrl:     d.GetString("pods_specs_repo_url", false),
+			RepositoryRemoteBaseParams: UnpackBaseRemoteRepo(s, packageType),
+			RepositoryVcsParams:        UnpackVcsRemoteRepo(s),
+			PodsSpecsRepoUrl:           d.GetString("pods_specs_repo_url", false),
 		}
 		return repo, repo.Id(), nil
 	}
@@ -40,7 +40,7 @@ func ResourceArtifactoryRemoteCocoapodsRepository() *schema.Resource {
 	return repository.MkResourceSchema(cocoapodsRemoteSchema, packer.Default(cocoapodsRemoteSchema), unpackCocoapodsRemoteRepo, func() interface{} {
 		repoLayout, _ := repository.GetDefaultRepoLayoutRef("remote", packageType)()
 		return &CocoapodsRemoteRepo{
-			RepositoryBaseParams: RepositoryBaseParams{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 				Rclass:              "remote",
 				PackageType:         packageType,
 				RemoteRepoLayoutRef: repoLayout.(string),

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_composer_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_composer_repository.go
@@ -9,7 +9,7 @@ import (
 )
 
 type ComposerRemoteRepo struct {
-	RepositoryBaseParams
+	RepositoryRemoteBaseParams
 	RepositoryVcsParams
 	ComposerRegistryUrl string `json:"composerRegistryUrl"`
 }
@@ -30,9 +30,9 @@ func ResourceArtifactoryRemoteComposerRepository() *schema.Resource {
 	var unpackComposerRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: s}
 		repo := ComposerRemoteRepo{
-			RepositoryBaseParams: UnpackBaseRemoteRepo(s, packageType),
-			RepositoryVcsParams:  UnpackVcsRemoteRepo(s),
-			ComposerRegistryUrl:  d.GetString("composer_registry_url", false),
+			RepositoryRemoteBaseParams: UnpackBaseRemoteRepo(s, packageType),
+			RepositoryVcsParams:        UnpackVcsRemoteRepo(s),
+			ComposerRegistryUrl:        d.GetString("composer_registry_url", false),
 		}
 		return repo, repo.Id(), nil
 	}
@@ -40,7 +40,7 @@ func ResourceArtifactoryRemoteComposerRepository() *schema.Resource {
 	return repository.MkResourceSchema(composerRemoteSchema, packer.Default(composerRemoteSchema), unpackComposerRemoteRepo, func() interface{} {
 		repoLayout, _ := repository.GetDefaultRepoLayoutRef("remote", packageType)()
 		return &ComposerRemoteRepo{
-			RepositoryBaseParams: RepositoryBaseParams{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 				Rclass:              "remote",
 				PackageType:         packageType,
 				RemoteRepoLayoutRef: repoLayout.(string),

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_docker_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_docker_repository.go
@@ -10,7 +10,7 @@ import (
 )
 
 type DockerRemoteRepository struct {
-	RepositoryBaseParams
+	RepositoryRemoteBaseParams
 	ExternalDependenciesEnabled  bool     `hcl:"external_dependencies_enabled" json:"externalDependenciesEnabled"`
 	ExternalDependenciesPatterns []string `hcl:"external_dependencies_patterns" json:"externalDependenciesPatterns"`
 	EnableTokenAuthentication    bool     `hcl:"enable_token_authentication" json:"enableTokenAuthentication"`
@@ -55,7 +55,7 @@ func ResourceArtifactoryRemoteDockerRepository() *schema.Resource {
 	var unpackDockerRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: s}
 		repo := DockerRemoteRepository{
-			RepositoryBaseParams:         UnpackBaseRemoteRepo(s, packageType),
+			RepositoryRemoteBaseParams:   UnpackBaseRemoteRepo(s, packageType),
 			EnableTokenAuthentication:    d.GetBool("enable_token_authentication", false),
 			ExternalDependenciesEnabled:  d.GetBool("external_dependencies_enabled", false),
 			BlockPushingSchema1:          d.GetBool("block_pushing_schema1", false),
@@ -78,7 +78,7 @@ func ResourceArtifactoryRemoteDockerRepository() *schema.Resource {
 
 	return repository.MkResourceSchema(dockerRemoteSchema, dockerRemoteRepoPacker, unpackDockerRemoteRepo, func() interface{} {
 		return &DockerRemoteRepository{
-			RepositoryBaseParams: RepositoryBaseParams{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 				Rclass:      "remote",
 				PackageType: packageType,
 			},

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_generic_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_generic_repository.go
@@ -10,7 +10,7 @@ import (
 func ResourceArtifactoryRemoteGenericRepository(pkt string) *schema.Resource {
 	constructor := func() interface{} {
 		repoLayout, _ := repository.GetDefaultRepoLayoutRef("remote", pkt)()
-		return &RepositoryBaseParams{
+		return &RepositoryRemoteBaseParams{
 			PackageType:         pkt,
 			Rclass:              "remote",
 			RemoteRepoLayoutRef: repoLayout.(string),

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_go_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_go_repository.go
@@ -9,7 +9,7 @@ import (
 )
 
 type GoRemoteRepo struct {
-	RepositoryBaseParams
+	RepositoryRemoteBaseParams
 	VcsGitProvider string `json:"vcsGitProvider"`
 }
 
@@ -29,8 +29,8 @@ func ResourceArtifactoryRemoteGoRepository() *schema.Resource {
 	var unpackGoRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: s}
 		repo := GoRemoteRepo{
-			RepositoryBaseParams: UnpackBaseRemoteRepo(s, packageType),
-			VcsGitProvider:       d.GetString("vcs_git_provider", false),
+			RepositoryRemoteBaseParams: UnpackBaseRemoteRepo(s, packageType),
+			VcsGitProvider:             d.GetString("vcs_git_provider", false),
 		}
 		return repo, repo.Id(), nil
 	}
@@ -38,7 +38,7 @@ func ResourceArtifactoryRemoteGoRepository() *schema.Resource {
 	return repository.MkResourceSchema(goRemoteSchema, packer.Default(goRemoteSchema), unpackGoRemoteRepo, func() interface{} {
 		repoLayout, _ := repository.GetDefaultRepoLayoutRef("remote", packageType)()
 		return &GoRemoteRepo{
-			RepositoryBaseParams: RepositoryBaseParams{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 				Rclass:              "remote",
 				PackageType:         packageType,
 				RemoteRepoLayoutRef: repoLayout.(string),

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_helm_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_helm_repository.go
@@ -42,7 +42,7 @@ func ResourceArtifactoryRemoteHelmRepository() *schema.Resource {
 	}, repository.RepoLayoutRefSchema("remote", packageType))
 
 	type HelmRemoteRepo struct {
-		RepositoryBaseParams
+		RepositoryRemoteBaseParams
 		HelmChartsBaseURL            string   `hcl:"helm_charts_base_url" json:"chartsBaseUrl"`
 		ExternalDependenciesEnabled  bool     `hcl:"external_dependencies_enabled" json:"externalDependenciesEnabled"`
 		ExternalDependenciesPatterns []string `hcl:"external_dependencies_patterns" json:"externalDependenciesPatterns"`
@@ -51,7 +51,7 @@ func ResourceArtifactoryRemoteHelmRepository() *schema.Resource {
 	var unpackHelmRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: s}
 		repo := HelmRemoteRepo{
-			RepositoryBaseParams:         UnpackBaseRemoteRepo(s, packageType),
+			RepositoryRemoteBaseParams:   UnpackBaseRemoteRepo(s, packageType),
 			HelmChartsBaseURL:            d.GetString("helm_charts_base_url", false),
 			ExternalDependenciesEnabled:  d.GetBool("external_dependencies_enabled", false),
 			ExternalDependenciesPatterns: d.GetList("external_dependencies_patterns"),
@@ -73,7 +73,7 @@ func ResourceArtifactoryRemoteHelmRepository() *schema.Resource {
 
 	return repository.MkResourceSchema(helmRemoteSchema, helmRemoteRepoPacker, unpackHelmRemoteRepo, func() interface{} {
 		return &HelmRemoteRepo{
-			RepositoryBaseParams: RepositoryBaseParams{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 				Rclass:      "remote",
 				PackageType: packageType,
 			},

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_java_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_java_repository.go
@@ -16,7 +16,7 @@ func ResourceArtifactoryRemoteJavaRepository(repoType string, suppressPom bool) 
 
 	return repository.MkResourceSchema(javaRemoteSchema, packer.Default(javaRemoteSchema), unpackJavaRemoteRepo, func() interface{} {
 		return &JavaRemoteRepo{
-			RepositoryBaseParams: RepositoryBaseParams{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 				Rclass:      "remote",
 				PackageType: repoType,
 			},

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_maven_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_maven_repository.go
@@ -42,7 +42,7 @@ func ResourceArtifactoryRemoteMavenRepository() *schema.Resource {
 	var constructor = func() interface{} {
 		return &MavenRemoteRepo{
 			JavaRemoteRepo: JavaRemoteRepo{
-				RepositoryBaseParams: RepositoryBaseParams{
+				RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 					Rclass:      "remote",
 					PackageType: "maven",
 				},

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository.go
@@ -9,7 +9,7 @@ import (
 )
 
 type NugetRemoteRepo struct {
-	RepositoryBaseParams
+	RepositoryRemoteBaseParams
 	FeedContextPath          string `json:"feedContextPath"`
 	DownloadContextPath      string `json:"downloadContextPath"`
 	V3FeedUrl                string `hcl:"v3_feed_url" json:"v3FeedUrl"` // Forced to specify hcl tag because predicate is not parsed by packer.Universal function.
@@ -59,12 +59,12 @@ func ResourceArtifactoryRemoteNugetRepository() *schema.Resource {
 	var unpackNugetRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: s}
 		repo := NugetRemoteRepo{
-			RepositoryBaseParams:     UnpackBaseRemoteRepo(s, packageType),
-			FeedContextPath:          d.GetString("feed_context_path", false),
-			DownloadContextPath:      d.GetString("download_context_path", false),
-			V3FeedUrl:                d.GetString("v3_feed_url", false),
-			ForceNugetAuthentication: d.GetBool("force_nuget_authentication", false),
-			SymbolServerUrl:          d.GetString("symbol_server_url", false),
+			RepositoryRemoteBaseParams: UnpackBaseRemoteRepo(s, packageType),
+			FeedContextPath:            d.GetString("feed_context_path", false),
+			DownloadContextPath:        d.GetString("download_context_path", false),
+			V3FeedUrl:                  d.GetString("v3_feed_url", false),
+			ForceNugetAuthentication:   d.GetBool("force_nuget_authentication", false),
+			SymbolServerUrl:            d.GetString("symbol_server_url", false),
 		}
 		return repo, repo.Id(), nil
 	}
@@ -72,7 +72,7 @@ func ResourceArtifactoryRemoteNugetRepository() *schema.Resource {
 	return repository.MkResourceSchema(nugetRemoteSchema, packer.Default(nugetRemoteSchema), unpackNugetRemoteRepo, func() interface{} {
 		repoLayout, _ := repository.GetDefaultRepoLayoutRef("remote", packageType)()
 		return &NugetRemoteRepo{
-			RepositoryBaseParams: RepositoryBaseParams{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 				Rclass:              "remote",
 				PackageType:         packageType,
 				RemoteRepoLayoutRef: repoLayout.(string),

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_pypi_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_pypi_repository.go
@@ -29,7 +29,7 @@ func ResourceArtifactoryRemotePypiRepository() *schema.Resource {
 	}, repository.RepoLayoutRefSchema("remote", packageType))
 
 	type PypiRemoteRepo struct {
-		RepositoryBaseParams
+		RepositoryRemoteBaseParams
 		PypiRegistryUrl      string `json:"pyPIRegistryUrl"`
 		PypiRepositorySuffix string `json:"pyPIRepositorySuffix"`
 	}
@@ -37,16 +37,16 @@ func ResourceArtifactoryRemotePypiRepository() *schema.Resource {
 	var unpackPypiRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: s}
 		repo := PypiRemoteRepo{
-			RepositoryBaseParams: UnpackBaseRemoteRepo(s, packageType),
-			PypiRegistryUrl:      d.GetString("pypi_registry_url", false),
-			PypiRepositorySuffix: d.GetString("pypi_repository_suffix", false),
+			RepositoryRemoteBaseParams: UnpackBaseRemoteRepo(s, packageType),
+			PypiRegistryUrl:            d.GetString("pypi_registry_url", false),
+			PypiRepositorySuffix:       d.GetString("pypi_repository_suffix", false),
 		}
 		return repo, repo.Id(), nil
 	}
 
 	return repository.MkResourceSchema(pypiRemoteSchema, packer.Default(pypiRemoteSchema), unpackPypiRemoteRepo, func() interface{} {
 		return &PypiRemoteRepo{
-			RepositoryBaseParams: RepositoryBaseParams{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 				Rclass:      "remote",
 				PackageType: packageType,
 			},

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_terraform_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_terraform_repository.go
@@ -9,7 +9,7 @@ import (
 )
 
 type TerraformRemoteRepo struct {
-	RepositoryBaseParams
+	RepositoryRemoteBaseParams
 	TerraformRegistryUrl  string `hcl:"terraform_registry_url" json:"terraformRegistryUrl"`
 	TerraformProvidersUrl string `hcl:"terraform_providers_url" json:"terraformProvidersUrl"`
 }
@@ -39,16 +39,16 @@ func ResourceArtifactoryRemoteTerraformRepository() *schema.Resource {
 	var unpackTerraformRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: s}
 		repo := TerraformRemoteRepo{
-			RepositoryBaseParams:  UnpackBaseRemoteRepo(s, packageType),
-			TerraformRegistryUrl:  d.GetString("terraform_registry_url", false),
-			TerraformProvidersUrl: d.GetString("terraform_providers_url", false),
+			RepositoryRemoteBaseParams: UnpackBaseRemoteRepo(s, packageType),
+			TerraformRegistryUrl:       d.GetString("terraform_registry_url", false),
+			TerraformProvidersUrl:      d.GetString("terraform_providers_url", false),
 		}
 		return repo, repo.Id(), nil
 	}
 
 	return repository.MkResourceSchema(terraformRemoteSchema, packer.Default(terraformRemoteSchema), unpackTerraformRemoteRepo, func() interface{} {
 		return &TerraformRemoteRepo{
-			RepositoryBaseParams: RepositoryBaseParams{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 				Rclass:      "remote",
 				PackageType: packageType,
 			},

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_vcs_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_vcs_repository.go
@@ -8,7 +8,7 @@ import (
 )
 
 type VcsRemoteRepo struct {
-	RepositoryBaseParams
+	RepositoryRemoteBaseParams
 	RepositoryVcsParams
 	MaxUniqueSnapshots int `json:"maxUniqueSnapshots"`
 }
@@ -30,9 +30,9 @@ func ResourceArtifactoryRemoteVcsRepository() *schema.Resource {
 	var UnpackVcsRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: s}
 		repo := VcsRemoteRepo{
-			RepositoryBaseParams: UnpackBaseRemoteRepo(s, packageType),
-			RepositoryVcsParams:  UnpackVcsRemoteRepo(s),
-			MaxUniqueSnapshots:   d.GetInt("max_unique_snapshots", false),
+			RepositoryRemoteBaseParams: UnpackBaseRemoteRepo(s, packageType),
+			RepositoryVcsParams:        UnpackVcsRemoteRepo(s),
+			MaxUniqueSnapshots:         d.GetInt("max_unique_snapshots", false),
 		}
 		return repo, repo.Id(), nil
 	}
@@ -40,7 +40,7 @@ func ResourceArtifactoryRemoteVcsRepository() *schema.Resource {
 	return repository.MkResourceSchema(vcsRemoteSchema, packer.Default(vcsRemoteSchema), UnpackVcsRemoteRepo, func() interface{} {
 		repoLayout, _ := repository.GetDefaultRepoLayoutRef("remote", packageType)()
 		return &VcsRemoteRepo{
-			RepositoryBaseParams: RepositoryBaseParams{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
 				Rclass:              "remote",
 				PackageType:         packageType,
 				RemoteRepoLayoutRef: repoLayout.(string),

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_alpine_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_alpine_repository.go
@@ -12,14 +12,18 @@ func ResourceArtifactoryVirtualAlpineRepository() *schema.Resource {
 
 	const packageType = "alpine"
 
-	var alpineVirtualSchema = util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
-		"primary_keypair_ref": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
-			Description:      "Primary keypair used to sign artifacts. Default value is empty.",
+	var alpineVirtualSchema = util.MergeMaps(
+		BaseVirtualRepoSchema,
+		retrievalCachePeriodSecondsSchema,
+		map[string]*schema.Schema{
+			"primary_keypair_ref": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+				Description:      "Primary keypair used to sign artifacts. Default value is empty.",
+			},
 		},
-	}, repository.RepoLayoutRefSchema("virtual", packageType))
+		repository.RepoLayoutRefSchema("virtual", packageType))
 
 	type AlpineVirtualRepositoryParams struct {
 		RepositoryBaseParamsWithRetrievalCachePeriodSecs

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_debian_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_debian_repository.go
@@ -1,12 +1,12 @@
 package virtual
 
 import (
-	"github.com/jfrog/terraform-provider-shared/packer"
 	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-shared/packer"
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
@@ -14,39 +14,42 @@ func ResourceArtifactoryVirtualDebianRepository() *schema.Resource {
 
 	const packageType = "debian"
 
-	var debianVirtualSchema = util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
-		"primary_keypair_ref": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
-			Description:      "Primary keypair used to sign artifacts. Default is empty.",
-		},
-		"secondary_keypair_ref": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
-			Description:      "Secondary keypair used to sign artifacts. Default is empty.",
-		},
-		"optional_index_compression_formats": {
-			Type:     schema.TypeSet,
-			Optional: true,
-			MinItems: 0,
-			Computed: true,
-			Elem: &schema.Schema{
-				Type:         schema.TypeString,
-				ValidateFunc: validation.StringInSlice([]string{"bz2", "lzma", "xz"}, false),
+	var debianVirtualSchema = util.MergeMaps(
+		BaseVirtualRepoSchema,
+		retrievalCachePeriodSecondsSchema,
+		map[string]*schema.Schema{
+			"primary_keypair_ref": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+				Description:      "Primary keypair used to sign artifacts. Default is empty.",
 			},
-			Description: `Index file formats you would like to create in addition to the default Gzip (.gzip extension). Supported values are 'bz2','lzma' and 'xz'. Default value is 'bz2'.`,
-		},
-		"debian_default_architectures": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			Default:          "amd64,i386",
-			ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.StringIsNotEmpty, validation.StringMatch(regexp.MustCompile(`.+(?:,.+)*`), "must be comma separated string"))),
-			StateFunc:        util.FormatCommaSeparatedString,
-			Description:      `Specifying  architectures will speed up Artifactory's initial metadata indexing process. The default architecture values are amd64 and i386.`,
-		},
-	}, repository.RepoLayoutRefSchema("virtual", packageType))
+			"secondary_keypair_ref": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+				Description:      "Secondary keypair used to sign artifacts. Default is empty.",
+			},
+			"optional_index_compression_formats": {
+				Type:     schema.TypeSet,
+				Optional: true,
+				MinItems: 0,
+				Computed: true,
+				Elem: &schema.Schema{
+					Type:         schema.TypeString,
+					ValidateFunc: validation.StringInSlice([]string{"bz2", "lzma", "xz"}, false),
+				},
+				Description: `Index file formats you would like to create in addition to the default Gzip (.gzip extension). Supported values are 'bz2','lzma' and 'xz'. Default value is 'bz2'.`,
+			},
+			"debian_default_architectures": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				Default:          "amd64,i386",
+				ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.StringIsNotEmpty, validation.StringMatch(regexp.MustCompile(`.+(?:,.+)*`), "must be comma separated string"))),
+				StateFunc:        util.FormatCommaSeparatedString,
+				Description:      `Specifying  architectures will speed up Artifactory's initial metadata indexing process. The default architecture values are amd64 and i386.`,
+			},
+		}, repository.RepoLayoutRefSchema("virtual", packageType))
 
 	type DebianVirtualRepositoryParams struct {
 		RepositoryBaseParamsWithRetrievalCachePeriodSecs

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_helm_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_helm_repository.go
@@ -11,14 +11,18 @@ func ResourceArtifactoryVirtualHelmRepository() *schema.Resource {
 
 	const packageType = "helm"
 
-	helmVirtualSchema := util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
-		"use_namespaces": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "From Artifactory 7.24.1 (SaaS Version), you can explicitly state a specific aggregated local or remote repository to fetch from a virtual by assigning namespaces to local and remote repositories\nSee https://www.jfrog.com/confluence/display/JFROG/Kubernetes+Helm+Chart+Repositories#KubernetesHelmChartRepositories-NamespaceSupportforHelmVirtualRepositories. Default to 'false'",
+	helmVirtualSchema := util.MergeMaps(
+		BaseVirtualRepoSchema,
+		retrievalCachePeriodSecondsSchema,
+		map[string]*schema.Schema{
+			"use_namespaces": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "From Artifactory 7.24.1 (SaaS Version), you can explicitly state a specific aggregated local or remote repository to fetch from a virtual by assigning namespaces to local and remote repositories\nSee https://www.jfrog.com/confluence/display/JFROG/Kubernetes+Helm+Chart+Repositories#KubernetesHelmChartRepositories-NamespaceSupportforHelmVirtualRepositories. Default to 'false'",
+			},
 		},
-	}, repository.RepoLayoutRefSchema("virtual", packageType))
+		repository.RepoLayoutRefSchema("virtual", packageType))
 
 	type HelmVirtualRepositoryParams struct {
 		RepositoryBaseParamsWithRetrievalCachePeriodSecs

--- a/pkg/artifactory/resource/repository/virtual/virtual.go
+++ b/pkg/artifactory/resource/repository/virtual/virtual.go
@@ -26,7 +26,7 @@ type RepositoryBaseParams struct {
 
 type RepositoryBaseParamsWithRetrievalCachePeriodSecs struct {
 	RepositoryBaseParams
-	VirtualRetrievalCachePeriodSecs int `hcl:"retrieval_cache_period_seconds" json:"virtualRetrievalCachePeriodSecs"`
+	VirtualRetrievalCachePeriodSecs int `hcl:"retrieval_cache_period_seconds" json:"virtualRetrievalCachePeriodSecs,omitempty"`
 }
 
 func (bp RepositoryBaseParams) Id() string {
@@ -128,13 +128,6 @@ var BaseVirtualRepoSchema = map[string]*schema.Schema{
 		Type:        schema.TypeString,
 		Optional:    true,
 		Description: "Default repository to deploy artifacts.",
-	},
-	"retrieval_cache_period_seconds": {
-		Type:         schema.TypeInt,
-		Optional:     true,
-		Default:      7200,
-		Description:  "This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.",
-		ValidateFunc: validation.IntAtLeast(0),
 	},
 }
 


### PR DESCRIPTION
Bug fix in 'artifactory_virtual_repository' resource. Removed incorrect default value for the attribute 'retrieval_cache_period_seconds', added this attribute only to the repo types where it belongs and added tests.
Documentation is modified as well to match the change. 
Renamed struct in remote repos for better clarity, RepositoryBaseParams -> RepositoryRemoteBaseParams