### PR TITLE
GH-684 Add warning when token can't be found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 7.2.1 (March 6, 2023). Tested on Artifactory 7.55.6
+
+IMPROVEMENTS:
+
+* resource/artifactory_scoped_token: When `expires_in` attribute is set to value that is less than Artifactory's persistency threshold then the token is created but never saved to the database. Add a warning message so users can potentially figure out why the Terraform state is invalid.
+  PR:    [#691](https://github.com/jfrog/terraform-provider-artifactory/pull/691) 
+  Issue: [#684](https://github.com/jfrog/terraform-provider-artifactory/issues/684)
+
 ## 7.2.0 (March 6, 2023). Tested on Artifactory 7.55.6
 
 FEATURES:

--- a/docs/resources/scoped_token.md
+++ b/docs/resources/scoped_token.md
@@ -5,9 +5,10 @@ subcategory: "Security"
 
 Provides an Artifactory Scoped Token resource. This can be used to create and manage Artifactory Scoped Tokens.
 
-**Note:** Scoped Tokens will be stored in the raw state as plain-text. [Read more about sensitive data in
+!>Scoped Tokens will be stored in the raw state as plain-text. [Read more about sensitive data in
 state](https://www.terraform.io/docs/state/sensitive-data.html).
 
+~>Token would not be saved by Artifactory if `expires_in` is less than the persistency threshold value (default to 10800 seconds) set in Access configuration. See [Persistency Threshold](https://www.jfrog.com/confluence/display/JFROG/Access+Tokens#AccessTokens-PersistencyThreshold) for details.
 
 ## Example Usages
 ### Create a new Artifactory scoped token for an existing user

--- a/scripts/access.config.patch.yml
+++ b/scripts/access.config.patch.yml
@@ -1,0 +1,3 @@
+token:
+  persistency:
+    persistent-expiry-threshold: 10800 # Available from Artifactory 7.8.0 - (seconds) token with expiry (expirationTime-issuedAt) below this value will not be persistent. set to -1 to make all tokens persistent. lowering this value will effectively revoke all tokens with expiry below the old value and above the new revocable-expiry-threshold.

--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -8,6 +8,7 @@ services:
       - "8082:8082"
     volumes:
       - ./artifactory.lic:/artifactory_extra_conf/artifactory.lic:ro # This file is not part of the repo. You need to provide this license file.
+      - ./access.config.patch.yml:/opt/jfrog/artifactory/var/etc/access/access.config.patch.yml:ro # This file is not part of the repo. You need to provide this license file.
 
   artifactory-2:
     image: releases-docker.jfrog.io/jfrog/artifactory-pro:${ARTIFACTORY_VERSION:-latest}

--- a/scripts/get-access-key.sh
+++ b/scripts/get-access-key.sh
@@ -27,10 +27,10 @@ function getAccessKey() {
   scoped_access_key=$(curl --location --request POST "${url}/access/api/v1/tokens" \
                       --header "Authorization: Bearer ${access_key}" \
                       --header "Content-Type: application/x-www-form-urlencoded" \
-                      --data-urlencode "expires_in=3600" \
+                      --data-urlencode "expires_in=0" \
                       --data-urlencode "username=admin" \
-                      --data-urlencode "scope=applied-permissions/user" \
-                      --data-urlencode "description=Created_with_script_in_TF_provider" | jq .access_token)
+                      --data-urlencode "scope=applied-permissions/admin" \
+                      --data-urlencode "description=Created_with_script_in_TF_provider" | jq -r .access_token)
 
-  echo "${scoped_access_key}"
+  echo ${scoped_access_key}
 }


### PR DESCRIPTION
Closes #684 

When `expires_in` attribute is set to value that is less than Artifactory's persistency threshold then the token is created but never saved to the database. Add a warning message so users can potentially figure out why the Terraform state is invalid.