### PR TITLE
GH-673 fixing an issue with `external_dependencies_enabled` and `external_dependencies_patterns`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 7.1.1 (March 2, 2023). Tested on Artifactory 7.55.2
 
 BUG FIXES:
-* resource/artifactory_remote_docker_repository, resource/artifactory_remote_helm_repository: fixed the issue when `externalDependenciesEnabled` was impossible to update. 
+* resource/artifactory_remote_docker_repository, resource/artifactory_remote_helm_repository: fixed the issue when `external_dependencies_enabled` was impossible to update. 
 Removed constraints from `external_dependencies_patterns` attribute, now it can be set when `external_dependencies_enabled` is set to false. This is a workaround for the Artifactory API behavior, when the default value [**] is assigned instead of an empty list on the update repository call.
  PR: [#678](https://github.com/jfrog/terraform-provider-artifactory/pull/678)
  Issue: [#673](https://github.com/jfrog/terraform-provider-artifactory/issues/673)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 * resource/artifactory_remote_docker_repository, resource/artifactory_remote_helm_repository: fixed the issue when `externalDependenciesEnabled` was impossible to update. 
-Removed constraints from `externalDependenciesPatterns` attribute, now it can be set when `externalDependenciesEnabled` is set to false. This is a workaround for the Artifactory API behavior, when the default value [**] is assigned instead of an empty list on the update repository call.
+Removed constraints from `external_dependencies_patterns` attribute, now it can be set when `external_dependencies_enabled` is set to false. This is a workaround for the Artifactory API behavior, when the default value [**] is assigned instead of an empty list on the update repository call.
  PR: [#678](https://github.com/jfrog/terraform-provider-artifactory/pull/678)
  Issue: [#673](https://github.com/jfrog/terraform-provider-artifactory/issues/673)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 7.1.1 (March 2, 2023).
+
+BUG FIXES:
+* resource/artifactory_remote_docker_repository, resource/artifactory_remote_helm_repository: fixed the issue when `externalDependenciesEnabled` was impossible to update. 
+Removed constraints from `externalDependenciesPatterns` attribute, now it can be set when `externalDependenciesEnabled` is set to false. This is a workaround for the Artifactory API behavior, when the default value [**] is assigned instead of an empty list on the update repository call.
+ PR: [#]()
+ Issue: [#673](https://github.com/jfrog/terraform-provider-artifactory/issues/673)
+
 ## 7.1.0 (March 1, 2023). Tested on Artifactory 7.55.2
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 BUG FIXES:
 * resource/artifactory_remote_docker_repository, resource/artifactory_remote_helm_repository: fixed the issue when `externalDependenciesEnabled` was impossible to update. 
 Removed constraints from `externalDependenciesPatterns` attribute, now it can be set when `externalDependenciesEnabled` is set to false. This is a workaround for the Artifactory API behavior, when the default value [**] is assigned instead of an empty list on the update repository call.
- PR: [#]()
+ PR: [#678](https://github.com/jfrog/terraform-provider-artifactory/pull/678)
  Issue: [#673](https://github.com/jfrog/terraform-provider-artifactory/issues/673)
 
 ## 7.1.0 (March 1, 2023). Tested on Artifactory 7.55.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.1.1 (March 2, 2023).
+## 7.1.1 (March 2, 2023). Tested on Artifactory 7.55.2
 
 BUG FIXES:
 * resource/artifactory_remote_docker_repository, resource/artifactory_remote_helm_repository: fixed the issue when `externalDependenciesEnabled` was impossible to update. 

--- a/docs/resources/remote_docker_repository.md
+++ b/docs/resources/remote_docker_repository.md
@@ -36,11 +36,12 @@ The following arguments are supported, along with the [common list of arguments 
 * `enable_token_authentication` - (Optional) Enable token (Bearer) based authentication.
 * `external_dependencies_enabled` - (Optional) Also known as 'Foreign Layers Caching' on the UI.
 * `external_dependencies_patterns` - (Optional) An allow list of Ant-style path patterns that determine which remote VCS roots Artifactory will
-  follow to download remote modules from, when presented with 'go-import' meta tags in the remote repository response. 
-  By default, this is set to '**' in the UI, which means that remote modules may be downloaded from any external VCS source.
+  follow to download remote modules from, when presented with 'go-import' meta tags in the remote repository response.
+  By default, this is set to '[**]' in the UI, which means that remote modules may be downloaded from any external VCS source.
   Due to SDKv2 limitations, we can't set the default value for the list.
-  This value must be assigned to the attribute manually, if user don't specify any other non-default values.
-  This attribute must be set together with `external_dependencies_enabled = true`.
+  This value '[**]' must be assigned to the attribute manually, if user don't specify any other non-default values.
+  We don't want to make this attribute required, but it must be set to avoid the state drift on update. Note: Artifactory assigns
+  '[**]' on update if HCL doesn't have the attribute set or the list is empty.
 
 ## Import
 

--- a/docs/resources/remote_helm_repository.md
+++ b/docs/resources/remote_helm_repository.md
@@ -35,7 +35,11 @@ The following arguments are supported, along with the [common list of arguments 
 * `external_dependencies_enabled` - (Optional) When set, external dependencies are rewritten. `External Dependency Rewrite` in the UI.
 * `external_dependencies_patterns` - (Optional) An allow list of Ant-style path patterns that determine which remote VCS roots Artifactory will
   follow to download remote modules from, when presented with 'go-import' meta tags in the remote repository response.
-  Default value in the UI is empty. This attribute must be set together with `external_dependencies_enabled = true`.
+  By default, this is set to '[**]' in the UI, which means that remote modules may be downloaded from any external VCS source.
+  Due to SDKv2 limitations, we can't set the default value for the list.
+  This value '[**]' must be assigned to the attribute manually, if user don't specify any other non-default values.
+  We don't want to make this attribute required, but it must be set to avoid the state drift on update. Note: Artifactory assigns
+  '[**]' on update if HCL doesn't have the attribute set or the list is empty.
 
 ## Import
 

--- a/docs/resources/virtual_gitlfs_repository.md
+++ b/docs/resources/virtual_gitlfs_repository.md
@@ -9,7 +9,7 @@ Official documentation can be found [here](https://www.jfrog.com/confluence/disp
 ## Example Usage
 
 ```hcl
-resource "artifactory_virtual_cgitlfs_repository" "foo-gitlfs" {
+resource "artifactory_virtual_gitlfs_repository" "foo-gitlfs" {
   key               = "foo-gitlfs"
   repositories      = []
   description       = "A test virtual repo"

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -633,12 +633,6 @@ func verifyExternalDependenciesDockerAndHelm(_ context.Context, diff *schema.Res
 		if _, ok := diff.GetOk("external_dependencies_patterns"); !ok {
 			return fmt.Errorf("if `external_dependencies_enabled` is set to `true`, `external_dependencies_patterns` list must be set")
 		}
-	} else {
-		if _, ok := diff.GetOk("external_dependencies_patterns"); ok {
-			if len(diff.Get("external_dependencies_patterns").([]interface{})) != 0 {
-				return fmt.Errorf("if `external_dependencies_enabled` is set to `false`, `external_dependencies_patterns` list can not be set")
-			}
-		}
 	}
 
 	return nil

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_docker_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_docker_repository.go
@@ -40,17 +40,18 @@ func ResourceArtifactoryRemoteDockerRepository() *schema.Resource {
 			RequiredWith: []string{"external_dependencies_enabled"},
 			Description: "An allow list of Ant-style path patterns that determine which remote VCS roots Artifactory will " +
 				"follow to download remote modules from, when presented with 'go-import' meta tags in the remote repository response. " +
-				"By default, this is set to '**' in the UI, which means that remote modules may be downloaded from any external VCS source." +
+				"By default, this is set to '[**]' in the UI, which means that remote modules may be downloaded from any external VCS source." +
 				"Due to SDKv2 limitations, we can't set the default value for the list." +
-				"This value must be assigned to the attribute manually, if user don't specify any other non-default values." +
-				"This attribute must be set together with `external_dependencies_enabled = true`",
+				"This value [**] must be assigned to the attribute manually, if user don't specify any other non-default values." +
+				"We don't want to make this attribute required, but it must be set to avoid the state drift on update. Note: Artifactory assigns " +
+				"[**] on update if HCL doesn't have the attribute set or the list is empty.",
 		},
 	}, repository.RepoLayoutRefSchema("remote", packageType))
 
 	type DockerRemoteRepository struct {
 		RepositoryRemoteBaseParams
-		ExternalDependenciesEnabled  bool     `hcl:"external_dependencies_enabled" json:"externalDependenciesEnabled,omitempty"`
-		ExternalDependenciesPatterns []string `hcl:"external_dependencies_patterns" json:"externalDependenciesPatterns,omitempty"`
+		ExternalDependenciesEnabled  bool     `hcl:"external_dependencies_enabled" json:"externalDependenciesEnabled"`
+		ExternalDependenciesPatterns []string `hcl:"external_dependencies_patterns" json:"externalDependenciesPatterns"`
 		EnableTokenAuthentication    bool     `hcl:"enable_token_authentication" json:"enableTokenAuthentication"`
 		BlockPushingSchema1          bool     `hcl:"block_pushing_schema1" json:"blockPushingSchema1"`
 	}

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_helm_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_helm_repository.go
@@ -37,8 +37,12 @@ func ResourceArtifactoryRemoteHelmRepository() *schema.Resource {
 			},
 			RequiredWith: []string{"external_dependencies_enabled"},
 			Description: "An allow list of Ant-style path patterns that determine which remote VCS roots Artifactory will " +
-				"follow to download remote modules from, when presented with 'go-import' meta tags in the remote repository response." +
-				"Default value in UI is empty. This attribute must be set together with `external_dependencies_enabled = true`",
+				"follow to download remote modules from, when presented with 'go-import' meta tags in the remote repository response. " +
+				"By default, this is set to '[**]' in the UI, which means that remote modules may be downloaded from any external VCS source." +
+				"Due to SDKv2 limitations, we can't set the default value for the list." +
+				"This value [**] must be assigned to the attribute manually, if user don't specify any other non-default values." +
+				"We don't want to make this attribute required, but it must be set to avoid the state drift on update. Note: Artifactory assigns " +
+				"[**] on update if HCL doesn't have the attribute set or the list is empty.",
 		},
 	}, repository.RepoLayoutRefSchema("remote", packageType))
 

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
@@ -100,6 +100,25 @@ func TestAccRemoteDockerRepositoryDepTrue(t *testing.T) {
 	resource.Test(t, testCase)
 }
 
+func TestAccRemoteDockerRepositoryDepFalse(t *testing.T) {
+	const packageType = "docker"
+	_, testCase := mkNewRemoteTestCase(packageType, t, map[string]interface{}{
+		"external_dependencies_enabled":  false,
+		"enable_token_authentication":    true,
+		"block_pushing_schema1":          true,
+		"priority_resolution":            false,
+		"external_dependencies_patterns": []interface{}{"**/hub.docker.io/**", "**/bintray.jfrog.io/**"},
+		"missed_cache_period_seconds":    1800, // https://github.com/jfrog/terraform-provider-artifactory/issues/225
+		"content_synchronisation": map[string]interface{}{
+			"enabled":                         false,
+			"statistics_enabled":              true,
+			"properties_enabled":              true,
+			"source_origin_absence_detection": true,
+		},
+	})
+	resource.Test(t, testCase)
+}
+
 func TestAccRemoteDockerRepositoryDependenciesTrueEmptyListFails(t *testing.T) {
 	const failKey = `
 		resource "artifactory_remote_docker_repository" "terraform-remote-docker-repo-basic" {
@@ -120,32 +139,6 @@ func TestAccRemoteDockerRepositoryDependenciesTrueEmptyListFails(t *testing.T) {
 			{
 				Config:      failKey,
 				ExpectError: regexp.MustCompile(".*if `external_dependencies_enabled` is set to `true`, `external_dependencies_patterns` list must be set.*"),
-			},
-		},
-	})
-}
-
-func TestAccRemoteDockerRepositoryDependenciesFalseListFails(t *testing.T) {
-	const failKey = `
-		resource "artifactory_remote_docker_repository" "terraform-remote-docker-repo-basic" {
-			key                     		= "remote-docker"
-			url                     		= "https://registry.npmjs.org/"
-			retrieval_cache_period_seconds 	= 70
-			enable_token_authentication    	= true
-			block_pushing_schema1          	= true
-			priority_resolution            	= false
-			external_dependencies_enabled   = false
-			external_dependencies_patterns 	= ["**/hub.docker.io/**", "**/bintray.jfrog.io/**"]
-		}
-	`
-
-	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      failKey,
-				ExpectError: regexp.MustCompile(".*if `external_dependencies_enabled` is set to `false`, `external_dependencies_patterns` list can not be set.*"),
 			},
 		},
 	})
@@ -334,6 +327,23 @@ func TestAccRemoteHelmRepository(t *testing.T) {
 		"helm_charts_base_url":           "https://github.com/rust-lang/foo.index",
 		"missed_cache_period_seconds":    1800, // https://github.com/jfrog/terraform-provider-artifactory/issues/225
 		"external_dependencies_enabled":  true,
+		"priority_resolution":            false,
+		"external_dependencies_patterns": []interface{}{"**github.com**"},
+		"content_synchronisation": map[string]interface{}{
+			"enabled":                         false, // even when set to true, it seems to come back as false on the wire
+			"statistics_enabled":              true,
+			"properties_enabled":              true,
+			"source_origin_absence_detection": true,
+		},
+	}))
+}
+
+func TestAccRemoteHelmRepositoryDepFalse(t *testing.T) {
+	const packageType = "helm"
+	resource.Test(mkNewRemoteTestCase(packageType, t, map[string]interface{}{
+		"helm_charts_base_url":           "https://github.com/rust-lang/foo.index",
+		"missed_cache_period_seconds":    1800, // https://github.com/jfrog/terraform-provider-artifactory/issues/225
+		"external_dependencies_enabled":  false,
 		"priority_resolution":            false,
 		"external_dependencies_patterns": []interface{}{"**github.com**"},
 		"content_synchronisation": map[string]interface{}{


### PR DESCRIPTION
- Fixing an issue with `external_dependencies_enabled` and `external_dependencies_patterns` for docker and helm remote repos.
- Removed constraints where `external_dependencies_patterns` can only be set if `external_dependencies_enabled` is true. The reason is non-standard Artifactory API behavior - if the list is set to empty on update, it automatically gets assigned a value of `[**]`, which creates a state drift. 
- Fixing type from GH-659.