### PR TITLE
GH-610 Fix import issues for "configuration" resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 6.22.3 (January 4, 2023)
+
+BUG FIXES:
+
+* resource/artifactory_backup, resource/artifactory_ldap_group_setting, resource/artifactory_ldap_setting, resource/artifactory_property_set, resource/artifactory_proxy, resource/artifactory_repository_layout: Fix import does not update the state. Issue: [#610](https://github.com/jfrog/terraform-provider-artifactory/issues/610) PR: [#613](https://github.com/jfrog/terraform-provider-artifactory/pull/613)
+
 ## 6.22.2 (December 22, 2022). Tested on Artifactory 7.47.14
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ BUG FIXES:
 
 * resource/artifactory_backup, resource/artifactory_ldap_group_setting, resource/artifactory_ldap_setting, resource/artifactory_property_set, resource/artifactory_proxy, resource/artifactory_repository_layout: Fix import does not update the state. Issue: [#610](https://github.com/jfrog/terraform-provider-artifactory/issues/610) PR: [#613](https://github.com/jfrog/terraform-provider-artifactory/pull/613)
 
+NOTES:
+
+* resource/artifactory_remote_vcs_repository: In Artifactory version 7.49.3, the attribute `max_unique_snapshots` cannot be set/updated due to an API bug.
+
 ## 6.22.2 (December 22, 2022). Tested on Artifactory 7.47.14
 
 BUG FIXES:

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ terraform {
   required_providers {
     artifactory = {
       source  = "registry.terraform.io/jfrog/artifactory"
-      version = "2.6.17"
+      version = "6.22.3"
     }
   }
 }

--- a/docs/resources/repository_layout.md
+++ b/docs/resources/repository_layout.md
@@ -36,5 +36,5 @@ The following arguments are supported:
 Repository layout can be imported using its name, e.g.
 
 ```
-$ terraform import artifactory_repository_layout.custom-layout custom_layout
+$ terraform import artifactory_repository_layout.custom-layout custom-layout
 ```

--- a/pkg/artifactory/resource/configuration/resource_artifactory_backup.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_backup.go
@@ -188,7 +188,7 @@ backups:
 		}
 
 		d.SetId("")
-		return resourceBackupRead(ctx, d, m)
+		return nil
 	}
 
 	return &schema.Resource{

--- a/pkg/artifactory/resource/configuration/resource_artifactory_backup.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_backup.go
@@ -120,17 +120,18 @@ func ResourceArtifactoryBackup() *schema.Resource {
 	}
 
 	var resourceBackupRead = func(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-		backups := &Backups{}
-		backup := unpackBackup(d)
+		data := &util.ResourceData{ResourceData: d}
+		key := data.GetString("key", false)
 
+		backups := &Backups{}
 		_, err := m.(*resty.Client).R().SetResult(&backups).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}
 
-		matchedBackup := FindConfigurationById[Backup](backups.BackupArr, backup.Key)
+		matchedBackup := FindConfigurationById[Backup](backups.BackupArr, key)
 		if matchedBackup == nil {
-			return nil
+			return diag.Errorf("No backup found for '%s'", key)
 		}
 
 		pkr := packer.Default(backupSchema)
@@ -197,7 +198,10 @@ backups:
 		ReadContext:   resourceBackupRead,
 
 		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
+			State: func(d *schema.ResourceData, meta any) ([]*schema.ResourceData, error) {
+				d.Set("key", d.Id())
+				return []*schema.ResourceData{d}, nil
+			},
 		},
 
 		Schema:      backupSchema,

