### PR TITLE
Remove warning for skipping downloading file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.28.1 (February 21, 2023)
+## 6.28.1 (February 21, 2023). Tested on Artifactory 7.49.8
 
 IMPROVEMENTS:
 * data/artifactory_file: removed warning message when skipping downloading of file. Issue: [#630](https://github.com/jfrog/terraform-provider-artifactory/issues/630) PR: [#653](https://github.com/jfrog/terraform-provider-artifactory/pull/653)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.28.1 (February 21, 2023)
+
+IMPROVEMENTS:
+* data/artifactory_file: removed warning message when skipping downloading of file. Issue: [#630](https://github.com/jfrog/terraform-provider-artifactory/issues/630) PR: [#653](https://github.com/jfrog/terraform-provider-artifactory/pull/653)
+
 ## 6.28.0 (February 15, 2023). Tested on Artifactory 7.49.8
 
 BUG FIXES:


### PR DESCRIPTION
Closes #630 

* Refactor code to be less complex
* Add fallback condition for `FileInfo.Id()`
* Use `FileInfo.Id()` for `d.SetId()` instead of manually choosing which field to use.