### PR TITLE
Fix configuration resources not reseting ID when they are manually deleted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 6.30.2 (February 27, 2023).
+
+BUG FIXES:
+* resource/artifactory_backup, resource/artifactory_ldap_group_setting, resource/artifactory_property_set, resource/artifactory_proxy, resource/artifactory_respository_layout: Fix provider erroring out instead of resetting resource ID if resource was deleted outside of Terraform. Issue: [#665](https://github.com/jfrog/terraform-provider-artifactory/issues/665) PR: [#667](https://github.com/jfrog/terraform-provider-artifactory/pull/667)
+
 ## 6.30.1 (February 24, 2023).
 
 BUG FIXES:

--- a/pkg/artifactory/resource/configuration/resource_artifactory_backup.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_backup.go
@@ -131,7 +131,8 @@ func ResourceArtifactoryBackup() *schema.Resource {
 
 		matchedBackup := FindConfigurationById[Backup](backups.BackupArr, key)
 		if matchedBackup == nil {
-			return diag.Errorf("No backup found for '%s'", key)
+			d.SetId("")
+			return nil
 		}
 
 		pkr := packer.Default(backupSchema)

--- a/pkg/artifactory/resource/configuration/resource_artifactory_backup_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_backup_test.go
@@ -115,7 +115,7 @@ func TestAccBackup_importNotFound(t *testing.T) {
 				ResourceName:  "artifactory_backup.not-exist-test",
 				ImportStateId: "not-exist-test",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile("No backup found for 'not-exist-test'"),
+				ExpectError:   regexp.MustCompile("Cannot import non-existent remote object"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting.go
@@ -118,7 +118,8 @@ Hierarchy: The user's DN is indicative of the groups the user belongs to by usin
 
 		matchedLdapGroupSetting := FindConfigurationById[LdapGroupSetting](ldapGroupConfigs.Security.LdapGroupSettings.LdapGroupSettingArr, name)
 		if matchedLdapGroupSetting == nil {
-			return diag.Errorf("No ldap_group_setting found for '%s'", name)
+			d.SetId("")
+			return nil
 		}
 
 		pkr := packer.Default(ldapGroupSettingsSchema)

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_test.go
@@ -101,7 +101,7 @@ func TestAccLdapGroupSetting_importNotFound(t *testing.T) {
 				ResourceName:  "artifactory_ldap_group_setting.not-exist-test",
 				ImportStateId: "not-exist-test",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile("No ldap_group_setting found for 'not-exist-test'"),
+				ExpectError:   regexp.MustCompile("Cannot import non-existent remote object"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting.go
@@ -164,7 +164,8 @@ func ResourceArtifactoryLdapSetting() *schema.Resource {
 
 		matchedLdapSetting := FindConfigurationById[LdapSetting](ldapConfigs.Security.LdapSettings.LdapSettingArr, key)
 		if matchedLdapSetting == nil {
-			return diag.Errorf("No ldap_setting found for '%s'", key)
+			d.SetId("")
+			return nil
 		}
 
 		pkr := packer.Universal(

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting_test.go
@@ -104,7 +104,7 @@ func TestAccLdapSetting_importNotFound(t *testing.T) {
 				ResourceName:  "artifactory_ldap_setting.not-exist-test",
 				ImportStateId: "not-exist-test",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile("No ldap_setting found for 'not-exist-test'"),
+				ExpectError:   regexp.MustCompile("Cannot import non-existent remote object"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/configuration/resource_artifactory_property_set.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_property_set.go
@@ -210,7 +210,8 @@ func ResourceArtifactoryPropertySet() *schema.Resource {
 
 		matchedPropertySet := FindConfigurationById[PropertySet](propertySetConfigs.PropertySets, name)
 		if matchedPropertySet == nil {
-			return diag.Errorf("No property set found for '%s'", name)
+			d.SetId("")
+			return nil
 		}
 
 		return packPropertySet(matchedPropertySet, d)

--- a/pkg/artifactory/resource/configuration/resource_artifactory_property_set_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_property_set_test.go
@@ -116,7 +116,7 @@ func TestAccPropertySetCustomizeDiff(t *testing.T) {
 				ResourceName:  fqrn,
 				ImportStateId: resourceName,
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile("No property set found for .*"),
+				ExpectError:   regexp.MustCompile("Cannot import non-existent remote object"),
 			},
 		},
 	})
@@ -149,7 +149,7 @@ func TestAccPropertySet_importNotFound(t *testing.T) {
 				ResourceName:  "artifactory_property_set.not-exist-test",
 				ImportStateId: "not-exist-test",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile("No property set found for 'not-exist-test'"),
+				ExpectError:   regexp.MustCompile("Cannot import non-existent remote object"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/configuration/resource_artifactory_proxy.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_proxy.go
@@ -169,7 +169,8 @@ func ResourceArtifactoryProxy() *schema.Resource {
 
 		matchedProxyConfig := FindConfigurationById[Proxy](proxiesConfig.Proxies, key)
 		if matchedProxyConfig == nil {
-			return diag.Errorf("No proxy found for '%s'", key)
+			d.SetId("")
+			return nil
 		}
 
 		return packProxy(matchedProxyConfig, d)

--- a/pkg/artifactory/resource/configuration/resource_artifactory_proxy_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_proxy_test.go
@@ -117,7 +117,7 @@ func TestAccProxy_importNotFound(t *testing.T) {
 				ResourceName:  "artifactory_proxy.not-exist-test",
 				ImportStateId: "not-exist-test",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile("No proxy found for 'not-exist-test'"),
+				ExpectError:   regexp.MustCompile("Cannot import non-existent remote object"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout.go
@@ -95,7 +95,8 @@ func ResourceArtifactoryRepositoryLayout() *schema.Resource {
 
 		matchedLayout := FindConfigurationById[Layout](layouts.Layouts, name)
 		if matchedLayout == nil {
-			return diag.Errorf("No layout found for '%s'", name)
+			d.SetId("")
+			return nil
 		}
 
 		pkr := packer.Default(layoutSchema)

--- a/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout_test.go
@@ -98,7 +98,7 @@ func TestAccLayout_importNotFound(t *testing.T) {
 				ResourceName:  "artifactory_repository_layout.not-exist-test",
 				ImportStateId: "not-exist-test",
 				ImportState:   true,
-				ExpectError:   regexp.MustCompile("No layout found for 'not-exist-test'"),
+				ExpectError:   regexp.MustCompile("Cannot import non-existent remote object"),
 			},
 		},
 	})


### PR DESCRIPTION
Fixes #665 

Instead of returning an error to Terraform and causes the process to quit, we reset the resource's ID so that Terraform knows it needs to re-create the resource.