--- a/pkg/artifactory/resource/configuration/resource_artifactory_backup.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_backup.go
@@ -123,7 +123,7 @@ func ResourceArtifactoryBackup() *schema.Resource {
 		data := &util.ResourceData{ResourceData: d}
 		key := data.GetString("key", false)
 
-		backups := &Backups{}
+		backups := Backups{}
 		_, err := m.(*resty.Client).R().SetResult(&backups).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")

--- a/pkg/artifactory/resource/configuration/resource_artifactory_backup_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_backup_test.go
@@ -10,62 +10,75 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/configuration"
+	"github.com/jfrog/terraform-provider-shared/test"
 	"github.com/jfrog/terraform-provider-shared/util"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
 )
 
 func TestAccBackup_full(t *testing.T) {
+	_, fqrn, resourceName := test.MkNames("backup-", "artifactory_backup")
+	_, _, repoResourceName1 := test.MkNames("test-backup-local-", "artifactory_local_generic_repository")
+	_, _, repoResourceName2 := test.MkNames("test-backup-local-", "artifactory_local_generic_repository")
+
 	const BackupTemplateFull = `
-resource "artifactory_backup" "backuptest" {
-    key = "backuptest"
+resource "artifactory_backup" "{{ .resourceName }}" {
+    key = "{{ .resourceName }}"
     enabled = true
     cron_exp = "0 0 2 ? * MON-SAT *"
 }`
 
+	testData := map[string]string{
+		"resourceName":      resourceName,
+		"repoResourceName1": repoResourceName1,
+		"repoResourceName2": repoResourceName2,
+	}
+
 	const BackupTemplateUpdate = `
-resource "artifactory_local_generic_repository" "test-backup-local1" {
-    key = "test-backup-local1"
+resource "artifactory_local_generic_repository" "{{ .repoResourceName1 }}" {
+    key = "{{ .repoResourceName1 }}"
 }
 
-resource "artifactory_local_generic_repository" "test-backup-local2" {
-    key = "test-backup-local2"
+resource "artifactory_local_generic_repository" "{{ .repoResourceName2 }}" {
+    key = "{{ .repoResourceName2 }}"
 }
 
-resource "artifactory_backup" "backuptest" {
-    key                    = "backuptest"
-    enabled                = false
+resource "artifactory_backup" "{{ .resourceName }}" {
+    key                    = "{{ .resourceName }}"
+    enabled                = true
     cron_exp               = "0 0 12 * * ? *"
     retention_period_hours = 1000
-    excluded_repositories  = [ "test-backup-local1", "test-backup-local2" ]
+    excluded_repositories  = [
+		artifactory_local_generic_repository.{{ .repoResourceName1 }}.key,
+		artifactory_local_generic_repository.{{ .repoResourceName2 }}.key,
+	]
 	create_archive         = true
 	verify_disk_space      = true
 	export_mission_control = true
-
-    depends_on = [ artifactory_local_generic_repository.test-backup-local1, artifactory_local_generic_repository.test-backup-local2 ]
 }`
 
-	fqrn := "artifactory_backup.backuptest"
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccBackupDestroy("backuptest"),
+		CheckDestroy:      testAccBackupDestroy(resourceName),
 
 		Steps: []resource.TestStep{
 			{
-				Config: BackupTemplateFull,
+				Config: util.ExecuteTemplate(fqrn, BackupTemplateFull, testData),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr("artifactory_backup.backuptest", "enabled", "true"),
+					resource.TestCheckResourceAttr(fqrn, "enabled", "true"),
+					resource.TestCheckResourceAttr(fqrn, "cron_exp", "0 0 2 ? * MON-SAT *"),
 				),
 			},
 			{
-				Config: BackupTemplateUpdate,
+				Config: util.ExecuteTemplate(fqrn, BackupTemplateUpdate, testData),
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(fqrn, "enabled", "false"),
+					resource.TestCheckResourceAttr(fqrn, "enabled", "true"),
+					resource.TestCheckResourceAttr(fqrn, "cron_exp", "0 0 12 * * ? *"),
 					resource.TestCheckResourceAttr(fqrn, "retention_period_hours", "1000"),
 					resource.TestCheckResourceAttr(fqrn, "excluded_repositories.#", "2"),
-					resource.TestCheckResourceAttr(fqrn, "excluded_repositories.0", "test-backup-local1"),
-					resource.TestCheckResourceAttr(fqrn, "excluded_repositories.1", "test-backup-local2"),
+					resource.TestCheckResourceAttr(fqrn, "excluded_repositories.0", repoResourceName1),
+					resource.TestCheckResourceAttr(fqrn, "excluded_repositories.1", repoResourceName2),
 					resource.TestCheckResourceAttr(fqrn, "create_archive", "true"),
 					resource.TestCheckResourceAttr(fqrn, "verify_disk_space", "true"),
 					resource.TestCheckResourceAttr(fqrn, "export_mission_control", "true"),

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting.go
@@ -110,7 +110,7 @@ Hierarchy: The user's DN is indicative of the groups the user belongs to by usin
 		data := &util.ResourceData{ResourceData: d}
 		name := data.GetString("name", false)
 
-		ldapGroupConfigs := &XmlLdapGroupConfig{}
+		ldapGroupConfigs := XmlLdapGroupConfig{}
 		_, err := m.(*resty.Client).R().SetResult(&ldapGroupConfigs).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting.go
@@ -156,7 +156,7 @@ func ResourceArtifactoryLdapSetting() *schema.Resource {
 		data := &util.ResourceData{ResourceData: d}
 		key := data.GetString("key", false)
 
-		ldapConfigs := &XmlLdapConfig{}
+		ldapConfigs := XmlLdapConfig{}
 		_, err := m.(*resty.Client).R().SetResult(&ldapConfigs).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")

--- a/pkg/artifactory/resource/configuration/resource_artifactory_property_set.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_property_set.go
@@ -201,7 +201,7 @@ func ResourceArtifactoryPropertySet() *schema.Resource {
 		data := &util.ResourceData{ResourceData: d}
 		name := data.GetString("name", false)
 
-		propertySetConfigs := &PropertySets{}
+		propertySetConfigs := PropertySets{}
 
 		_, err := m.(*resty.Client).R().SetResult(&propertySetConfigs).Get("artifactory/api/system/configuration")
 		if err != nil {

--- a/pkg/artifactory/resource/configuration/resource_artifactory_property_set.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_property_set.go
@@ -7,8 +7,6 @@ import (
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jfrog/terraform-provider-shared/packer"
-	"github.com/jfrog/terraform-provider-shared/predicate"
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
 	"gopkg.in/yaml.v3"
@@ -21,7 +19,7 @@ type PredefinedValue struct {
 
 type Property struct {
 	Name                  string            `xml:"name" yaml:"-"`
-	PredefinedValues      []PredefinedValue `xml:"predefinedValues" yaml:"predefinedValues"`
+	PredefinedValues      []PredefinedValue `xml:"predefinedValues>predefinedValue" yaml:"predefinedValues"`
 	ClosedPredefinedValue bool              `xml:"closedPredefinedValues" yaml:"closedPredefinedValues"`
 	MultipleChoice        bool              `xml:"multipleChoice" yaml:"multipleChoice"`
 }
@@ -41,30 +39,51 @@ type PropertySets struct {
 }
 
 func ResourceArtifactoryPropertySet() *schema.Resource {
+	var predefinedValueSchema = schema.Schema{
+		Type:        schema.TypeSet,
+		Required:    true,
+		Description: "Properties in the property set.",
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:             schema.TypeString,
+					Required:         true,
+					Description:      "Predefined property name.",
+					ValidateDiagFunc: validator.StringIsNotEmpty,
+				},
+				"default_value": {
+					Type:        schema.TypeBool,
+					Required:    true,
+					Description: "Whether the value is selected by default in the UI.",
+				},
+			},
+		},
+	}
+
 	var propertySetsSchema = map[string]*schema.Schema{
 		"name": {
 			Type:             schema.TypeString,
 			Required:         true,
 			ValidateDiagFunc: validator.StringIsNotEmpty,
-			Description:      `Property set name.`,
+			Description:      "Property set name.",
 		},
 		"visible": {
 			Type:        schema.TypeBool,
 			Optional:    true,
 			Default:     true,
-			Description: `Defines if the list visible and assignable to the repository or artifact.`,
+			Description: "Defines if the list visible and assignable to the repository or artifact.",
 		},
 		"property": {
 			Type:        schema.TypeSet,
 			Required:    true,
 			MinItems:    1,
-			Description: `A list of properties that will be part of the property set.`,
+			Description: "A list of properties that will be part of the property set.",
 			Elem: &schema.Resource{
 				Schema: map[string]*schema.Schema{
 					"name": {
 						Type:             schema.TypeString,
 						Required:         true,
-						Description:      `The name of the property.`,
+						Description:      "The name of the property.",
 						ValidateDiagFunc: validator.StringIsNotEmpty,
 					},
 					"closed_predefined_values": {
@@ -79,26 +98,7 @@ func ResourceArtifactoryPropertySet() *schema.Resource {
 						Default:     false,
 						Description: `Whether or not user can select multiple values. "closed_predefined_values" should be set to "true".`,
 					},
-					"predefined_value": {
-						Type:        schema.TypeSet,
-						Required:    true,
-						Description: `Properties in the property set.`,
-						Elem: &schema.Resource{
-							Schema: map[string]*schema.Schema{
-								"name": {
-									Type:             schema.TypeString,
-									Required:         true,
-									Description:      `Predefined property name.`,
-									ValidateDiagFunc: validator.StringIsNotEmpty,
-								},
-								"default_value": {
-									Type:        schema.TypeBool,
-									Required:    true,
-									Description: `Whether the value is selected by default in the UI.`,
-								},
-							},
-						},
-					},
+					"predefined_value": &predefinedValueSchema,
 				},
 			},
 		},
@@ -154,28 +154,63 @@ func ResourceArtifactoryPropertySet() *schema.Resource {
 		return propertySet
 	}
 
+	var packPropertySet = func(p *PropertySet, d *schema.ResourceData) diag.Diagnostics {
+		setValue := util.MkLens(d)
+
+		setValue("name", p.Name)
+		setValue("visible", p.Visible)
+
+		var packPredefinedValues = func(predefinedValues []PredefinedValue) []interface{} {
+			packedValues := []interface{}{}
+
+			for _, predefinedValue := range predefinedValues {
+				value := map[string]interface{}{
+					"name":          predefinedValue.Name,
+					"default_value": predefinedValue.DefaultValue,
+				}
+
+				packedValues = append(packedValues, value)
+			}
+
+			return packedValues
+		}
+
+		predefinedValueResource := predefinedValueSchema.Elem.(*schema.Resource)
+		properties := []interface{}{}
+		for _, prop := range p.Properties {
+			property := map[string]interface{}{
+				"name":                     prop.Name,
+				"closed_predefined_values": prop.ClosedPredefinedValue,
+				"multiple_choice":          prop.MultipleChoice,
+				"predefined_value":         schema.NewSet(schema.HashResource(predefinedValueResource), packPredefinedValues(prop.PredefinedValues)),
+			}
+
+			properties = append(properties, property)
+		}
+
+		propertyResource := propertySetsSchema["property"].Elem.(*schema.Resource)
+		errors := setValue("property", schema.NewSet(schema.HashResource(propertyResource), properties))
+
+		if errors != nil && len(errors) > 0 {
+			return diag.Errorf("failed to pack property_set %q", errors)
+		}
+		return nil
+	}
+
 	var resourcePropertySetRead = func(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		propertySetConfigs := &PropertySets{}
-		// Unpacking HCL to compare the names of the property sets with the XML data we will get from the API
-		unpackedPropertySet := unpackPropertySet(d)
 
 		_, err := m.(*resty.Client).R().SetResult(&propertySetConfigs).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}
 
-		matchedPropertySet := FindConfigurationById[PropertySet](propertySetConfigs.PropertySets, unpackedPropertySet.Name)
+		matchedPropertySet := FindConfigurationById[PropertySet](propertySetConfigs.PropertySets, d.Id())
 		if matchedPropertySet == nil {
-			return nil
+			return diag.Errorf("No property set found for '%s'", d.Id())
 		}
 
-		pkr := packer.Universal(
-			predicate.All(
-				predicate.SchemaHasKey(propertySetsSchema),
-			),
-		)
-
-		return diag.FromErr(pkr(matchedPropertySet, d))
+		return packPropertySet(matchedPropertySet, d)
 	}
 
 	var transformPredefinedValues = func(values []PredefinedValue) map[string]interface{} {
@@ -236,7 +271,6 @@ func ResourceArtifactoryPropertySet() *schema.Resource {
 
 	var resourcePropertySetDelete = func(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		propertySetConfigs := &PropertySets{}
-		unpackedPropertySet := unpackPropertySet(d)
 
 		response, err := m.(*resty.Client).R().SetResult(&propertySetConfigs).Get("artifactory/api/system/configuration")
 		if err != nil {
@@ -246,9 +280,9 @@ func ResourceArtifactoryPropertySet() *schema.Resource {
 			return diag.Errorf("got error response for API: /artifactory/api/system/configuration request during Read")
 		}
 
-		matchedPropertySet := FindConfigurationById[PropertySet](propertySetConfigs.PropertySets, unpackedPropertySet.Name)
+		matchedPropertySet := FindConfigurationById[PropertySet](propertySetConfigs.PropertySets, d.Id())
 		if matchedPropertySet == nil {
-			return nil
+			return diag.Errorf("No property set found for '%s'", d.Id())
 		}
 
 		var constructBody = map[string]map[string]string{
@@ -266,6 +300,8 @@ func ResourceArtifactoryPropertySet() *schema.Resource {
 		if err != nil {
 			return diag.Errorf("failed to send PATCH request to Artifactory during Delete")
 		}
+
+		d.SetId("")
 
 		return nil
 	}

--- a/pkg/artifactory/resource/configuration/resource_artifactory_property_set_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_property_set_test.go
@@ -114,19 +114,19 @@ func TestAccPropertySetCustomizeDiff(t *testing.T) {
 func TestAccPropertySet_importNotFound(t *testing.T) {
 	config := `
 		resource "artifactory_property_set" "not-exist-test" {
-			name                     = "not-exist-test"
-			visible                  = true
-			closed_predefined_values = true
-			multiple_choice          = true
+		  name                     = "not-exist-test"
+		  visible                  = true
+		  closed_predefined_values = true
+		  multiple_choice          = true
 
-			property {
-			  name = "property1"
+		  property {
+		    name = "property1"
 
-			  predefined_value {
-			    name          = "passed-QA"
-			    default_value = true
-			  }
-			}
+		    predefined_value {
+		      name          = "passed-QA"
+		      default_value = true
+	        }
+		  }
 		}
 	`
 	resource.Test(t, resource.TestCase{
@@ -203,59 +203,59 @@ resource "artifactory_property_set" "{{ .resource_name }}" {
   visible 	= {{ .visible }}
 
   property {
-      name = "{{ .property1 }}"
+    name = "{{ .property1 }}"
 
-      predefined_value {
-        name 			= "passed-QA"
-        default_value 	= true
-      }
+    predefined_value {
+      name          = "passed-QA"
+      default_value = true
+    }
 
-      predefined_value {
-        name 			= "failed-QA"
-        default_value 	= false
-      }
+    predefined_value {
+      name          = "failed-QA"
+      default_value = false
+    }
 
-      closed_predefined_values 	= true
-      multiple_choice 			= true
+    closed_predefined_values = true
+    multiple_choice          = true
   }
 
   property {
-      name = "{{ .property2 }}"
+    name = "{{ .property2 }}"
 
-      predefined_value {
-        name 			= "passed-QA"
-        default_value 	= true
-      }
+    predefined_value {
+      name          = "passed-QA"
+      default_value = true
+    }
 
-      predefined_value {
-        name 			= "failed-QA"
-        default_value 	= false
-      }
+    predefined_value {
+      name          = "failed-QA"
+      default_value = false
+    }
 
-      closed_predefined_values 	= false
-      multiple_choice 			= false
+    closed_predefined_values = false
+    multiple_choice          = false
   }
 }`
 
 const PropertySetUpdateAndDiffTemplate = `
 resource "artifactory_property_set" "{{ .resource_name }}" {
-  name 		= "{{ .property_set_name }}"
-  visible 	= {{ .visible }}
+  name    = "{{ .property_set_name }}"
+  visible = {{ .visible }}
 
   property {
-      name = "{{ .property1 }}"
+    name = "{{ .property1 }}"
 
-      predefined_value {
-        name 			= "passed-QA"
-        default_value 	= {{ .default_value1 }}
-      }
+    predefined_value {
+      name          = "passed-QA"
+      default_value = {{ .default_value1 }}
+    }
 
-      predefined_value {
-        name 			= "failed-QA"
-        default_value 	= {{ .default_value2 }}
-      }
+    predefined_value {
+      name          = "failed-QA"
+      default_value = {{ .default_value2 }}
+    }
 
-      closed_predefined_values 	= {{ .closed_predefined_values }}
-      multiple_choice 			= {{ .multiple_choice }}
+    closed_predefined_values = {{ .closed_predefined_values }}
+    multiple_choice          = {{ .multiple_choice }}
   }
 }`

--- a/pkg/artifactory/resource/configuration/resource_artifactory_proxy.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_proxy.go
@@ -161,7 +161,7 @@ func ResourceArtifactoryProxy() *schema.Resource {
 		data := &util.ResourceData{ResourceData: d}
 		key := data.GetString("key", false)
 
-		proxiesConfig := &Proxies{}
+		proxiesConfig := Proxies{}
 		_, err := m.(*resty.Client).R().SetResult(&proxiesConfig).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")

--- a/pkg/artifactory/resource/configuration/resource_artifactory_proxy.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_proxy.go
@@ -164,11 +164,9 @@ func ResourceArtifactoryProxy() *schema.Resource {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}
 
-		// Unpacking HCL to compare the names of the property sets with the XML data we will get from the API
-		unpackedProxy := unpackProxy(d)
-		matchedProxyConfig := FindConfigurationById[Proxy](proxiesConfig.Proxies, unpackedProxy.Key)
+		matchedProxyConfig := FindConfigurationById[Proxy](proxiesConfig.Proxies, d.Id())
 		if matchedProxyConfig == nil {
-			return nil
+			return diag.Errorf("No proxy found for '%s'", d.Id())
 		}
 
 		return packProxy(matchedProxyConfig, d)
@@ -214,10 +212,9 @@ func ResourceArtifactoryProxy() *schema.Resource {
 			return diag.Errorf("got error response for API: /artifactory/api/system/configuration request during Read")
 		}
 
-		unpackedProxy := unpackProxy(d)
-		matchedProxyConfig := FindConfigurationById[Proxy](proxiesConfig.Proxies, unpackedProxy.Key)
+		matchedProxyConfig := FindConfigurationById[Proxy](proxiesConfig.Proxies, d.Id())
 		if matchedProxyConfig == nil {
-			return nil
+			return diag.Errorf("No proxy found for '%s'", d.Id())
 		}
 
 		var body = map[string]map[string]string{
@@ -235,6 +232,8 @@ func ResourceArtifactoryProxy() *schema.Resource {
 		if err != nil {
 			return diag.Errorf("failed to send PATCH request to Artifactory during Delete")
 		}
+
+		d.SetId("")
 
 		return nil
 	}

--- a/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout.go
@@ -14,12 +14,12 @@ import (
 )
 
 type Layout struct {
-	Name                             string `xml:"name" yaml:"name"`
-	ArtifactPathPattern              string `xml:"artifactPathPattern" yaml:"artifactPathPattern"`
-	DistinctiveDescriptorPathPattern bool   `xml:"distinctiveDescriptorPathPattern" yaml:"distinctiveDescriptorPathPattern"`
-	DescriptorPathPattern            string `xml:"descriptorPathPattern" yaml:"descriptorPathPattern"`
-	FolderIntegrationRevisionRegExp  string `xml:"folderIntegrationRevisionRegExp" yaml:"folderIntegrationRevisionRegExp"`
-	FileIntegrationRevisionRegExp    string `xml:"fileIntegrationRevisionRegExp" yaml:"fileIntegrationRevisionRegExp"`
+	Name                             string `hcl:"name" xml:"name" yaml:"name"`
+	ArtifactPathPattern              string `hcl:"artifact_path_pattern" xml:"artifactPathPattern" yaml:"artifactPathPattern"`
+	DistinctiveDescriptorPathPattern bool   `hcl:"distinctive_descriptor_path_pattern" xml:"distinctiveDescriptorPathPattern" yaml:"distinctiveDescriptorPathPattern"`
+	DescriptorPathPattern            string `hcl:"descriptor_path_pattern" xml:"descriptorPathPattern" yaml:"descriptorPathPattern"`
+	FolderIntegrationRevisionRegExp  string `hcl:"folder_integration_revision_regexp" xml:"folderIntegrationRevisionRegExp" yaml:"folderIntegrationRevisionRegExp"`
+	FileIntegrationRevisionRegExp    string `hcl:"file_integration_revision_regexp" xml:"fileIntegrationRevisionRegExp" yaml:"fileIntegrationRevisionRegExp"`
 }
 
 func (l Layout) Id() string {
@@ -83,18 +83,17 @@ func ResourceArtifactoryRepositoryLayout() *schema.Resource {
 		}
 	}
 
-	var resourceLayoutRead = func(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-		layouts := &Layouts{}
-		layout := unpackLayout(d)
+	var resourceLayoutRead = func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+		layouts := Layouts{}
 
 		_, err := m.(*resty.Client).R().SetResult(&layouts).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}
 
-		matchedLayout := FindConfigurationById[Layout](layouts.Layouts, layout.Name)
+		matchedLayout := FindConfigurationById[Layout](layouts.Layouts, d.Id())
 		if matchedLayout == nil {
-			return nil
+			return diag.Errorf("No layout found for '%s'", d.Id())
 		}
 
 		pkr := packer.Default(layoutSchema)
@@ -146,7 +145,7 @@ repoLayouts:
 		}
 
 		d.SetId("")
-		return resourceLayoutRead(ctx, d, m)
+		return nil
 	}
 
 	var distinctiveDescriptorPathPatternDiff = func(ctx context.Context, diff *schema.ResourceDiff, v interface{}) error {

--- a/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout_test.go
@@ -46,7 +46,6 @@ func TestAccLayout_full(t *testing.T) {
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccLayoutDestroy(name),
-
 		Steps: []resource.TestStep{
 			{
 				Config: layoutConfig,
@@ -69,6 +68,37 @@ func TestAccLayout_full(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "folder_integration_revision_regexp", "Foo"),
 					resource.TestCheckResourceAttr(fqrn, "file_integration_revision_regexp", "Foo|(?:(?:[0-9]{8}.[0-9]{6})-(?:[0-9]+))"),
 				),
+			},
+			{
+				ResourceName:      fqrn,
+				ImportState:       true,
+				ImportStateVerify: true,
+			},
+		},
+	})
+}
+
+func TestAccLayout_importNotFound(t *testing.T) {
+	config := `
+		resource "artifactory_repository_layout" "not-exist-test" {
+			name                                = "not-exist-test"
+			artifact_path_pattern               = "[orgPath]/[module]/[baseRev](-[folderItegRev])/[module]-[baseRev](-[fileItegRev])(-[classifier]).[ext]"
+			distinctive_descriptor_path_pattern = true
+			descriptor_path_pattern             = "[orgPath]/[module]/[baseRev](-[folderItegRev])/[module]-[baseRev](-[fileItegRev])(-[classifier]).pom"
+			folder_integration_revision_regexp  = "Foo"
+			file_integration_revision_regexp    = "Foo|(?:(?:[0-9]{8}.[0-9]{6})-(?:[0-9]+))"
+		}
+	`
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:        config,
+				ResourceName:  "artifactory_repository_layout.not-exist-test",
+				ImportStateId: "not-exist-test",
+				ImportState:   true,
+				ExpectError:   regexp.MustCompile("No layout found for 'not-exist-test'"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_debian_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_debian_repository.go
@@ -33,7 +33,7 @@ var DebianLocalSchema = util.MergeMaps(
 
 type DebianLocalRepositoryParams struct {
 	RepositoryBaseParams
-	TrivialLayout           bool     `hcl:"trivial_layout" json:"debianTrivialLayout,omitempty"`
+	TrivialLayout           bool     `hcl:"trivial_layout" json:"debianTrivialLayout"`
 	IndexCompressionFormats []string `hcl:"index_compression_formats" json:"optionalIndexCompressionFormats,omitempty"`
 	PrimaryKeyPairRef       string   `hcl:"primary_keypair_ref" json:"primaryKeyPairRef,omitempty"`
 	SecondaryKeyPairRef     string   `hcl:"secondary_keypair_ref" json:"secondaryKeyPairRef,omitempty"`

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_debian_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_debian_repository.go
@@ -23,6 +23,7 @@ var DebianLocalSchema = util.MergeMaps(
 		"trivial_layout": {
 			Type:        schema.TypeBool,
 			Optional:    true,
+			Default:     false,
 			Description: "When set, the repository will use the deprecated trivial layout.",
 			Deprecated:  "You shouldn't be using this",
 		},

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
@@ -434,7 +434,7 @@ func TestAccRemoteVcsRepository(t *testing.T) {
 		"url":                  "https://github.com/",
 		"vcs_git_provider":     "CUSTOM",
 		"vcs_git_download_url": "https://www.customrepo.com",
-		"max_unique_snapshots": 5,
+		// "max_unique_snapshots": 5, // commented out due to API bug in 7.49.3
 	}))
 }
 

--- a/sample.tf
+++ b/sample.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     artifactory = {
       source  = "registry.terraform.io/jfrog/artifactory"
-      version = "6.19.2"
+      version = "6.22.3"
     }
   }
 }


### PR DESCRIPTION
Fixes #610 

## Details

The importer has not been setup to copy the resource's ID to the data struct's identifying attribute. For example, for repository the attribute 'key' is used in read function to fetch repo's data. For others, it may be the 'name' field, depending on the resource/API.

We can't just change the read function to use `d.Id()` because during import, there's no Terraform state yet so `d.Id()` returns nothing.

For example:

```hcl
resource "artifactory_proxy" "some-proxy-id" {
  key               = "proxy-1"
  host              = "https://fake-proxy.org"
  port              = 8080
  username          = "fake-user"
  password          = "fake-password"
  nt_host           = "fake-nt-host"
  nt_domain         = "fake-nt-domain"
  platform_default  = false
  redirect_to_hosts = ["foo"]
  services          = ["jfrt"]
}
```

In this case, the resource ID is `some-proxy-id` and the actual proxy key is `proxy-1`. Therefore, the importer function needs to copy the resource ID into the identifying attribute so the read function can use that attribute with the API.

E.g. for importing:

```sh
$ terraform import artifactory_proxy.some-proxy-id proxy-1
```

## Changes

- Fix packing function for `artifactory_repository_layout` 

For `artifactory_backup`, `artifactory_ldap_setting`, `artifactory_ldap_group_setting`, `artifactory_repository_layout`, `artifactory_proxy`, `artifactory_property_set`:
- Fix importer func to ensure data source ID is copied to the correct attribute (for use by read func later)
- Use struct identifying field (e.g. `key`, `name`, etc.) in read func.
- Ensure we return error to Terraform if we can't find matching resource in read func.
- Add import and update tests