### PR TITLE
Fix federated docker resource documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 BUG FIXES:
 
-* resource/artifactory_federated_docker_repository: Provide backward compatibility and is aliased to `artifactory_federated_docker_v2_repository` resource. Issue: [#577](https://github.com/jfrog/terraform-provider-artifactory/issues/577) [#601](https://github.com/jfrog/terraform-provider-artifactory/pull/601)
-* resource/artifactory_federated_docker_v1_repository, artifactory_federated_docker_v2_repository: Add missing documentation. Issue: [#577](https://github.com/jfrog/terraform-provider-artifactory/issues/577) [#601](https://github.com/jfrog/terraform-provider-artifactory/pull/601)
+* resource/artifactory_federated_docker_repository: Provide backward compatibility and is aliased to `artifactory_federated_docker_v2_repository` resource. Issue: [#593](https://github.com/jfrog/terraform-provider-artifactory/issues/593) [#601](https://github.com/jfrog/terraform-provider-artifactory/pull/601)
+* resource/artifactory_federated_docker_v1_repository, artifactory_federated_docker_v2_repository: Add missing documentation. Issue: [#593](https://github.com/jfrog/terraform-provider-artifactory/issues/593) [#601](https://github.com/jfrog/terraform-provider-artifactory/pull/601)
 
 ## 6.21.5 (December 12, 2022). Tested on Artifactory 7.47.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 BUG FIXES:
 
-* resource/artifactory_federated_docker_repository: Provide backward compatibility and is aliased to `artifactory_federated_docker_v2_repository` resource. Issue: [#577](https://github.com/jfrog/terraform-provider-artifactory/issues/577) [#599](https://github.com/jfrog/terraform-provider-artifactory/pull/599)
-* resource/artifactory_federated_docker_v1_repository, artifactory_federated_docker_v2_repository: Add missing documentation. Issue: [#577](https://github.com/jfrog/terraform-provider-artifactory/issues/577) [#599](https://github.com/jfrog/terraform-provider-artifactory/pull/599)
+* resource/artifactory_federated_docker_repository: Provide backward compatibility and is aliased to `artifactory_federated_docker_v2_repository` resource. Issue: [#577](https://github.com/jfrog/terraform-provider-artifactory/issues/577) [#601](https://github.com/jfrog/terraform-provider-artifactory/pull/601)
+* resource/artifactory_federated_docker_v1_repository, artifactory_federated_docker_v2_repository: Add missing documentation. Issue: [#577](https://github.com/jfrog/terraform-provider-artifactory/issues/577) [#601](https://github.com/jfrog/terraform-provider-artifactory/pull/601)
 
 ## 6.21.5 (December 12, 2022). Tested on Artifactory 7.47.12
 
@@ -11,7 +11,7 @@ IMPROVEMENTS:
 
 * resource/artifactory_anonymous_user: Update documentation and make resource limitation more prominent. Issue: [#577](https://github.com/jfrog/terraform-provider-artifactory/issues/577) PR: [#599](https://github.com/jfrog/terraform-provider-artifactory/pull/599)
 * resource/artifactory_local_*_repository, resource/artifactory_remote_*_repository, resource/artifactory_virtual_*_repository:
-  updated documentation for `project_environments` and `project_key` attributes. Added guide for adding repositories to the project. 
+  updated documentation for `project_environments` and `project_key` attributes. Added guide for adding repositories to the project.
   PR: [#600](https://github.com/jfrog/terraform-provider-artifactory/pull/600)
 
 ## 6.21.4 (December 9, 2022). Tested on Artifactory 7.47.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,15 @@
+## 6.21.6 (December 14, 2022)
+
+BUG FIXES:
+
+* resource/artifactory_federated_docker_repository: Provide backward compatibility and is aliased to `artifactory_federated_docker_v2_repository` resource. Issue: [#577](https://github.com/jfrog/terraform-provider-artifactory/issues/577) [#599](https://github.com/jfrog/terraform-provider-artifactory/pull/599)
+* resource/artifactory_federated_docker_v1_repository, artifactory_federated_docker_v2_repository: Add missing documentation. Issue: [#577](https://github.com/jfrog/terraform-provider-artifactory/issues/577) [#599](https://github.com/jfrog/terraform-provider-artifactory/pull/599)
+
 ## 6.21.5 (December 12, 2022). Tested on Artifactory 7.47.12
 
 IMPROVEMENTS:
 
-* resource/artifactory_anonymous_user: Issue: Update documentation and make resource limitation more prominent.
-  Issue: [#577](https://github.com/jfrog/terraform-provider-artifactory/issues/577) 
-  PR: [#599](https://github.com/jfrog/terraform-provider-artifactory/pull/599)
+* resource/artifactory_anonymous_user: Update documentation and make resource limitation more prominent. Issue: [#577](https://github.com/jfrog/terraform-provider-artifactory/issues/577) PR: [#599](https://github.com/jfrog/terraform-provider-artifactory/pull/599)
 * resource/artifactory_local_*_repository, resource/artifactory_remote_*_repository, resource/artifactory_virtual_*_repository:
   updated documentation for `project_environments` and `project_key` attributes. Added guide for adding repositories to the project. 
   PR: [#600](https://github.com/jfrog/terraform-provider-artifactory/pull/600)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.21.6 (December 14, 2022)
+## 6.21.6 (December 14, 2022). Tested on Artifactory 7.47.12
 
 BUG FIXES:
 

--- a/docs/resources/federated_docker_v1_repository.md
+++ b/docs/resources/federated_docker_v1_repository.md
@@ -1,16 +1,14 @@
 ---
 subcategory: "Federated Repositories"
 ---
-# Artifactory Federated Docker Repository Resource
+# Artifactory Federated Docker V1 Repository Resource
 
 Creates a federated Docker repository.
-
-~>This resource has been superseded by the `artifactory_federated_docker_v2_repository` resource. This resource will continue to be available in the provider for backward compatibility. For documentation, please refer to [the new resource](federated_docker_v2_repository.md).
 
 ## Example Usage
 
 ```hcl
-resource "artifactory_federated_docker_repository" "terraform-federated-test-docker-repo" {
+resource "artifactory_federated_docker_v1_repository" "terraform-federated-test-docker-repo" {
   key       = "terraform-federated-test-docker-repo"
 
   member {
@@ -27,7 +25,7 @@ resource "artifactory_federated_docker_repository" "terraform-federated-test-doc
 
 ## Argument Reference
 
-The following attributes are supported, along with the [list of attributes from the local Docker V2 repository](local_docker_v2_repository.md):
+The following attributes are supported, along with the [list of attributes from the local Docker V1 repository](local_docker_v1_repository.md):
 
 * `key` - (Required) the identity key of the repo.
 * `member` - (Required) The list of Federated members and must contain this repository URL (configured base URL

--- a/docs/resources/federated_docker_v2_repository.md
+++ b/docs/resources/federated_docker_v2_repository.md
@@ -1,16 +1,14 @@
 ---
 subcategory: "Federated Repositories"
 ---
-# Artifactory Federated Docker Repository Resource
+# Artifactory Federated Docker V2 Repository Resource
 
 Creates a federated Docker repository.
-
-~>This resource has been superseded by the `artifactory_federated_docker_v2_repository` resource. This resource will continue to be available in the provider for backward compatibility. For documentation, please refer to [the new resource](federated_docker_v2_repository.md).
 
 ## Example Usage
 
 ```hcl
-resource "artifactory_federated_docker_repository" "terraform-federated-test-docker-repo" {
+resource "artifactory_federated_docker_v2_repository" "terraform-federated-test-docker-repo" {
   key       = "terraform-federated-test-docker-repo"
 
   member {

--- a/pkg/artifactory/provider/provider.go
+++ b/pkg/artifactory/provider/provider.go
@@ -34,6 +34,7 @@ func Provider() *schema.Provider {
 		"artifactory_federated_alpine_repository":             federated.ResourceArtifactoryFederatedAlpineRepository(),
 		"artifactory_federated_cargo_repository":              federated.ResourceArtifactoryFederatedCargoRepository(),
 		"artifactory_federated_debian_repository":             federated.ResourceArtifactoryFederatedDebianRepository(),
+		"artifactory_federated_docker_repository":             federated.ResourceArtifactoryFederatedDockerV2Repository(), // Alias for backward compatibility
 		"artifactory_federated_docker_v1_repository":          federated.ResourceArtifactoryFederatedDockerV1Repository(),
 		"artifactory_federated_docker_v2_repository":          federated.ResourceArtifactoryFederatedDockerV2Repository(),
 		"artifactory_federated_maven_repository":              federated.ResourceArtifactoryFederatedJavaRepository("maven", false),

--- a/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_repository_test.go
+++ b/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_repository_test.go
@@ -667,6 +667,77 @@ func TestAccFederatedDockerV2Repository(t *testing.T) {
 	})
 }
 
+// TestAccFederatedDockerRepository tests for backward compatibility
+func TestAccFederatedDockerRepository(t *testing.T) {
+	_, fqrn, name := test.MkNames("docker-federated", "artifactory_federated_docker_repository")
+	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", acctest.GetArtifactoryUrl(t), name)
+
+	template := `
+		resource "artifactory_federated_docker_repository" "{{ .name }}" {
+			key 	              = "{{ .name }}"
+			tag_retention         = {{ .retention }}
+			max_unique_tags       = {{ .max_tags }}
+			block_pushing_schema1 = {{ .block }}
+
+			member {
+				url     = "{{ .memberUrl }}"
+				enabled = true
+			}
+		}
+	`
+
+	params := map[string]interface{}{
+		"block":     test.RandBool(),
+		"retention": test.RandSelect(1, 5, 10),
+		"max_tags":  test.RandSelect(0, 5, 10),
+		"name":      name,
+		"memberUrl": federatedMemberUrl,
+	}
+	federatedRepositoryBasic := util.ExecuteTemplate("TestAccFederatedDockerRepository", template, params)
+
+	updated := map[string]interface{}{
+		"block":     test.RandBool(),
+		"retention": test.RandSelect(1, 5, 10),
+		"max_tags":  test.RandSelect(0, 5, 10),
+		"name":      name,
+		"memberUrl": federatedMemberUrl,
+	}
+	federatedRepositoryUpdated := util.ExecuteTemplate("TestAccFederatedDockerRepository", template, updated)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: federatedRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "block_pushing_schema1", fmt.Sprintf("%t", params["block"])),
+					resource.TestCheckResourceAttr(fqrn, "tag_retention", fmt.Sprintf("%d", params["retention"])),
+					resource.TestCheckResourceAttr(fqrn, "max_unique_tags", fmt.Sprintf("%d", params["max_tags"])),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("federated", "docker")(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+				),
+			},
+			{
+				Config: federatedRepositoryUpdated,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "block_pushing_schema1", fmt.Sprintf("%t", updated["block"])),
+					resource.TestCheckResourceAttr(fqrn, "tag_retention", fmt.Sprintf("%d", updated["retention"])),
+					resource.TestCheckResourceAttr(fqrn, "max_unique_tags", fmt.Sprintf("%d", updated["max_tags"])),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("federated", "docker")(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+				),
+			},
+			{
+				ResourceName:      fqrn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
 func TestAccFederatedDockerV1Repository(t *testing.T) {
 	_, fqrn, name := test.MkNames("docker-federated", "artifactory_federated_docker_v1_repository")
 	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", acctest.GetArtifactoryUrl(t), name)


### PR DESCRIPTION
Fixes missing resource in #593.

Add documentation for new federated Docker v1 and v2 resources.