### PR TITLE
GH-591 cron 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ IMPROVEMENTS:
 
 * resource/artifactory_*_replication: Cron expression validation replaced with verification of groups number (6 to 7). Cron verification will happen on the Artifactory API side to match UI behavior. Added more tests, documentation updated for both resources. 
   Issue: [#591](https://github.com/jfrog/terraform-provider-artifactory/issues/591) 
-  PR: []()
+  PR: [#618](https://github.com/jfrog/terraform-provider-artifactory/pull/618)
 
 ## 6.24.0 (January 5, 2023). Tested on Artifactory 7.49.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.24.1 (January 9, 2023).
+## 6.24.1 (January 9, 2023). Tested on Artifactory 7.49.3
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 6.24.1 (January 9, 2023).
+
+IMPROVEMENTS:
+
+* resource/artifactory_*_replication: Cron expression validation replaced with verification of groups number (6 to 7). Cron verification will happen on the Artifactory API side to match UI behavior. Added more tests, documentation updated for both resources. 
+  Issue: [#591](https://github.com/jfrog/terraform-provider-artifactory/issues/591) 
+  PR: []()
+
 ## 6.24.0 (January 5, 2023). Tested on Artifactory 7.49.3
 
 IMPROVEMENTS:

--- a/docs/resources/backup.md
+++ b/docs/resources/backup.md
@@ -36,7 +36,7 @@ The following arguments are supported:
 
 * `key`                          - (Required) The unique ID of the artifactory backup config.
 * `enabled`                      - (Optional) Flag to enable or disable the backup config. Default value is `true`.
-* `cron_exp`                     - (Required) A valid CRON expression that you can use to control backup frequency. Eg: "0 0 12 * * ? *", "0 0 2 ? * MON-SAT *". Note: please use 7 character format - Seconds,	Minutes	Hours, Day Of Month, Month, Day Of Week, Year.
+* `cron_exp`                     - (Required) A valid CRON expression that you can use to control backup frequency. Eg: "0 0 12 * * ? *", "0 0 2 ? * MON-SAT *". Note: please use 7 character format - Seconds, Minutes Hours, Day Of Month, Month, Day Of Week, Year. Also, specifying both a day-of-week AND a day-of-month parameter is not supported. One of them should be replaced by `?`. Incorrect: `* 5,7,9 14/2 * * WED,SAT *`, correct: `* 5,7,9 14/2 ? * WED,SAT *`. See details in [Cron Trigger Tutorial](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html) and in [Cronexp package readme](https://github.com/gorhill/cronexpr#other-details).
 * `retention_period_hours`       - (Optional) The number of hours to keep a backup before Artifactory will clean it up to free up disk space. Applicable only to non-incremental backups. Default value is 168 hours ie: 7 days.
 * `excluded_repositories`        - (Optional) A list of excluded repositories from the backup. Default is empty list.
 * `create_archive`               - (Optional) If set, backups will be created within a Zip archive (Slow and CPU intensive). Default value is `false`.

--- a/docs/resources/pull_replication.md
+++ b/docs/resources/pull_replication.md
@@ -34,8 +34,8 @@ resource "artifactory_pull_replication" "remote-rep" {
 
 The following arguments are supported:
 
-* `repo_key` - (Required)
-* `cron_exp` - (Required)
+* `repo_key` - (Required) Repository name.
+* `cron_exp` - (Required) A valid CRON expression that you can use to control replication frequency. Eg: "0 0 12 * * ? *", "0 0 2 ? * MON-SAT *". Note: use 6 or 7 parts format - Seconds, Minutes Hours, Day Of Month, Month, Day Of Week, Year (optional). Specifying both a day-of-week AND a day-of-month parameter is not supported. One of them should be replaced by `?`. Incorrect: `* 5,7,9 14/2 * * WED,SAT *`, correct: `* 5,7,9 14/2 ? * WED,SAT *`. See details in [Cron Trigger Tutorial](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 * `enable_event_replication` - (Optional) When set, each event will trigger replication of the artifacts changed in this event. This can be any type of event on artifact, e.g. added, deleted or property change.
 * `url` - (Optional) The URL of the target local repository on a remote Artifactory server. For some package types, you need to prefix the repository key in the URL with api/<pkg>. 
    For a list of package types where this is required, see the [note](https://www.jfrog.com/confluence/display/JFROG/Repository+Replication#RepositoryReplication-anchorPREFIX). 

--- a/docs/resources/push_replication.md
+++ b/docs/resources/push_replication.md
@@ -54,8 +54,8 @@ resource "artifactory_push_replication" "foo-rep" {
 
 The following arguments are supported:
 
-* `repo_key` - (Required)
-* `cron_exp` - (Required)
+* `repo_key` - (Required) Repository name.
+* `cron_exp` - (Required) A valid CRON expression that you can use to control replication frequency. Eg: "0 0 12 * * ? *", "0 0 2 ? * MON-SAT *". Note: use 6 or 7 parts format - Seconds, Minutes Hours, Day Of Month, Month, Day Of Week, Year (optional). Specifying both a day-of-week AND a day-of-month parameter is not supported. One of them should be replaced by `?`. Incorrect: `* 5,7,9 14/2 * * WED,SAT *`, correct: `* 5,7,9 14/2 ? * WED,SAT *`. See details in [Cron Trigger Tutorial](http://www.quartz-scheduler.org/documentation/quartz-2.3.0/tutorials/crontrigger.html).
 * `enable_event_replication` - (Optional) When set, each event will trigger replication of the artifacts changed in this event. This can be any type of event on artifact, e.g. added, deleted or property change.
 * `replications` - (Optional)
     * `url` - (Required) The URL of the target local repository on a remote Artifactory server. Required for local repository, but not needed for remote repository.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-log v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
-	github.com/jfrog/terraform-provider-shared v1.8.0
+	github.com/jfrog/terraform-provider-shared v1.9.0
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4

--- a/go.sum
+++ b/go.sum
@@ -145,8 +145,6 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v1.8.0 h1:kaAN8/F1NgZa+V/LbDYUHk3hzCxa5yISBqak7NHvCmI=
-github.com/jfrog/terraform-provider-shared v1.8.0/go.mod h1:oIzDjD2mOlfXymkzwp5kbFG3Bqy3ymVGYX50CrCxiIE=
 github.com/jfrog/terraform-provider-shared v1.9.0 h1:HxRt9L2FEdCzkhFUkVyMFanORDFNq43gnM2N+zViius=
 github.com/jfrog/terraform-provider-shared v1.9.0/go.mod h1:oIzDjD2mOlfXymkzwp5kbFG3Bqy3ymVGYX50CrCxiIE=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=

--- a/go.sum
+++ b/go.sum
@@ -147,6 +147,8 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jfrog/terraform-provider-shared v1.8.0 h1:kaAN8/F1NgZa+V/LbDYUHk3hzCxa5yISBqak7NHvCmI=
 github.com/jfrog/terraform-provider-shared v1.8.0/go.mod h1:oIzDjD2mOlfXymkzwp5kbFG3Bqy3ymVGYX50CrCxiIE=
+github.com/jfrog/terraform-provider-shared v1.9.0 h1:HxRt9L2FEdCzkhFUkVyMFanORDFNq43gnM2N+zViius=
+github.com/jfrog/terraform-provider-shared v1.9.0/go.mod h1:oIzDjD2mOlfXymkzwp5kbFG3Bqy3ymVGYX50CrCxiIE=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/pkg/artifactory/resource/configuration/resource_artifactory_backup_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_backup_test.go
@@ -130,6 +130,7 @@ func TestAccCronExpressions(t *testing.T) {
 		"* 5-9 14/2 * * 1-3 *",
 		"*/3 */51 */12 */2 */4 ? *",
 		"* 5 22-23 * * Sun *",
+		"0/5 14,18,3-39,52 * ? JAN,MAR,SEP MON-FRI 2002-2010",
 	}
 	for _, cron := range cronExpressions {
 		title := fmt.Sprintf("TestBackupCronExpression_%s", cases.Title(language.AmericanEnglish).String(cron))

--- a/pkg/artifactory/resource/replication/resource_artifactory_pull_replication_test.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_pull_replication_test.go
@@ -42,17 +42,16 @@ func mkTclForPullRepConfg(name, cron, url string) string {
 
 func TestAccPullReplicationInvalidCron(t *testing.T) {
 
-	_, fqrn, name := test.MkNames("lib-local", "artifactory_pull_replication")
+	_, _, name := test.MkNames("lib-local", "artifactory_pull_replication")
 	var failCron = mkTclForPullRepConfg(name, "0 0 * * * !!", acctest.GetArtifactoryUrl(t))
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckReplicationDestroy(fqrn),
 		Steps: []resource.TestStep{
 			{
 				Config:      failCron,
-				ExpectError: regexp.MustCompile(`.*syntax error in year field: '!!'.*`),
+				ExpectError: regexp.MustCompile(`.*Invalid cronExp.*`),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/replication/resource_artifactory_pull_replication_test.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_pull_replication_test.go
@@ -76,12 +76,12 @@ func TestAccCronExpressions(t *testing.T) {
 	for _, cron := range cronExpressions {
 		title := fmt.Sprintf("TestPullReplicationLocalRepoCron_%s", cases.Title(language.AmericanEnglish).String(cron))
 		t.Run(title, func(t *testing.T) {
-			resource.Test(PullReplicationLocalRepoTestCase(cron, t))
+			resource.Test(pullReplicationLocalRepoTestCase(cron, t))
 		})
 	}
 }
 
-func PullReplicationLocalRepoTestCase(cronExpression string, t *testing.T) (*testing.T, resource.TestCase) {
+func pullReplicationLocalRepoTestCase(cronExpression string, t *testing.T) (*testing.T, resource.TestCase) {
 	_, fqrn, name := test.MkNames("lib-local", "artifactory_pull_replication")
 	config := mkTclForPullRepConfg(name, cronExpression, acctest.GetArtifactoryUrl(t))
 

--- a/pkg/artifactory/resource/replication/resource_artifactory_pull_replication_test.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_pull_replication_test.go
@@ -2,13 +2,15 @@ package replication_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
 	"github.com/jfrog/terraform-provider-shared/test"
 	"github.com/jfrog/terraform-provider-shared/util"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
 )
 
 func mkTclForPullRepConfg(name, cron, url string) string {
@@ -54,6 +56,55 @@ func TestAccPullReplicationInvalidCron(t *testing.T) {
 			},
 		},
 	})
+}
+
+func TestAccCronExpressions(t *testing.T) {
+	cronExpressions := [...]string{
+		"10/20 15 14 5-10 * ? *",
+		"* 5,7,9 14-16 * * ? *",
+		"* 5,7,9 14/2 ? * WED,Sat *",
+		"* * * * * ? *",
+		"* * 14/2 ? * mon/3 *",
+		"* 5-9 14/2 ? * 1-3 *",
+		"*/3 */51 */12 */2 */4 ? *",
+		"* 5 22-23 ? * Sun *",
+		"0/5 14,18,3-39,52 * ? JAN,MAR,SEP MON-FRI 2002-2010",
+		"0 15 10 * * ? *",
+		"0 15 10 ? * 6#2",
+		"0 15 10 15 * ?",
+		"0 0 2 ? * MON-SAT",
+	}
+	for _, cron := range cronExpressions {
+		title := fmt.Sprintf("TestPullReplicationLocalRepoCron_%s", cases.Title(language.AmericanEnglish).String(cron))
+		t.Run(title, func(t *testing.T) {
+			resource.Test(PullReplicationLocalRepoTestCase(cron, t))
+		})
+	}
+}
+
+func PullReplicationLocalRepoTestCase(cronExpression string, t *testing.T) (*testing.T, resource.TestCase) {
+	_, fqrn, name := test.MkNames("lib-local", "artifactory_pull_replication")
+	config := mkTclForPullRepConfg(name, cronExpression, acctest.GetArtifactoryUrl(t))
+
+	return t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      testAccCheckReplicationDestroy(fqrn),
+
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "repo_key", name),
+					resource.TestCheckResourceAttr(fqrn, "cron_exp", cronExpression),
+					resource.TestCheckResourceAttr(fqrn, "enable_event_replication", "true"),
+					resource.TestCheckResourceAttr(fqrn, "username", acctest.RtDefaultUser),
+					resource.TestCheckResourceAttr(fqrn, "password", "Passw0rd!"),
+					resource.TestCheckResourceAttr(fqrn, "check_binary_existence_in_filestore", "true"),
+				),
+			},
+		},
+	}
 }
 
 func TestAccPullReplicationLocalRepo(t *testing.T) {

--- a/pkg/artifactory/resource/replication/resource_artifactory_push_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_push_replication.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/util"
-	"github.com/jfrog/terraform-provider-shared/validator"
 	"golang.org/x/exp/slices"
 )
 
@@ -53,23 +52,6 @@ type UpdatePushReplication struct {
 	CronExp                string                  `json:"cronExp,omitempty"`
 	EnableEventReplication bool                    `json:"enableEventReplication,omitempty"`
 	Replications           []updateReplicationBody `json:"replications,omitempty"`
-}
-
-var pushReplicationSchemaCommon = map[string]*schema.Schema{
-	"repo_key": {
-		Type:     schema.TypeString,
-		Required: true,
-	},
-	"cron_exp": {
-		Type:             schema.TypeString,
-		Required:         true,
-		ValidateDiagFunc: validator.Cron,
-	},
-	"enable_event_replication": {
-		Type:     schema.TypeBool,
-		Optional: true,
-		Computed: true,
-	},
 }
 
 var pushRepMultipleSchema = map[string]*schema.Schema{
@@ -156,7 +138,7 @@ func ResourceArtifactoryPushReplication() *schema.Resource {
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
-		Schema: util.MergeMaps(pushReplicationSchemaCommon, pushRepMultipleSchema),
+		Schema: util.MergeMaps(replicationSchemaCommon, pushRepMultipleSchema),
 	}
 }
 

--- a/pkg/artifactory/resource/replication/resource_artifactory_push_replication_test.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_push_replication_test.go
@@ -1,15 +1,15 @@
 package replication_test
 
 import (
-	"github.com/jfrog/terraform-provider-shared/test"
-	"github.com/jfrog/terraform-provider-shared/util"
-
 	"fmt"
+	"regexp"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
-	"regexp"
-	"testing"
+	"github.com/jfrog/terraform-provider-shared/test"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 func TestAccPushReplicationInvalidPushCronFails(t *testing.T) {
@@ -36,7 +36,7 @@ func TestAccPushReplicationInvalidPushCronFails(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      invalidCron,
-				ExpectError: regexp.MustCompile(`.*syntax error in day-of-month field.*`),
+				ExpectError: regexp.MustCompile(`.*Invalid cronExp.*`),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/replication/resource_artifactory_replication_config.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_replication_config.go
@@ -237,7 +237,9 @@ func packReplicationConfig(replicationConfig *GetReplicationConfig, d *schema.Re
 func resourceReplicationConfigCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	replicationConfig := unpackReplicationConfig(d)
 
-	_, err := m.(*resty.Client).R().SetBody(replicationConfig).Put(EndpointPath + "multiple/" + replicationConfig.RepoKey)
+	_, err := m.(*resty.Client).R().
+		SetBody(replicationConfig).
+		Put(EndpointPath + "multiple/" + replicationConfig.RepoKey)
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/artifactory/resource/replication/resource_artifactory_replication_config.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_replication_config.go
@@ -35,7 +35,8 @@ var replicationSchemaCommon = map[string]*schema.Schema{
 	"cron_exp": {
 		Type:             schema.TypeString,
 		Required:         true,
-		ValidateDiagFunc: validator.Cron,
+		ValidateDiagFunc: validator.CronLength,
+		Description:      "Cron expression to control the operation frequency.",
 	},
 	"enable_event_replication": {
 		Type:     schema.TypeBool,

--- a/pkg/artifactory/resource/replication/resource_artifactory_replication_config_test.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_replication_config_test.go
@@ -1,15 +1,15 @@
 package replication_test
 
 import (
-	"github.com/jfrog/terraform-provider-shared/test"
-	"github.com/jfrog/terraform-provider-shared/util"
-
 	"fmt"
+	"regexp"
+	"testing"
+
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
-	"regexp"
-	"testing"
+	"github.com/jfrog/terraform-provider-shared/test"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 func TestInvalidCronFails(t *testing.T) {
@@ -26,7 +26,6 @@ func TestInvalidCronFails(t *testing.T) {
 			replications {
 				url = "http://localhost:8080"
 				username = "%s"
-				password = "%s"
 			}
 		}
 	`
@@ -36,7 +35,7 @@ func TestInvalidCronFails(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      invalidCron,
-				ExpectError: regexp.MustCompile(`.*syntax error in day-of-month field.*`),
+				ExpectError: regexp.MustCompile(`.*Invalid cronExp.*`),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/replication/resource_artifactory_single_replication_config_test.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_single_replication_config_test.go
@@ -2,13 +2,13 @@ package replication_test
 
 import (
 	"fmt"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
-	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
 	"log"
 	"regexp"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
 	"github.com/jfrog/terraform-provider-shared/test"
 	"github.com/jfrog/terraform-provider-shared/util"
 )
@@ -39,19 +39,19 @@ func mkTclForRepConfg(name, cron, url, proxy string) string {
 		proxy,
 	)
 }
+
 func TestInvalidCronSingleReplication(t *testing.T) {
 
-	_, fqrn, name := test.MkNames("lib-local", "artifactory_single_replication_config")
+	_, _, name := test.MkNames("lib-local", "artifactory_single_replication_config")
 	var failCron = mkTclForRepConfg(name, "0 0 * * * !!", acctest.GetArtifactoryUrl(t), "")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckReplicationDestroy(fqrn),
 		Steps: []resource.TestStep{
 			{
 				Config:      failCron,
-				ExpectError: regexp.MustCompile(`.*syntax error in year field: '!!'.*`),
+				ExpectError: regexp.MustCompile(`.*Invalid cronExp.*`),
 			},
 		},
 	})


### PR DESCRIPTION
- remove usage of the cron validation package from the pull and push replications resource. Only verify if the expression is 6 or 7 parts long.
- update documentation.
- add more tests.
- remove code duplicates.