### PR TITLE
PTRENG-4823 virtual repo attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 BUG FIX:
 
 * resource/artifactory_virtual_*_repository: `omitempty` is removed from `artifactory_requests_can_retrieve_remote_artifacts` attribute, allowing users to update the value with `false` value, if it was set to `true` before.
- PR [#]()
+ PR [#628](https://github.com/jfrog/terraform-provider-artifactory/pull/628)
 
 ## 6.24.1 (January 9, 2023). Tested on Artifactory 7.49.3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.24.2 (January 13, 2023).
+## 6.24.2 (January 13, 2023). Tested on Artifactory 7.49.5
 
 BUG FIX:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 6.24.2 (January 13, 2023).
+
+BUG FIX:
+
+* resource/artifactory_virtual_*_repository: `omitempty` is removed from `artifactory_requests_can_retrieve_remote_artifacts` attribute, allowing users to update the value with `false` value, if it was set to `true` before.
+ PR [#]()
+
 ## 6.24.1 (January 9, 2023). Tested on Artifactory 7.49.3
 
 IMPROVEMENTS:

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
@@ -446,6 +446,7 @@ func TestAccVirtualRepository_update(t *testing.T) {
 			key          = "%s"
 			description  = "Before"
 			repositories = []
+			artifactory_requests_can_retrieve_remote_artifacts = true
 		}
 	`
 	const virtualRepositoryUpdateAfter = `
@@ -453,6 +454,7 @@ func TestAccVirtualRepository_update(t *testing.T) {
 			key          = "%s"
 			description  = "After"
 			repositories = []
+			artifactory_requests_can_retrieve_remote_artifacts = false
 		}
 	`
 
@@ -469,6 +471,7 @@ func TestAccVirtualRepository_update(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "description", "Before"),
 					resource.TestCheckResourceAttr(fqrn, "package_type", "maven"),
 					resource.TestCheckResourceAttr(fqrn, "repositories.#", "0"),
+					resource.TestCheckResourceAttr(fqrn, "artifactory_requests_can_retrieve_remote_artifacts", "true"),
 				),
 			},
 			{
@@ -478,6 +481,7 @@ func TestAccVirtualRepository_update(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "description", "After"),
 					resource.TestCheckResourceAttr(fqrn, "package_type", "maven"),
 					resource.TestCheckResourceAttr(fqrn, "repositories.#", "0"),
+					resource.TestCheckResourceAttr(fqrn, "artifactory_requests_can_retrieve_remote_artifacts", "false"),
 				),
 			},
 		},

--- a/pkg/artifactory/resource/repository/virtual/virtual.go
+++ b/pkg/artifactory/resource/repository/virtual/virtual.go
@@ -20,7 +20,7 @@ type RepositoryBaseParams struct {
 	ExcludesPattern                               string   `json:"excludesPattern"`
 	RepoLayoutRef                                 string   `hcl:"repo_layout_ref" json:"repoLayoutRef,omitempty"`
 	Repositories                                  []string `hcl:"repositories" json:"repositories,omitempty"`
-	ArtifactoryRequestsCanRetrieveRemoteArtifacts bool     `hcl:"artifactory_requests_can_retrieve_remote_artifacts" json:"artifactoryRequestsCanRetrieveRemoteArtifacts,omitempty"`
+	ArtifactoryRequestsCanRetrieveRemoteArtifacts bool     `hcl:"artifactory_requests_can_retrieve_remote_artifacts" json:"artifactoryRequestsCanRetrieveRemoteArtifacts"`
 	DefaultDeploymentRepo                         string   `hcl:"default_deployment_repo" json:"defaultDeploymentRepo,omitempty"`
 }
 


### PR DESCRIPTION
Remove `omitempty` from `artifactory_requests_can_retrieve_remote_artifacts`, so users will be able to update the boolean to `false`, if it was initially set to `true`. 