### PR TITLE
Replace Resty SetPathParams() with string interpolation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 7.0.1. (February 28, 2023)
+
+BUG FIXES:
+* resource/artifactory_file: Fix `/` in artifact path being escaped. Issue: [#666](https://github.com/jfrog/terraform-provider-artifactory/issues/666) PR: [#669](https://github.com/jfrog/terraform-provider-artifactory/pull/669)
+
 ## 7.0.0. (February 27, 2023) Tested on Artifactory 7.55.0
 
 BACKWARDS INCOMPATIBILITIES:

--- a/pkg/artifactory/datasource/datasource_artifactory_file_test.go
+++ b/pkg/artifactory/datasource/datasource_artifactory_file_test.go
@@ -36,7 +36,7 @@ func uploadTestFile(client *resty.Client, localPath, remotePath, contentType str
 func downloadPreCheck(t *testing.T, downloadPath string, localFileModTime *time.Time) {
 	const localFilePath = "../../../samples/crash.zip"
 	client := acctest.GetTestResty(t)
-	err := uploadTestFile(client, localFilePath, "example-repo-local/crash.zip", "application/zip")
+	err := uploadTestFile(client, localFilePath, "example-repo-local/test/crash.zip", "application/zip")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -74,7 +74,7 @@ func TestDownloadFile(t *testing.T) {
 	const script = `
 		data "artifactory_file" "example" {
 		  repository      = "example-repo-local"
-		  path            = "crash.zip"
+		  path            = "test/crash.zip"
 		  output_path     = "%s"
 		  force_overwrite = true
 		}
@@ -215,7 +215,7 @@ func TestDownloadFileSkipCheck(t *testing.T) {
 	const noOverWriteForcedScript = `
 		data "artifactory_file" "example" {
 		  repository      = "example-repo-local"
-		  path            = "crash.zip"
+		  path            = "test/crash.zip"
 		  output_path     = "%s"
 		  force_overwrite = false
 		}
@@ -223,7 +223,7 @@ func TestDownloadFileSkipCheck(t *testing.T) {
 	const forceOverWriteScript = `
 		data "artifactory_file" "example" {
 		  repository      = "example-repo-local"
-		  path            = "crash.zip"
+		  path            = "test/crash.zip"
 		  output_path     = "%s"
 		  force_overwrite = true
 		}


### PR DESCRIPTION
Because Resty escape slash character.

Fixes #666 