### PR TITLE
GH-594 add ForceNew to artifactory_keypair

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.21.3 (December 6, 2022)
+## 6.21.3 (December 6, 2022). Tested on Artifactory 7.47.10
 
 BUG FIX:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 6.21.3 (December 6, 2022)
+
+BUG FIX:
+
+* resource/artifactory_keypair:
+  * Fix updating 'passphrase' does not delete and recreate key pair.
+  * Fix externally deleted key pair does not trigger Terraform to recreate.
+
+Issue: [#594](https://github.com/jfrog/terraform-provider-artifactory/issues/594) PR: [#596](https://github.com/jfrog/terraform-provider-artifactory/pull/596)
+
 ## 6.21.2 (November 30, 2022). Tested on Artifactory 7.46.11
 
 BUG FIX:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -7,7 +7,7 @@ GORELEASER_ARCH=${TARGET_ARCH}
 ifeq ($(GO_ARCH), amd64)
 GORELEASER_ARCH=${TARGET_ARCH}_$(shell go env GOAMD64)
 endif
-PKG_NAME=pkg/xray
+PKG_NAME=pkg/artifactory
 # if this path ever changes, you need to also update the 'ldflags' value in .goreleaser.yml
 PKG_VERSION_PATH=github.com/jfrog/terraform-provider-${PRODUCT}/${PKG_NAME}
 VERSION := $(shell git tag --sort=-creatordate | head -1 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')

--- a/docs/resources/keypair.md
+++ b/docs/resources/keypair.md
@@ -3,10 +3,10 @@ subcategory: "Security"
 ---
 # Artifactory keypair Resource
 
-RSA key pairs are used to sign and verify the Alpine Linux index files in JFrog Artifactory, while GPG key pairs are 
-used to sign and validate packages integrity in JFrog Distribution. The JFrog Platform enables you to manage multiple 
-RSA and GPG signing keys through the Keys Management UI and REST API. The JFrog Platform supports managing multiple 
-pairs of GPG signing keys to sign packages for authentication of several package types such as Debian, Opkg, and RPM 
+RSA key pairs are used to sign and verify the Alpine Linux index files in JFrog Artifactory, while GPG key pairs are
+used to sign and validate packages integrity in JFrog Distribution. The JFrog Platform enables you to manage multiple
+RSA and GPG signing keys through the Keys Management UI and REST API. The JFrog Platform supports managing multiple
+pairs of GPG signing keys to sign packages for authentication of several package types such as Debian, Opkg, and RPM
 through the Keys Management UI and REST API.
 
 ## Example Usage
@@ -27,13 +27,6 @@ resource "artifactory_keypair" "some-keypair6543461672124900137" {
   private_key = file("samples/rsa.priv")
   public_key  = file("samples/rsa.pub")
   passphrase  = "PASSPHRASE"
-  
-  lifecycle {
-    ignore_changes = [
-      private_key,
-      passphrase,
-    ]
-  }
 }
 ```
 
@@ -45,12 +38,11 @@ The following arguments are supported:
 * `pair_type` - (Required) Key Pair type. Supported types - GPG and RSA.
 * `alias` - (Required) Will be used as a filename when retrieving the public key via REST API.
 * `private_key` - (Required, Sensitive)  - Private key. PEM format will be validated.
-* `passphrase` - (Optional) Passphrase will be used to decrypt the private key. Validated server side.
+* `passphrase` - (Optional, Sensitive) Passphrase will be used to decrypt the private key. Validated server side.
 * `public_key` - (Required) Public key. PEM format will be validated.
 * `unavailable` - (Computed) Unknown usage. Returned in the json payload and cannot be set.
 
 Artifactory REST API call Get Key Pair doesn't return keys `private_key` and `passphrase`, but consumes these keys in the POST call.
-The meta-argument `lifecycle` used here to make Provider ignore the changes for these two keys in the Terraform state.
 
 ## Import
 

--- a/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/security"
 	"github.com/jfrog/terraform-provider-shared/test"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 func TestAccKeyPairFailPrivateCertCheck(t *testing.T) {
@@ -101,54 +102,73 @@ func TestAccKeyPairFailPubCertCheck(t *testing.T) {
 
 func TestAccKeyPairRSA(t *testing.T) {
 	id, fqrn, name := test.MkNames("mykp", "artifactory_keypair")
-	keyBasic := fmt.Sprintf(`
-		resource "artifactory_keypair" "%s" {
-			pair_name  = "%s"
-			pair_type = "RSA"
-			alias = "foo-alias%d"
-			passphrase = "password"
-			private_key = <<EOF
-		-----BEGIN RSA PRIVATE KEY-----
-		MIIEpAIBAAKCAQEA2ymVc24BoaZb0ElXoI3X4zUKJGZEetR6F4yT1tJhkPDg7UTm
-		iNoFB5TZJvP6LBrrSwszkpZbxaVOkBrwrGbqFUaXPgud8VabfHl0imXvN746zmpj
-		YEMGqJzm+Gh6aBWOlnPdLuHhds/kcanFAEppj5yN0tVWDnqjOJjR7EpxMSdP3TSd
-		6tNAY73LGNLNJQc6tSxh8nMIb4HhSWQSgfof+FwcLGvs+mmyBq8Jz5Zy4BSCk1fQ
-		FmCnSGyzpyBD0vMd6eLHk2l0tm56DrlonbDMX8KGs7e9ZgjANkT5PnipLOaeLJU4
-		H+OWyBZUAT4hl/iRVvLwV81x7g0/O38kmPYJDQIDAQABAoIBAFb7wyhEIfuhhlE9
-		uryrb2LrGzJlMIq7qBWOouKhLz4SjIM/VGw+c76VkjZGoSU+LeLj+D0W1ie0u2Cw
-		gJM8aW22TbK/c5lksWOO5PVFDdPG+ZoRWY3MLGlhlL5E4UhMPgJyy/eeiRjZ3CZM
-		pja+UfVAwn1KVNR8UinVZYPt680AvEd1FGxoNLxemIPNug46nNqp6Al86Bn+BnkN
-		GXpwyooXVSfo4k+pnFBFIXUdA1dUEXQSVb1AxlTo6g/Ok/+8Gfq8idCdu+5fcZI2
-		1eLeC+FAa92rr1SFX/UWeB4cMyuAqwuxbFFIplT22SaUSsNuOUSH4E00nbP/AuCb
-		1BqrLmECgYEA7tQKfyF9aiXTsOMdOnSAa5OyEaCfsFtcmLd4ykVrwN8O36NoX005
-		VbGuqo87fwIXQIKHU+kOEs/TmaQ8bNcbCD/SfWGTtOnHG4qfIsepJuoMwbQHRhGF
-		JeoXh5yEUKg5pcDBY8PENEtEVKmFuL4bPOdn+9FNLGsjftvXpmGWbGUCgYEA6uuQ
-		7kzO6WD88OsxdJzlJM11hg2SaSBCh3+5tnOhF1ULOUt4tdYXzh3QI6BPX7tkArYf
-		XteVfWoWqn6T7LtCjFm350BqVpPhqfLKnt6fYf1yotsj/cyZXlXquRbxbgakB0n0
-		4PrsZaube0TPPVeirzNyOVHyFc+iW+F+IUYD+4kCgYEApDEjBkP/9PoMj4+UiJuP
-		rmXcBkJnhtdI0bVRVb5kVjUEBLxTBTISONfvPVM7lBXb5n3Wi9mt00EOOJKw+CLq
-		csFt9MUgxz/xov2qaj7aC+bc3k7msUVaRLardpAkZ09AUrQyQGRWf50/XPUu+dO4
-		5iYxVu6OH/uIa664k6qDwAECgYEAslS8oomgEL3VhbWkx1dLA5MMggTPfgpFNsMY
-		4Y4JXcLrUEUgjzjEvW0YUdMiLhP8qapDSiXxj1D3f9myxWSp8g0xc9UMZEjCZ9at
-		RcjNyP8zBLnCKqokSt6B3puyDsnvvrC/ugIBbnTFBOCJSZG7J7CwJx8z3KbQI1ub
-		+fpCj7ECgYAd69soLEybUGMjsdI+OijIGoUTUoZGXJm+0VpBt4QJCe7AMnYPfYzA
-		JnEmN4D7HLTKUBklQnb/FhP/RuiT2bSAd1l+PNeuU7gYROCBBonzxXQ1wEbNrSYA
-		iyoc9g/kvV8HTW8361xEhu7wmuSEEx1gQ/7sdhTkgrTncc8hxVRxuA==
-		-----END RSA PRIVATE KEY-----
-		EOF
-			public_key = <<EOF
-		-----BEGIN PUBLIC KEY-----
-		MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2ymVc24BoaZb0ElXoI3X
-		4zUKJGZEetR6F4yT1tJhkPDg7UTmiNoFB5TZJvP6LBrrSwszkpZbxaVOkBrwrGbq
-		FUaXPgud8VabfHl0imXvN746zmpjYEMGqJzm+Gh6aBWOlnPdLuHhds/kcanFAEpp
-		j5yN0tVWDnqjOJjR7EpxMSdP3TSd6tNAY73LGNLNJQc6tSxh8nMIb4HhSWQSgfof
-		+FwcLGvs+mmyBq8Jz5Zy4BSCk1fQFmCnSGyzpyBD0vMd6eLHk2l0tm56DrlonbDM
-		X8KGs7e9ZgjANkT5PnipLOaeLJU4H+OWyBZUAT4hl/iRVvLwV81x7g0/O38kmPYJ
-		DQIDAQAB
-		-----END PUBLIC KEY-----
-		EOF
-		}
-	`, name, name, id)
+	template := `
+	resource "artifactory_keypair" "{{ .name }}" {
+		pair_name  = "{{ .name }}"
+		pair_type = "RSA"
+		alias = "foo-alias{{ .id }}"
+		passphrase = "{{ .passphrase }}"
+		private_key = <<EOF
+	-----BEGIN RSA PRIVATE KEY-----
+	MIIEpAIBAAKCAQEA2ymVc24BoaZb0ElXoI3X4zUKJGZEetR6F4yT1tJhkPDg7UTm
+	iNoFB5TZJvP6LBrrSwszkpZbxaVOkBrwrGbqFUaXPgud8VabfHl0imXvN746zmpj
+	YEMGqJzm+Gh6aBWOlnPdLuHhds/kcanFAEppj5yN0tVWDnqjOJjR7EpxMSdP3TSd
+	6tNAY73LGNLNJQc6tSxh8nMIb4HhSWQSgfof+FwcLGvs+mmyBq8Jz5Zy4BSCk1fQ
+	FmCnSGyzpyBD0vMd6eLHk2l0tm56DrlonbDMX8KGs7e9ZgjANkT5PnipLOaeLJU4
+	H+OWyBZUAT4hl/iRVvLwV81x7g0/O38kmPYJDQIDAQABAoIBAFb7wyhEIfuhhlE9
+	uryrb2LrGzJlMIq7qBWOouKhLz4SjIM/VGw+c76VkjZGoSU+LeLj+D0W1ie0u2Cw
+	gJM8aW22TbK/c5lksWOO5PVFDdPG+ZoRWY3MLGlhlL5E4UhMPgJyy/eeiRjZ3CZM
+	pja+UfVAwn1KVNR8UinVZYPt680AvEd1FGxoNLxemIPNug46nNqp6Al86Bn+BnkN
+	GXpwyooXVSfo4k+pnFBFIXUdA1dUEXQSVb1AxlTo6g/Ok/+8Gfq8idCdu+5fcZI2
+	1eLeC+FAa92rr1SFX/UWeB4cMyuAqwuxbFFIplT22SaUSsNuOUSH4E00nbP/AuCb
+	1BqrLmECgYEA7tQKfyF9aiXTsOMdOnSAa5OyEaCfsFtcmLd4ykVrwN8O36NoX005
+	VbGuqo87fwIXQIKHU+kOEs/TmaQ8bNcbCD/SfWGTtOnHG4qfIsepJuoMwbQHRhGF
+	JeoXh5yEUKg5pcDBY8PENEtEVKmFuL4bPOdn+9FNLGsjftvXpmGWbGUCgYEA6uuQ
+	7kzO6WD88OsxdJzlJM11hg2SaSBCh3+5tnOhF1ULOUt4tdYXzh3QI6BPX7tkArYf
+	XteVfWoWqn6T7LtCjFm350BqVpPhqfLKnt6fYf1yotsj/cyZXlXquRbxbgakB0n0
+	4PrsZaube0TPPVeirzNyOVHyFc+iW+F+IUYD+4kCgYEApDEjBkP/9PoMj4+UiJuP
+	rmXcBkJnhtdI0bVRVb5kVjUEBLxTBTISONfvPVM7lBXb5n3Wi9mt00EOOJKw+CLq
+	csFt9MUgxz/xov2qaj7aC+bc3k7msUVaRLardpAkZ09AUrQyQGRWf50/XPUu+dO4
+	5iYxVu6OH/uIa664k6qDwAECgYEAslS8oomgEL3VhbWkx1dLA5MMggTPfgpFNsMY
+	4Y4JXcLrUEUgjzjEvW0YUdMiLhP8qapDSiXxj1D3f9myxWSp8g0xc9UMZEjCZ9at
+	RcjNyP8zBLnCKqokSt6B3puyDsnvvrC/ugIBbnTFBOCJSZG7J7CwJx8z3KbQI1ub
+	+fpCj7ECgYAd69soLEybUGMjsdI+OijIGoUTUoZGXJm+0VpBt4QJCe7AMnYPfYzA
+	JnEmN4D7HLTKUBklQnb/FhP/RuiT2bSAd1l+PNeuU7gYROCBBonzxXQ1wEbNrSYA
+	iyoc9g/kvV8HTW8361xEhu7wmuSEEx1gQ/7sdhTkgrTncc8hxVRxuA==
+	-----END RSA PRIVATE KEY-----
+	EOF
+		public_key = <<EOF
+	-----BEGIN PUBLIC KEY-----
+	MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2ymVc24BoaZb0ElXoI3X
+	4zUKJGZEetR6F4yT1tJhkPDg7UTmiNoFB5TZJvP6LBrrSwszkpZbxaVOkBrwrGbq
+	FUaXPgud8VabfHl0imXvN746zmpjYEMGqJzm+Gh6aBWOlnPdLuHhds/kcanFAEpp
+	j5yN0tVWDnqjOJjR7EpxMSdP3TSd6tNAY73LGNLNJQc6tSxh8nMIb4HhSWQSgfof
+	+FwcLGvs+mmyBq8Jz5Zy4BSCk1fQFmCnSGyzpyBD0vMd6eLHk2l0tm56DrlonbDM
+	X8KGs7e9ZgjANkT5PnipLOaeLJU4H+OWyBZUAT4hl/iRVvLwV81x7g0/O38kmPYJ
+	DQIDAQAB
+	-----END PUBLIC KEY-----
+	EOF
+	}`
+
+	keyBasic := util.ExecuteTemplate(
+		fqrn,
+		template,
+		map[string]string{
+			"id": fmt.Sprint(id),
+			"name": name,
+			"passphrase": "password",
+		},
+	)
+
+	keyUpdatedPassphrase := util.ExecuteTemplate(
+		fqrn,
+		template,
+		map[string]string{
+			"id": fmt.Sprint(id),
+			"name": name,
+			"passphrase": "new-password",
+		},
+	)
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
@@ -165,6 +185,18 @@ func TestAccKeyPairRSA(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "pair_type", "RSA"),
 					resource.TestCheckResourceAttr(fqrn, "unavailable", "false"),
 					resource.TestCheckResourceAttr(fqrn, "passphrase", "password"),
+				),
+			},
+			{
+				Config: keyUpdatedPassphrase,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "pair_name", name),
+					resource.TestCheckResourceAttr(fqrn, "public_key", "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA2ymVc24BoaZb0ElXoI3X\n4zUKJGZEetR6F4yT1tJhkPDg7UTmiNoFB5TZJvP6LBrrSwszkpZbxaVOkBrwrGbq\nFUaXPgud8VabfHl0imXvN746zmpjYEMGqJzm+Gh6aBWOlnPdLuHhds/kcanFAEpp\nj5yN0tVWDnqjOJjR7EpxMSdP3TSd6tNAY73LGNLNJQc6tSxh8nMIb4HhSWQSgfof\n+FwcLGvs+mmyBq8Jz5Zy4BSCk1fQFmCnSGyzpyBD0vMd6eLHk2l0tm56DrlonbDM\nX8KGs7e9ZgjANkT5PnipLOaeLJU4H+OWyBZUAT4hl/iRVvLwV81x7g0/O38kmPYJ\nDQIDAQAB\n-----END PUBLIC KEY-----\n"),
+					resource.TestCheckResourceAttr(fqrn, "private_key", "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA2ymVc24BoaZb0ElXoI3X4zUKJGZEetR6F4yT1tJhkPDg7UTm\niNoFB5TZJvP6LBrrSwszkpZbxaVOkBrwrGbqFUaXPgud8VabfHl0imXvN746zmpj\nYEMGqJzm+Gh6aBWOlnPdLuHhds/kcanFAEppj5yN0tVWDnqjOJjR7EpxMSdP3TSd\n6tNAY73LGNLNJQc6tSxh8nMIb4HhSWQSgfof+FwcLGvs+mmyBq8Jz5Zy4BSCk1fQ\nFmCnSGyzpyBD0vMd6eLHk2l0tm56DrlonbDMX8KGs7e9ZgjANkT5PnipLOaeLJU4\nH+OWyBZUAT4hl/iRVvLwV81x7g0/O38kmPYJDQIDAQABAoIBAFb7wyhEIfuhhlE9\nuryrb2LrGzJlMIq7qBWOouKhLz4SjIM/VGw+c76VkjZGoSU+LeLj+D0W1ie0u2Cw\ngJM8aW22TbK/c5lksWOO5PVFDdPG+ZoRWY3MLGlhlL5E4UhMPgJyy/eeiRjZ3CZM\npja+UfVAwn1KVNR8UinVZYPt680AvEd1FGxoNLxemIPNug46nNqp6Al86Bn+BnkN\nGXpwyooXVSfo4k+pnFBFIXUdA1dUEXQSVb1AxlTo6g/Ok/+8Gfq8idCdu+5fcZI2\n1eLeC+FAa92rr1SFX/UWeB4cMyuAqwuxbFFIplT22SaUSsNuOUSH4E00nbP/AuCb\n1BqrLmECgYEA7tQKfyF9aiXTsOMdOnSAa5OyEaCfsFtcmLd4ykVrwN8O36NoX005\nVbGuqo87fwIXQIKHU+kOEs/TmaQ8bNcbCD/SfWGTtOnHG4qfIsepJuoMwbQHRhGF\nJeoXh5yEUKg5pcDBY8PENEtEVKmFuL4bPOdn+9FNLGsjftvXpmGWbGUCgYEA6uuQ\n7kzO6WD88OsxdJzlJM11hg2SaSBCh3+5tnOhF1ULOUt4tdYXzh3QI6BPX7tkArYf\nXteVfWoWqn6T7LtCjFm350BqVpPhqfLKnt6fYf1yotsj/cyZXlXquRbxbgakB0n0\n4PrsZaube0TPPVeirzNyOVHyFc+iW+F+IUYD+4kCgYEApDEjBkP/9PoMj4+UiJuP\nrmXcBkJnhtdI0bVRVb5kVjUEBLxTBTISONfvPVM7lBXb5n3Wi9mt00EOOJKw+CLq\ncsFt9MUgxz/xov2qaj7aC+bc3k7msUVaRLardpAkZ09AUrQyQGRWf50/XPUu+dO4\n5iYxVu6OH/uIa664k6qDwAECgYEAslS8oomgEL3VhbWkx1dLA5MMggTPfgpFNsMY\n4Y4JXcLrUEUgjzjEvW0YUdMiLhP8qapDSiXxj1D3f9myxWSp8g0xc9UMZEjCZ9at\nRcjNyP8zBLnCKqokSt6B3puyDsnvvrC/ugIBbnTFBOCJSZG7J7CwJx8z3KbQI1ub\n+fpCj7ECgYAd69soLEybUGMjsdI+OijIGoUTUoZGXJm+0VpBt4QJCe7AMnYPfYzA\nJnEmN4D7HLTKUBklQnb/FhP/RuiT2bSAd1l+PNeuU7gYROCBBonzxXQ1wEbNrSYA\niyoc9g/kvV8HTW8361xEhu7wmuSEEx1gQ/7sdhTkgrTncc8hxVRxuA==\n-----END RSA PRIVATE KEY-----\n"),
+					resource.TestCheckResourceAttr(fqrn, "alias", fmt.Sprintf("foo-alias%d", id)),
+					resource.TestCheckResourceAttr(fqrn, "pair_type", "RSA"),
+					resource.TestCheckResourceAttr(fqrn, "unavailable", "false"),
+					resource.TestCheckResourceAttr(fqrn, "passphrase", "new-password"),
 				),
 			},
 		},

--- a/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
@@ -154,8 +154,8 @@ func TestAccKeyPairRSA(t *testing.T) {
 		fqrn,
 		template,
 		map[string]string{
-			"id": fmt.Sprint(id),
-			"name": name,
+			"id":         fmt.Sprint(id),
+			"name":       name,
 			"passphrase": "password",
 		},
 	)
@@ -164,8 +164,8 @@ func TestAccKeyPairRSA(t *testing.T) {
 		fqrn,
 		template,
 		map[string]string{
-			"id": fmt.Sprint(id),
-			"name": name,
+			"id":         fmt.Sprint(id),
+			"name":       name,
 			"passphrase": "new-password",
 		},
 	)

--- a/sample.tf
+++ b/sample.tf
@@ -214,12 +214,7 @@ resource "artifactory_keypair" "some-keypairRSA" {
   private_key = file("samples/rsa.priv")
   public_key  = file("samples/rsa.pub")
   alias       = "foo-aliasfoo"
-  lifecycle {
-    ignore_changes = [
-      private_key,
-      passphrase,
-    ]
-  }
+  passphrase  = "some-passphrase"
 }
 
 resource "artifactory_keypair" "some-keypairGPG1" {
@@ -228,12 +223,7 @@ resource "artifactory_keypair" "some-keypairGPG1" {
   alias       = "foo-alias1"
   private_key = file("samples/gpg.priv")
   public_key  = file("samples/gpg.pub")
-  lifecycle {
-    ignore_changes = [
-      private_key,
-      passphrase,
-    ]
-  }
+  passphrase  = "some-passphrase"
 }
 
 resource "artifactory_keypair" "some-keypairGPG2" {
@@ -242,12 +232,7 @@ resource "artifactory_keypair" "some-keypairGPG2" {
   alias       = "foo-alias2"
   private_key = file("samples/gpg.priv")
   public_key  = file("samples/gpg.pub")
-  lifecycle {
-    ignore_changes = [
-      private_key,
-      passphrase,
-    ]
-  }
+  passphrase  = "some-passphrase"
 }
 
 resource "artifactory_local_debian_repository" "my-debian-repo" {

--- a/scripts/run-artifactory.sh
+++ b/scripts/run-artifactory.sh
@@ -42,4 +42,4 @@ echo "Circle-of-Trust is setup between artifactory-1 and artifactory-2 instances
 
 echo "Generate Admin Access Keys for both instances"
 
-echo "export JFROG_ACCESS_TOKEN=$(getAccessKey "${ARTIFACTORY_UI_URL_1}")"
+echo "export JFROG_ACCESS_TOKEN=$(getAccessKey ${ARTIFACTORY_UI_URL_1})"


### PR DESCRIPTION
Fixes #594 

- Add ForceNew to 'passphrase' attribute
- Fix read func doesn't reset resource ID if resource is missing.
- Call read func at the end of create func to ensure TF gets latest state from Artifactory
- Add test for verifying passphrase update
- Remove extraneous quotes from access token env var export