### PR TITLE
GH-573 add access token migration doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.21.8 (December 15, 2022)
+## 6.21.8 (December 15, 2022). Tested on Artifactory 7.47.12
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 6.21.8 (December 15, 2022)
+
+IMPROVEMENTS:
+
+* resource/artifactory_access_token: Remove ability to import which was never supported.
+* Add documentation guide for migrating access token to scoped token.
+
+Issue: [#573](https://github.com/jfrog/terraform-provider-artifactory/issues/573) PR: [#604](https://github.com/jfrog/terraform-provider-artifactory/pull/604)
+
 ## 6.21.7 (December 14, 2022). Tested on Artifactory 7.47.12
 
 BUG FIXES:

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @alexhung
+* @danielmkn

--- a/docs/guides/access_token_to_scoped_token_migration.md
+++ b/docs/guides/access_token_to_scoped_token_migration.md
@@ -1,0 +1,11 @@
+---
+page_title: "Migrating from access token to scoped token"
+---
+
+Artifactory version 7.21.1 introduced scoped token which replaces the access token. In this provider, we have `artifactory_scoped_token` and `artifactory_access_token` resources supporting both accordingly.
+
+While access token continues to be supported and can still be used to generate a token, we recommend only using scoped token for any new token resources.
+
+Since Artifactory API does not allow retrieval of an existing token (for good security reason), importing an existing token (access or scoped) into Terraform state is not supported. Therefore, we recommend that when the time comes to rotate/replace an existing **access** token, you replace it with a new **scoped** token. This consists of creating a new scoped token resource and update any references to the existing access token with the new scoped token.
+
+Once you've verified the new scoped token is working, you can safely remove the old access token resource from your Terraform configuration.

--- a/pkg/artifactory/resource/security/resource_artifactory_access_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_access_token.go
@@ -54,8 +54,6 @@ func ResourceArtifactoryAccessToken() *schema.Resource {
 		ReadContext:   resourceAccessTokenRead,
 		DeleteContext: resourceAccessTokenDelete,
 
-		Importer: nil,
-
 		Schema: map[string]*schema.Schema{
 			"username": {
 				Type:     schema.TypeString,

--- a/pkg/artifactory/resource/security/resource_artifactory_access_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_access_token.go
@@ -54,9 +54,7 @@ func ResourceArtifactoryAccessToken() *schema.Resource {
 		ReadContext:   resourceAccessTokenRead,
 		DeleteContext: resourceAccessTokenDelete,
 
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
+		Importer: nil,
 
 		Schema: map[string]*schema.Schema{
 			"username": {

--- a/pkg/artifactory/resource/security/resource_artifactory_access_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_access_token_test.go
@@ -45,6 +45,7 @@ func TestAccAccessTokenAudienceBad(t *testing.T) {
 }
 
 func TestAccAccessTokenAudienceGood(t *testing.T) {
+	fqrn := "artifactory_access_token.foobar"
 	const audienceGood = `
 		resource "artifactory_user" "existinguser" {
 			name  = "existinguser"
@@ -64,19 +65,25 @@ func TestAccAccessTokenAudienceGood(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckAccessTokenDestroy(t, "artifactory_access_token.foobar"),
+		CheckDestroy:      testAccCheckAccessTokenDestroy(t, fqrn),
 		Steps: []resource.TestStep{
 			{
 				Config: audienceGood,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "access_token"),
-					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "username", "existinguser"),
-					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "end_date_relative", "1s"),
-					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "end_date"),
-					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "refreshable", "true"),
-					resource.TestCheckResourceAttrSet("artifactory_access_token.foobar", "refresh_token"),
-					resource.TestCheckResourceAttr("artifactory_access_token.foobar", "groups.#", "0"),
+					resource.TestCheckResourceAttrSet(fqrn, "access_token"),
+					resource.TestCheckResourceAttr(fqrn, "username", "existinguser"),
+					resource.TestCheckResourceAttr(fqrn, "end_date_relative", "1s"),
+					resource.TestCheckResourceAttrSet(fqrn, "end_date"),
+					resource.TestCheckResourceAttr(fqrn, "refreshable", "true"),
+					resource.TestCheckResourceAttrSet(fqrn, "refresh_token"),
+					resource.TestCheckResourceAttr(fqrn, "groups.#", "0"),
 				),
+			},
+			{
+				Config: audienceGood,
+				ResourceName: fqrn,
+				ImportState: true,
+				ExpectError: regexp.MustCompile("resource artifactory_access_token doesn't support import"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/security/resource_artifactory_access_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_access_token_test.go
@@ -80,10 +80,10 @@ func TestAccAccessTokenAudienceGood(t *testing.T) {
 				),
 			},
 			{
-				Config: audienceGood,
+				Config:       audienceGood,
 				ResourceName: fqrn,
-				ImportState: true,
-				ExpectError: regexp.MustCompile("resource artifactory_access_token doesn't support import"),
+				ImportState:  true,
+				ExpectError:  regexp.MustCompile("resource artifactory_access_token doesn't support import"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
@@ -59,10 +59,10 @@ func TestAccScopedToken_WithDefaults(t *testing.T) {
 				),
 			},
 			{
-				Config: accessTokenConfig,
+				Config:       accessTokenConfig,
 				ResourceName: fqrn,
-				ImportState: true,
-				ExpectError: regexp.MustCompile("resource artifactory_scoped_token doesn't support import"),
+				ImportState:  true,
+				ExpectError:  regexp.MustCompile("resource artifactory_scoped_token doesn't support import"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
@@ -58,6 +58,12 @@ func TestAccScopedToken_WithDefaults(t *testing.T) {
 					resource.TestCheckResourceAttrSet(fqrn, "issuer"),
 				),
 			},
+			{
+				Config: accessTokenConfig,
+				ResourceName: fqrn,
+				ImportState: true,
+				ExpectError: regexp.MustCompile("resource artifactory_scoped_token doesn't support import"),
+			},
 		},
 	})
 }


### PR DESCRIPTION
Closes #573 

- Add documentation guide for migrating access token to scoped token.
- Remove ability to import for `artifactory_access_token` which was never supported. Add tests to verify for both access and scoped token resources.