### PR TITLE
PTRENG-4810, replace deprecated Docker remote portal URL.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* resource/artifactory_remote_docker_repository: Remove deprecated URL from the documentation and HCL example. [#603](https://github.com/jfrog/terraform-provider-artifactory/pull/603)
+* resource/artifactory_remote_docker_repository: Update URL from the documentation and HCL example. [#603](https://github.com/jfrog/terraform-provider-artifactory/pull/603)
 
 ## 6.21.6 (December 14, 2022). Tested on Artifactory 7.47.12
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.21.7 (December 14, 2022). Tested on Artifactory 7.47.12
+
+BUG FIXES:
+
+* resource/artifactory_remote_docker_repository: Remove deprecated URL from the documentation and HCL example. [#602](https://github.com/jfrog/terraform-provider-artifactory/pull/602)
+
 ## 6.21.6 (December 14, 2022). Tested on Artifactory 7.47.12
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* resource/artifactory_remote_docker_repository: Remove deprecated URL from the documentation and HCL example. [#602](https://github.com/jfrog/terraform-provider-artifactory/pull/602)
+* resource/artifactory_remote_docker_repository: Remove deprecated URL from the documentation and HCL example. [#603](https://github.com/jfrog/terraform-provider-artifactory/pull/603)
 
 ## 6.21.6 (December 14, 2022). Tested on Artifactory 7.47.12
 

--- a/docs/resources/remote_docker_repository.md
+++ b/docs/resources/remote_docker_repository.md
@@ -13,9 +13,9 @@ Official documentation can be found [here](https://www.jfrog.com/confluence/disp
 resource "artifactory_remote_docker_repository" "my-remote-docker" {
   key                            = "my-remote-docker"
   external_dependencies_enabled  = true
-  external_dependencies_patterns = ["**/hub.docker.io/**"]
+  external_dependencies_patterns = ["**/registry-1.docker.io/**"]
   enable_token_authentication    = true
-  url                            = "https://hub.docker.io/"
+  url                            = "https://registry-1.docker.io/"
   block_pushing_schema1          = true
 }
 ```

--- a/sample.tf
+++ b/sample.tf
@@ -308,9 +308,9 @@ resource "artifactory_remote_debian_repository" "my-remote-debian" {
 resource "artifactory_remote_docker_repository" "my-remote-docker" {
   key                            = "my-remote-docker"
   external_dependencies_enabled  = true
-  external_dependencies_patterns = ["**/hub.docker.io/**", "**/bintray.jfrog.io/**"]
+  external_dependencies_patterns = ["**/registry-1.docker.io/**"]
   enable_token_authentication    = true
-  url                            = "https://hub.docker.io/"
+  url                            = "https://registry-1.docker.io/"
   block_pushing_schema1          = true
 }
 


### PR DESCRIPTION
Replace `https://hub.docker.io/` with `https://registry-1.docker.io/`