### PR TITLE
GH-642, don't assign an empty string to password attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 * resource/artifactory_remote_*_repository: fixed bug, where remote repository password could be deleted, if it wasn't managed by the provider and `ignore_changes` was applied to that attribute.
-  PR: []()
+  PR: [#634](https://github.com/jfrog/terraform-provider-artifactory/pull/643)
   Issue: [#642](https://github.com/jfrog/terraform-provider-artifactory/issues/642)
  
   

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.26.1 (February 8, 2023).
+## 6.26.1 (February 8, 2023). Tested on Artifactory 7.49.6
 
 BUG FIXES:
 * resource/artifactory_remote_*_repository: fixed bug, where remote repository password could be deleted, if it wasn't managed by the provider and `ignore_changes` was applied to that attribute.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## 6.26.0. (January 31, 2023). Tested on Artifactory 7.49.6
+## 6.26.1 (February 8, 2023).
+
+BUG FIXES:
+* resource/artifactory_remote_*_repository: fixed bug, where remote repository password could be deleted, if it wasn't managed by the provider and `ignore_changes` was applied to that attribute.
+  PR: []()
+  Issue: [#642](https://github.com/jfrog/terraform-provider-artifactory/issues/642)
+ 
+  
+## 6.26.0 (January 31, 2023). Tested on Artifactory 7.49.6
 
 IMPROVEMENTS:
 

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -21,7 +21,7 @@ type RepositoryRemoteBaseParams struct {
 	PackageType                       string                             `json:"packageType,omitempty"`
 	Url                               string                             `json:"url"`
 	Username                          string                             `json:"username"`
-	Password                          string                             `json:"password"`
+	Password                          string                             `json:"password,omitempty"` // must have 'omitempty' to avoid sending an empty string on update, if attribute is ignored by the provider.
 	Proxy                             string                             `json:"proxy"`
 	Description                       string                             `json:"description"`
 	Notes                             string                             `json:"notes"`


### PR DESCRIPTION
Fix the bug, when an empty string was assigned to the password attribute in the remote repo, if the attribute is ignored by the lifecycle management. 