### PR TITLE
GH-635, add a note for `propagate_query_params`, remote repos.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 6.25.2. (January 31, 2023).
+
+IMPROVEMENTS:
+
+* resource/artifactory_remote_*_repository: documentation, add a note for `propagate_query_params`. This attribute should be used only with Generic repo type.
+  PR: [#]()
+  Issue: [#635](https://github.com/jfrog/terraform-provider-artifactory/issues/635)
+
 ## 6.25.1 (January 27, 2023). Tested on Artifactory 7.49.6
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 IMPROVEMENTS:
 
 * resource/artifactory_remote_*_repository: documentation, add a note for `propagate_query_params`. This attribute should be used only with Generic repo type.
-  PR: [#]()
+  PR: [#638](https://github.com/jfrog/terraform-provider-artifactory/pull/638)
   Issue: [#635](https://github.com/jfrog/terraform-provider-artifactory/issues/635)
 
 ## 6.25.1 (January 27, 2023). Tested on Artifactory 7.49.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-## 6.25.2. (January 31, 2023). Tested on Artifactory 7.49.6
+## 6.26.0. (January 31, 2023). Tested on Artifactory 7.49.6
 
 IMPROVEMENTS:
 
-* resource/artifactory_remote_*_repository: documentation, add a note for `propagate_query_params`. This attribute should be used only with Generic repo type.
+* resource/artifactory_remote_*_repository: `propagate_query_params` attribute is removed from the common remote repository configuration. This attribute only works with Generic repo type. This change is implemented in schema V2 and migrator was added. During the migration from V1 to V2 that attribute will be removed.
   PR: [#638](https://github.com/jfrog/terraform-provider-artifactory/pull/638)
   Issue: [#635](https://github.com/jfrog/terraform-provider-artifactory/issues/635)
 

--- a/docs/resources/remote.md
+++ b/docs/resources/remote.md
@@ -79,10 +79,6 @@ All generic repo arguments are supported, in addition to:
   * `statistics_enabled` - (Optional, Default: false) If set, Artifactory will notify the remote instance whenever an artifact in the Smart Remote Repository is downloaded locally so that it can update its download counter. Note that if this option is not set, there may be a discrepancy between the number of artifacts reported to have been downloaded in the different Artifactory instances of the proxy chain.
   * `properties_enabled` - (Optional, Default: false) If set, properties for artifacts that have been cached in this repository will be updated if they are modified in the artifact hosted at the remote Artifactory instance. The trigger to synchronize the properties is download of the artifact from the remote repository cache of the local Artifactory instance.
   * `source_origin_absence_detection` - (Optional, Default: false) If set, Artifactory displays an indication on cached items if they have been deleted from the corresponding repository in the remote Artifactory instance.
-
-~>`propagate_query_params` is only available for Generic type repositories.
-
-* `propagate_query_params` - (Optional, Default: false) When set, if query params are included in the request to Artifactory, they will be passed on to the remote repository.
 * `query_params` - (Optional) Custom HTTP query parameters that will be automatically included in all remote resource requests. For example: "param1=val1&param2=val2&param3=val3"
 * `list_remote_folder_items` - (Optional, Default: false) Lists the items of remote folders in simple and list browsing. The remote content is cached according to the value of the 'Retrieval Cache Period'. This field exists in the API but not in the UI.
 * `download_direct` - (Optional, Default: false) When set, download requests to this repository will redirect the client to download 

--- a/docs/resources/remote.md
+++ b/docs/resources/remote.md
@@ -79,6 +79,9 @@ All generic repo arguments are supported, in addition to:
   * `statistics_enabled` - (Optional, Default: false) If set, Artifactory will notify the remote instance whenever an artifact in the Smart Remote Repository is downloaded locally so that it can update its download counter. Note that if this option is not set, there may be a discrepancy between the number of artifacts reported to have been downloaded in the different Artifactory instances of the proxy chain.
   * `properties_enabled` - (Optional, Default: false) If set, properties for artifacts that have been cached in this repository will be updated if they are modified in the artifact hosted at the remote Artifactory instance. The trigger to synchronize the properties is download of the artifact from the remote repository cache of the local Artifactory instance.
   * `source_origin_absence_detection` - (Optional, Default: false) If set, Artifactory displays an indication on cached items if they have been deleted from the corresponding repository in the remote Artifactory instance.
+
+~>`propagate_query_params` is only available for Generic type repositories.
+
 * `propagate_query_params` - (Optional, Default: false) When set, if query params are included in the request to Artifactory, they will be passed on to the remote repository.
 * `query_params` - (Optional) Custom HTTP query parameters that will be automatically included in all remote resource requests. For example: "param1=val1&param2=val2&param3=val3"
 * `list_remote_folder_items` - (Optional, Default: false) Lists the items of remote folders in simple and list browsing. The remote content is cached according to the value of the 'Retrieval Cache Period'. This field exists in the API but not in the UI.

--- a/docs/resources/remote_generic_repository.md
+++ b/docs/resources/remote_generic_repository.md
@@ -22,9 +22,11 @@ The following arguments are supported, along with the [common list of arguments 
 All generic repo arguments are supported, in addition to:
 * `key` - (Required) A mandatory identifier for the repository that must be unique. It cannot begin with a number or
   contain spaces or special characters.
-* `description` - (Optional)
-* `notes` - (Optional)
+* `description` - (Optional) Public description.
+* `notes` - (Optional) Internal description.
 * `url` - (Required) The remote repo URL.
+* `propagate_query_params` - (Optional, Default: false) When set, if query params are included in the request to Artifactory, they will be passed on to the remote repository.
+
 
 ## Import
 

--- a/pkg/artifactory/provider/provider.go
+++ b/pkg/artifactory/provider/provider.go
@@ -60,6 +60,7 @@ func Provider() *schema.Provider {
 		"artifactory_remote_composer_repository":              remote.ResourceArtifactoryRemoteComposerRepository(),
 		"artifactory_remote_conan_repository":                 remote.ResourceArtifactoryRemoteConanRepository(),
 		"artifactory_remote_docker_repository":                remote.ResourceArtifactoryRemoteDockerRepository(),
+		"artifactory_remote_generic_repository":               remote.ResourceArtifactoryRemoteGenericRepository(),
 		"artifactory_remote_go_repository":                    remote.ResourceArtifactoryRemoteGoRepository(),
 		"artifactory_remote_helm_repository":                  remote.ResourceArtifactoryRemoteHelmRepository(),
 		"artifactory_remote_maven_repository":                 remote.ResourceArtifactoryRemoteMavenRepository(),
@@ -108,9 +109,9 @@ func Provider() *schema.Provider {
 		resourceMap[localResourceName] = local.ResourceArtifactoryLocalGenericRepository(repoType)
 	}
 
-	for _, repoType := range remote.RepoTypesLikeGeneric {
+	for _, repoType := range remote.RepoTypesLikeBasic {
 		remoteResourceName := fmt.Sprintf("artifactory_remote_%s_repository", repoType)
-		resourceMap[remoteResourceName] = remote.ResourceArtifactoryRemoteGenericRepository(repoType)
+		resourceMap[remoteResourceName] = remote.ResourceArtifactoryRemoteBasicRepository(repoType)
 	}
 
 	for _, repoType := range repository.GradleLikeRepoTypes {

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -431,7 +431,7 @@ var VcsRemoteRepoSchema = map[string]*schema.Schema{
 
 func getJavaRemoteSchema(repoType string, suppressPom bool) map[string]*schema.Schema {
 	return util.MergeMaps(
-		baseRemoteRepoSchema,
+		baseRemoteRepoSchemaV2,
 		map[string]*schema.Schema{
 			"fetch_jars_eagerly": {
 				Type:        schema.TypeBool,
@@ -602,6 +602,7 @@ func mkResourceSchema(skeema map[string]*schema.Schema, packer packer.PackFunc, 
 		CustomizeDiff: repository.ProjectEnvironmentsDiff,
 	}
 }
+
 func ResourceStateUpgradeV1(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
 	if rawState["package_type"] != "generic" {
 		delete(rawState, "propagate_query_params")

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -375,7 +375,7 @@ var BaseRemoteRepoSchema = map[string]*schema.Schema{
 		Type:        schema.TypeBool,
 		Optional:    true,
 		Default:     false,
-		Description: "When set, if query params are included in the request to Artifactory, they will be passed on to the remote repository.",
+		Description: "Note: `propagate_query_params` is only available for Generic type repositories. When set, if query params are included in the request to Artifactory, they will be passed on to the remote repository.",
 	},
 	"query_params": {
 		Type:     schema.TypeString,

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -30,7 +30,6 @@ type RepositoryRemoteBaseParams struct {
 	Offline                           *bool                              `json:"offline,omitempty"`
 	BlackedOut                        *bool                              `json:"blackedOut,omitempty"`
 	XrayIndex                         bool                               `json:"xrayIndex"`
-	PropagateQueryParams              bool                               `json:"propagateQueryParams"`
 	QueryParams                       string                             `json:"queryParams,omitempty"`
 	PriorityResolution                bool                               `json:"priorityResolution"`
 	StoreArtifactsLocally             *bool                              `json:"storeArtifactsLocally,omitempty"`
@@ -74,14 +73,13 @@ func (bp RepositoryRemoteBaseParams) Id() string {
 	return bp.Key
 }
 
-var RepoTypesLikeGeneric = []string{
+var RepoTypesLikeBasic = []string{
 	"alpine",
 	"chef",
 	"conda",
 	"cran",
 	"debian",
 	"gems",
-	"generic",
 	"gitlfs",
 	"npm",
 	"opkg",
@@ -371,12 +369,6 @@ var BaseRemoteRepoSchema = map[string]*schema.Schema{
 			},
 		},
 	},
-	"propagate_query_params": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Default:     false,
-		Description: "Note: `propagate_query_params` is only available for Generic type repositories. When set, if query params are included in the request to Artifactory, they will be passed on to the remote repository.",
-	},
 	"query_params": {
 		Type:     schema.TypeString,
 		Optional: true,
@@ -504,7 +496,6 @@ func UnpackBaseRemoteRepo(s *schema.ResourceData, packageType string) Repository
 		BlackedOut:                        d.GetBoolRef("blacked_out", false),
 		XrayIndex:                         d.GetBool("xray_index", false),
 		DownloadRedirect:                  d.GetBool("download_direct", false),
-		PropagateQueryParams:              d.GetBool("propagate_query_params", false),
 		QueryParams:                       d.GetString("query_params", false),
 		StoreArtifactsLocally:             d.GetBoolRef("store_artifacts_locally", false),
 		SocketTimeoutMillis:               d.GetInt("socket_timeout_millis", false),

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_bower_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_bower_repository.go
@@ -17,7 +17,7 @@ type BowerRemoteRepo struct {
 func ResourceArtifactoryRemoteBowerRepository() *schema.Resource {
 	const packageType = "bower"
 
-	var bowerRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, VcsRemoteRepoSchema, map[string]*schema.Schema{
+	var bowerRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, VcsRemoteRepoSchema, map[string]*schema.Schema{
 		"bower_registry_url": {
 			Type:         schema.TypeString,
 			Optional:     true,
@@ -52,5 +52,5 @@ func ResourceArtifactoryRemoteBowerRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(bowerRemoteSchema, packer.Default(bowerRemoteSchema), unpackBowerRemoteRepo, constructor)
+	return mkResourceSchema(bowerRemoteSchema, packer.Default(bowerRemoteSchema), unpackBowerRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_cargo_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_cargo_repository.go
@@ -17,7 +17,7 @@ type CargoRemoteRepo struct {
 func ResourceArtifactoryRemoteCargoRepository() *schema.Resource {
 	const packageType = "cargo"
 
-	var cargoRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, map[string]*schema.Schema{
+	var cargoRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, map[string]*schema.Schema{
 		"git_registry_url": {
 			Type:         schema.TypeString,
 			Required:     true,
@@ -51,5 +51,5 @@ func ResourceArtifactoryRemoteCargoRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(cargoRemoteSchema, packer.Default(cargoRemoteSchema), unpackCargoRemoteRepo, constructor)
+	return mkResourceSchema(cargoRemoteSchema, packer.Default(cargoRemoteSchema), unpackCargoRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_cocoapods_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_cocoapods_repository.go
@@ -17,7 +17,7 @@ type CocoapodsRemoteRepo struct {
 func ResourceArtifactoryRemoteCocoapodsRepository() *schema.Resource {
 	const packageType = "cocoapods"
 
-	var cocoapodsRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, VcsRemoteRepoSchema, map[string]*schema.Schema{
+	var cocoapodsRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, VcsRemoteRepoSchema, map[string]*schema.Schema{
 		"pods_specs_repo_url": {
 			Type:         schema.TypeString,
 			Optional:     true,
@@ -52,5 +52,5 @@ func ResourceArtifactoryRemoteCocoapodsRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(cocoapodsRemoteSchema, packer.Default(cocoapodsRemoteSchema), unpackCocoapodsRemoteRepo, constructor)
+	return mkResourceSchema(cocoapodsRemoteSchema, packer.Default(cocoapodsRemoteSchema), unpackCocoapodsRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_composer_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_composer_repository.go
@@ -17,7 +17,7 @@ type ComposerRemoteRepo struct {
 func ResourceArtifactoryRemoteComposerRepository() *schema.Resource {
 	const packageType = "composer"
 
-	var composerRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, VcsRemoteRepoSchema, map[string]*schema.Schema{
+	var composerRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, VcsRemoteRepoSchema, map[string]*schema.Schema{
 		"composer_registry_url": {
 			Type:         schema.TypeString,
 			Optional:     true,
@@ -52,5 +52,5 @@ func ResourceArtifactoryRemoteComposerRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(composerRemoteSchema, packer.Default(composerRemoteSchema), unpackComposerRemoteRepo, constructor)
+	return mkResourceSchema(composerRemoteSchema, packer.Default(composerRemoteSchema), unpackComposerRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_conan_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_conan_repository.go
@@ -15,7 +15,7 @@ type ConanRemoteRepo struct {
 func ResourceArtifactoryRemoteConanRepository() *schema.Resource {
 	const packageType = "conan"
 
-	var conanRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, map[string]*schema.Schema{
+	var conanRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, map[string]*schema.Schema{
 		"force_conan_authentication": {
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -48,5 +48,5 @@ func ResourceArtifactoryRemoteConanRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(conanRemoteSchema, packer.Default(conanRemoteSchema), unpackConanRemoteRepo, constructor)
+	return mkResourceSchema(conanRemoteSchema, packer.Default(conanRemoteSchema), unpackConanRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_docker_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_docker_repository.go
@@ -20,7 +20,7 @@ type DockerRemoteRepository struct {
 func ResourceArtifactoryRemoteDockerRepository() *schema.Resource {
 	const packageType = "docker"
 
-	var dockerRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, map[string]*schema.Schema{
+	var dockerRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, map[string]*schema.Schema{
 		"external_dependencies_enabled": {
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -85,5 +85,5 @@ func ResourceArtifactoryRemoteDockerRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(dockerRemoteSchema, dockerRemoteRepoPacker, unpackDockerRemoteRepo, constructor)
+	return mkResourceSchema(dockerRemoteSchema, dockerRemoteRepoPacker, unpackDockerRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_generic_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_generic_repository.go
@@ -7,7 +7,51 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-func ResourceArtifactoryRemoteGenericRepository(pkt string) *schema.Resource {
+type GenericRemoteRepo struct {
+	RepositoryRemoteBaseParams
+	PropagateQueryParams bool `json:"propagateQueryParams"`
+}
+
+func ResourceArtifactoryRemoteGenericRepository() *schema.Resource {
+	const packageType = "generic"
+
+	var genericRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, map[string]*schema.Schema{
+		"propagate_query_params": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "When set, if query params are included in the request to Artifactory, they will be passed on to the remote repository.",
+		},
+	}, repository.RepoLayoutRefSchema("remote", packageType))
+
+	var unpackGenericRemoteRepo = func(s *schema.ResourceData) (interface{}, string, error) {
+		d := &util.ResourceData{ResourceData: s}
+		repo := GenericRemoteRepo{
+			RepositoryRemoteBaseParams: UnpackBaseRemoteRepo(s, packageType),
+			PropagateQueryParams:       d.GetBool("propagate_query_params", false),
+		}
+		return repo, repo.Id(), nil
+	}
+
+	constructor := func() (interface{}, error) {
+		repoLayout, err := repository.GetDefaultRepoLayoutRef("remote", packageType)()
+		if err != nil {
+			return nil, err
+		}
+
+		return &GenericRemoteRepo{
+			RepositoryRemoteBaseParams: RepositoryRemoteBaseParams{
+				Rclass:        "remote",
+				PackageType:   packageType,
+				RepoLayoutRef: repoLayout.(string),
+			},
+		}, nil
+	}
+
+	return repository.MkResourceSchema(genericRemoteSchema, packer.Default(genericRemoteSchema), unpackGenericRemoteRepo, constructor)
+}
+
+func ResourceArtifactoryRemoteBasicRepository(pkt string) *schema.Resource {
 	constructor := func() (interface{}, error) {
 		repoLayout, err := repository.GetDefaultRepoLayoutRef("remote", pkt)()
 		if err != nil {

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_generic_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_generic_repository.go
@@ -15,7 +15,7 @@ type GenericRemoteRepo struct {
 func ResourceArtifactoryRemoteGenericRepository() *schema.Resource {
 	const packageType = "generic"
 
-	var genericRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, map[string]*schema.Schema{
+	var genericRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, map[string]*schema.Schema{
 		"propagate_query_params": {
 			Type:        schema.TypeBool,
 			Optional:    true,
@@ -70,7 +70,7 @@ func ResourceArtifactoryRemoteBasicRepository(pkt string) *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	mergedRemoteRepoSchema := util.MergeMaps(BaseRemoteRepoSchema, repository.RepoLayoutRefSchema("remote", pkt))
+	mergedRemoteRepoSchema := util.MergeMaps(baseRemoteRepoSchema, repository.RepoLayoutRefSchema("remote", pkt))
 
-	return repository.MkResourceSchema(mergedRemoteRepoSchema, packer.Default(mergedRemoteRepoSchema), unpack, constructor)
+	return mkResourceSchema(mergedRemoteRepoSchema, packer.Default(mergedRemoteRepoSchema), unpack, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_generic_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_generic_repository.go
@@ -48,7 +48,7 @@ func ResourceArtifactoryRemoteGenericRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(genericRemoteSchema, packer.Default(genericRemoteSchema), unpackGenericRemoteRepo, constructor)
+	return mkResourceSchema(genericRemoteSchema, packer.Default(genericRemoteSchema), unpackGenericRemoteRepo, constructor)
 }
 
 func ResourceArtifactoryRemoteBasicRepository(pkt string) *schema.Resource {

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_go_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_go_repository.go
@@ -16,7 +16,7 @@ type GoRemoteRepo struct {
 func ResourceArtifactoryRemoteGoRepository() *schema.Resource {
 	const packageType = "go"
 
-	var goRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, map[string]*schema.Schema{
+	var goRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, map[string]*schema.Schema{
 		"vcs_git_provider": {
 			Type:             schema.TypeString,
 			Optional:         true,
@@ -50,5 +50,5 @@ func ResourceArtifactoryRemoteGoRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(goRemoteSchema, packer.Default(goRemoteSchema), unpackGoRemoteRepo, constructor)
+	return mkResourceSchema(goRemoteSchema, packer.Default(goRemoteSchema), unpackGoRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_helm_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_helm_repository.go
@@ -13,7 +13,7 @@ import (
 func ResourceArtifactoryRemoteHelmRepository() *schema.Resource {
 	const packageType = "helm"
 
-	var helmRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, map[string]*schema.Schema{
+	var helmRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, map[string]*schema.Schema{
 		"helm_charts_base_url": {
 			Type:             schema.TypeString,
 			Optional:         true,
@@ -80,5 +80,5 @@ func ResourceArtifactoryRemoteHelmRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(helmRemoteSchema, helmRemoteRepoPacker, unpackHelmRemoteRepo, constructor)
+	return mkResourceSchema(helmRemoteSchema, helmRemoteRepoPacker, unpackHelmRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_java_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_java_repository.go
@@ -2,7 +2,6 @@ package remote
 
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/packer"
 )
 
@@ -24,5 +23,5 @@ func ResourceArtifactoryRemoteJavaRepository(repoType string, suppressPom bool) 
 		}, nil
 	}
 
-	return repository.MkResourceSchema(javaRemoteSchema, packer.Default(javaRemoteSchema), unpackJavaRemoteRepo, constructor)
+	return mkResourceSchema(javaRemoteSchema, packer.Default(javaRemoteSchema), unpackJavaRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_maven_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_maven_repository.go
@@ -3,7 +3,6 @@ package remote
 import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/packer"
 	"github.com/jfrog/terraform-provider-shared/util"
 )
@@ -51,5 +50,5 @@ func ResourceArtifactoryRemoteMavenRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(mavenRemoteSchema, packer.Default(mavenRemoteSchema), unpackMavenRemoteRepo, constructor)
+	return mkResourceSchema(mavenRemoteSchema, packer.Default(mavenRemoteSchema), unpackMavenRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository.go
@@ -20,7 +20,7 @@ type NugetRemoteRepo struct {
 func ResourceArtifactoryRemoteNugetRepository() *schema.Resource {
 	const packageType = "nuget"
 
-	var nugetRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, map[string]*schema.Schema{
+	var nugetRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, map[string]*schema.Schema{
 		"feed_context_path": {
 			Type:        schema.TypeString,
 			Optional:    true,
@@ -84,5 +84,5 @@ func ResourceArtifactoryRemoteNugetRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(nugetRemoteSchema, packer.Default(nugetRemoteSchema), unpackNugetRemoteRepo, constructor)
+	return mkResourceSchema(nugetRemoteSchema, packer.Default(nugetRemoteSchema), unpackNugetRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_pypi_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_pypi_repository.go
@@ -11,7 +11,7 @@ import (
 func ResourceArtifactoryRemotePypiRepository() *schema.Resource {
 	const packageType = "pypi"
 
-	var pypiRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, map[string]*schema.Schema{
+	var pypiRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, map[string]*schema.Schema{
 		"pypi_registry_url": {
 			Type:             schema.TypeString,
 			Optional:         true,
@@ -53,5 +53,5 @@ func ResourceArtifactoryRemotePypiRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(pypiRemoteSchema, packer.Default(pypiRemoteSchema), unpackPypiRemoteRepo, constructor)
+	return mkResourceSchema(pypiRemoteSchema, packer.Default(pypiRemoteSchema), unpackPypiRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
@@ -877,9 +877,9 @@ func TestAccRemoteRepository_generic_with_propagate(t *testing.T) {
 }
 
 func TestAccRemoteRepository_gems_with_propagate_fails(t *testing.T) {
-
-	const remoteGemsRepoBasicWithPropagate = `
-		resource "artifactory_remote_gems_repository" "%s" {
+	for _, repoType := range remote.RepoTypesLikeBasic {
+		const remoteGemsRepoBasicWithPropagate = `
+		resource "artifactory_remote_%s_repository" "%s" {
 			key                     		= "%s"
 			description 					= "This is a test"
 			url                     		= "https://rubygems.org/"
@@ -887,21 +887,22 @@ func TestAccRemoteRepository_gems_with_propagate_fails(t *testing.T) {
 			propagate_query_params  		= true
 		}
 	`
-	id := test.RandomInt()
-	name := fmt.Sprintf("terraform-remote-test-repo-basic%d", id)
-	fqrn := fmt.Sprintf("artifactory_remote_gems_repository.%s", name)
+		id := test.RandomInt()
+		name := fmt.Sprintf("terraform-remote-test-repo-basic%d", id)
+		fqrn := fmt.Sprintf("artifactory_remote_gems_repository.%s", name)
 
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
-		Steps: []resource.TestStep{
-			{
-				Config:      fmt.Sprintf(remoteGemsRepoBasicWithPropagate, name, name),
-				ExpectError: regexp.MustCompile(".*Unsupported argument.*"),
+		resource.Test(t, resource.TestCase{
+			PreCheck:          func() { acctest.PreCheck(t) },
+			ProviderFactories: acctest.ProviderFactories,
+			CheckDestroy:      acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
+			Steps: []resource.TestStep{
+				{
+					Config:      fmt.Sprintf(remoteGemsRepoBasicWithPropagate, repoType, name, name),
+					ExpectError: regexp.MustCompile(".*Unsupported argument.*"),
+				},
 			},
-		},
-	})
+		})
+	}
 }
 
 func TestRemoteRepoResourceStateUpgradeV1(t *testing.T) {
@@ -915,7 +916,7 @@ func TestRemoteRepoResourceStateUpgradeV1(t *testing.T) {
 		"repo_layout_ref": "simple-default",
 	}
 
-	actual, err := repository.ResourceStateUpgradeV1(context.Background(), v1Data, nil)
+	actual, err := remote.ResourceStateUpgradeV1(context.Background(), v1Data, nil)
 
 	if err != nil {
 		t.Fatalf("error migrating state: %s", err)

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_terraform_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_terraform_repository.go
@@ -17,7 +17,7 @@ type TerraformRemoteRepo struct {
 func ResourceArtifactoryRemoteTerraformRepository() *schema.Resource {
 	const packageType = "terraform"
 
-	var terraformRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, map[string]*schema.Schema{
+	var terraformRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, map[string]*schema.Schema{
 		"terraform_registry_url": {
 			Type:         schema.TypeString,
 			Optional:     true,
@@ -55,5 +55,5 @@ func ResourceArtifactoryRemoteTerraformRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(terraformRemoteSchema, packer.Default(terraformRemoteSchema), unpackTerraformRemoteRepo, constructor)
+	return mkResourceSchema(terraformRemoteSchema, packer.Default(terraformRemoteSchema), unpackTerraformRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_vcs_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_vcs_repository.go
@@ -16,7 +16,7 @@ type VcsRemoteRepo struct {
 func ResourceArtifactoryRemoteVcsRepository() *schema.Resource {
 	const packageType = "vcs"
 
-	var vcsRemoteSchema = util.MergeMaps(BaseRemoteRepoSchema, VcsRemoteRepoSchema, map[string]*schema.Schema{
+	var vcsRemoteSchema = util.MergeMaps(baseRemoteRepoSchemaV2, VcsRemoteRepoSchema, map[string]*schema.Schema{
 		"max_unique_snapshots": {
 			Type:     schema.TypeInt,
 			Optional: true,
@@ -52,5 +52,5 @@ func ResourceArtifactoryRemoteVcsRepository() *schema.Resource {
 		}, nil
 	}
 
-	return repository.MkResourceSchema(vcsRemoteSchema, packer.Default(vcsRemoteSchema), UnpackVcsRemoteRepo, constructor)
+	return mkResourceSchema(vcsRemoteSchema, packer.Default(vcsRemoteSchema), UnpackVcsRemoteRepo, constructor)
 }

--- a/pkg/artifactory/resource/repository/repository.go
+++ b/pkg/artifactory/resource/repository/repository.go
@@ -55,7 +55,7 @@ type ReadFunc func(d *schema.ResourceData, m interface{}) error
 // Constructor Must return a pointer to a struct. When just returning a struct, resty gets confused and thinks it's a map
 type Constructor func() (interface{}, error)
 
-func mkRepoCreate(unpack unpacker.UnpackFunc, read schema.ReadContextFunc) schema.CreateContextFunc {
+func MkRepoCreate(unpack unpacker.UnpackFunc, read schema.ReadContextFunc) schema.CreateContextFunc {
 
 	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		repo, key, err := unpack(d)
@@ -77,7 +77,7 @@ func mkRepoCreate(unpack unpacker.UnpackFunc, read schema.ReadContextFunc) schem
 	}
 }
 
-func mkRepoRead(pack packer.PackFunc, construct Constructor) schema.ReadContextFunc {
+func MkRepoRead(pack packer.PackFunc, construct Constructor) schema.ReadContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		repo, err := construct()
 		if err != nil {
@@ -101,7 +101,7 @@ func mkRepoRead(pack packer.PackFunc, construct Constructor) schema.ReadContextF
 	}
 }
 
-func mkRepoUpdate(unpack unpacker.UnpackFunc, read schema.ReadContextFunc) schema.UpdateContextFunc {
+func MkRepoUpdate(unpack unpacker.UnpackFunc, read schema.ReadContextFunc) schema.UpdateContextFunc {
 	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		repo, key, err := unpack(d)
 		if err != nil {
@@ -164,7 +164,7 @@ func unassignRepoFromProject(repoKey string, client *resty.Client) error {
 	return err
 }
 
-func deleteRepo(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func DeleteRepo(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	resp, err := m.(*resty.Client).R().
 		AddRetryCondition(client.RetryOnMergeError).
 		SetPathParam("key", d.Id()).
@@ -261,7 +261,7 @@ func HandleResetWithNonExistentValue(d *util.ResourceData, key string) string {
 	return value
 }
 
-func projectEnvironmentsDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+func ProjectEnvironmentsDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
 	if data, ok := diff.GetOk("project_environments"); ok {
 		projectEnvironments := data.(*schema.Set).List()
 
@@ -276,52 +276,19 @@ func projectEnvironmentsDiff(_ context.Context, diff *schema.ResourceDiff, _ int
 }
 
 func MkResourceSchema(skeema map[string]*schema.Schema, packer packer.PackFunc, unpack unpacker.UnpackFunc, constructor Constructor) *schema.Resource {
-	var reader = mkRepoRead(packer, constructor)
+	var reader = MkRepoRead(packer, constructor)
 	return &schema.Resource{
-		SchemaVersion: 2,
-		CreateContext: mkRepoCreate(unpack, reader),
+		CreateContext: MkRepoCreate(unpack, reader),
 		ReadContext:   reader,
-		UpdateContext: mkRepoUpdate(unpack, reader),
-		DeleteContext: deleteRepo,
+		UpdateContext: MkRepoUpdate(unpack, reader),
+		DeleteContext: DeleteRepo,
 		Importer: &schema.ResourceImporter{
 			StateContext: schema.ImportStatePassthroughContext,
 		},
 
 		Schema:        skeema,
-		CustomizeDiff: projectEnvironmentsDiff,
-		StateUpgraders: []schema.StateUpgrader{
-			{
-				Type:    MkResourceSchemaV1(skeema, packer, unpack, constructor).CoreConfigSchema().ImpliedType(),
-				Upgrade: ResourceStateUpgradeV1,
-				Version: 1,
-			},
-		},
+		CustomizeDiff: ProjectEnvironmentsDiff,
 	}
-}
-
-func MkResourceSchemaV1(skeema map[string]*schema.Schema, packer packer.PackFunc, unpack unpacker.UnpackFunc, constructor Constructor) *schema.Resource {
-	var reader = mkRepoRead(packer, constructor)
-	return &schema.Resource{
-		SchemaVersion: 1,
-		CreateContext: mkRepoCreate(unpack, reader),
-		ReadContext:   reader,
-		UpdateContext: mkRepoUpdate(unpack, reader),
-		DeleteContext: deleteRepo,
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Schema:        skeema,
-		CustomizeDiff: projectEnvironmentsDiff,
-	}
-}
-
-func ResourceStateUpgradeV1(_ context.Context, rawState map[string]interface{}, _ interface{}) (map[string]interface{}, error) {
-	if rawState["package_type"] != "generic" {
-		delete(rawState, "propagate_query_params")
-	}
-
-	return rawState, nil
 }
 
 const RepositoriesEndpoint = "artifactory/api/repositories/{key}"


### PR DESCRIPTION
`propagate_query_params` works only for Generic remote repos and can break Gems repo functionality. 
This attribute is removed form the common remote repo configuration, migrator and tests added.
