### PR TITLE
Gh 647 default value for project_key attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ BACKWARDS INCOMPATIBILITIES:
 
 * resource/artifactory_*_repository: `project_key` attribute is assigned default value `default` to be compatible with Artifactory 7.50.x and above.
   It will create a state drift for Artifactory 7.49.x and below. For this reason, please use Terraform Provider Artifactory version 6.x on Artifactory 7.49.x and below.
-  PR: []
+  PR: [#668](https://github.com/jfrog/terraform-provider-artifactory/pull/668)
   Issue: [#647](https://github.com/jfrog/terraform-provider-artifactory/issues/647)
 
 ## 6.30.2 (February 27, 2023).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 7.0.0. (February 27, 2023) Tested on Artifactory 7.55.0
+
+BACKWARDS INCOMPATIBILITIES:
+
+* resource/artifactory_*_repository: `project_key` attribute is assigned default value `default` to be compatible with Artifactory 7.50.x and above.
+  It will create a state drift for Artifactory 7.49.x and below. For this reason, please use Terraform Provider Artifactory version 6.x on Artifactory 7.49.x and below.
+  PR: []
+  Issue: [#647](https://github.com/jfrog/terraform-provider-artifactory/issues/647)
+
 ## 6.30.2 (February 27, 2023).
 
 BUG FIXES:

--- a/docs/resources/local.md
+++ b/docs/resources/local.md
@@ -27,7 +27,7 @@ contain spaces or special characters.
 * `project_key` - (Optional) Project key for assigning this repository to. Must be 2 - 20 lowercase alphanumeric and hyphen characters.
   When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.
   We don't recommend using this attribute to assign the repository to the project. Use the `repos` attribute in Project provider
-  to manage the list of repositories.
+  to manage the list of repositories.  Default value - `default`.
 * `project_environments` - (Optional) Project environment for assigning this repository to. Allow values: "DEV" or "PROD".
   The attribute should only be used if the repository is already assigned to the existing project.
   If not, the attribute will be ignored by Artifactory, but will remain in the Terraform state, which will create state

--- a/docs/resources/remote.md
+++ b/docs/resources/remote.md
@@ -40,7 +40,7 @@ All generic repo arguments are supported, in addition to:
 * `project_key` - (Optional) Project key for assigning this repository to. Must be 2 - 20 lowercase alphanumeric and hyphen characters.
   When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.
   We don't recommend using this attribute to assign the repository to the project. Use the `repos` attribute in Project provider
-  to manage the list of repositories.
+  to manage the list of repositories. Default value - `default`.
 * `project_environments` - (Optional) Project environment for assigning this repository to. Allow values: "DEV" or "PROD".
   The attribute should only be used if the repository is already assigned to the existing project.
   If not, the attribute will be ignored by Artifactory, but will remain in the Terraform state, which will create state

--- a/docs/resources/virtual.md
+++ b/docs/resources/virtual.md
@@ -31,7 +31,7 @@ The following arguments are supported:
 * `project_key` - (Optional) Project key for assigning this repository to. Must be 2 - 20 lowercase alphanumeric and hyphen characters. 
   When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.
   We don't recommend using this attribute to assign the repository to the project. Use the `repos` attribute in Project provider 
-  to manage the list of repositories.
+  to manage the list of repositories. Default value - `default`.
 * `project_environments` - (Optional) Project environment for assigning this repository to. Allow values: "DEV" or "PROD".
   The attribute should only be used if the repository is already assigned to the existing project. 
   If not, the attribute will be ignored by Artifactory, but will remain in the Terraform state, which will create state 

--- a/pkg/artifactory/resource/repository/local/local.go
+++ b/pkg/artifactory/resource/repository/local/local.go
@@ -70,6 +70,7 @@ var BaseLocalRepoSchema = map[string]*schema.Schema{
 	"project_key": {
 		Type:             schema.TypeString,
 		Optional:         true,
+		Default:          "default",
 		ValidateDiagFunc: validator.ProjectKey,
 		Description:      "Project key for assigning this repository to. Must be 2 - 20 lowercase alphanumeric and hyphen characters. When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.",
 	},

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -107,6 +107,7 @@ var baseRemoteRepoSchema = map[string]*schema.Schema{
 	"project_key": {
 		Type:             schema.TypeString,
 		Optional:         true,
+		Default:          "default",
 		ValidateDiagFunc: validator.ProjectKey,
 		Description:      "Project key for assigning this repository to. Must be 2 - 20 lowercase alphanumeric and hyphen characters. When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.",
 	},

--- a/pkg/artifactory/resource/repository/virtual/virtual.go
+++ b/pkg/artifactory/resource/repository/virtual/virtual.go
@@ -63,6 +63,7 @@ var BaseVirtualRepoSchema = map[string]*schema.Schema{
 	"project_key": {
 		Type:             schema.TypeString,
 		Optional:         true,
+		Default:          "default",
 		ValidateDiagFunc: validator.ProjectKey,
 		Description:      "Project key for assigning this repository to. Must be 2 - 20 lowercase alphanumeric and hyphen characters. When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.",
 	},


### PR DESCRIPTION
Assign default value to `project_key` attribute - `default`. 
The change is introduced in Artifactory 7.50.x and we are changing the provider to accommodate this. 
Change is NOT backward compatible with Artifactory 7.49.x and only works on Artifactory 7.50.x
Users on Artifactory 7.49.x should use TF provider 6.x, which will be maintained by our team as well. 