### PR TITLE
GH-705 update repository environments attribute limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.4.1 (March 28, 2023)
+## 7.4.1 (March 28, 2023). Tested on Artifactory 7.55.9
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 7.4.1 (March 28, 2023)
+
+IMPROVEMENTS:
+
+* resource/artifactory_*_repository: Updates `project_environments` attribute validation. Before Artifactory 7.53.1, up to 2 values (`DEV` and `PROD`) are allowed. From 7.53.1 onward, only one value (`DEV`, `PROD`, or one of custom environment) is allowed.
+PR:    [#706](https://github.com/jfrog/terraform-provider-artifactory/pull/706)
+Issue: [#705](https://github.com/jfrog/terraform-provider-artifactory/issues/705)
+
 ## 7.4.0 (March 20, 2023). Tested on Artifactory 7.55.8
 
 FEATURES:

--- a/docs/resources/local.md
+++ b/docs/resources/local.md
@@ -29,6 +29,7 @@ contain spaces or special characters.
   We don't recommend using this attribute to assign the repository to the project. Use the `repos` attribute in Project provider
   to manage the list of repositories.  Default value - `default`.
 * `project_environments` - (Optional) Project environment for assigning this repository to. Allow values: `DEV` or `PROD`.
+  Before Artifactory 7.53.1, up to 2 values (`DEV` and `PROD`) are allowed. From 7.53.1 onward, only one value is allowed.
   The attribute should only be used if the repository is already assigned to the existing project.
   If not, the attribute will be ignored by Artifactory, but will remain in the Terraform state, which will create state
   drift during the update.

--- a/docs/resources/remote.md
+++ b/docs/resources/remote.md
@@ -42,6 +42,7 @@ All generic repo arguments are supported, in addition to:
   We don't recommend using this attribute to assign the repository to the project. Use the `repos` attribute in Project provider
   to manage the list of repositories. Default value - `default`.
 * `project_environments` - (Optional) Project environment for assigning this repository to. Allow values: `DEV` or `PROD`.
+  Before Artifactory 7.53.1, up to 2 values (`DEV` and `PROD`) are allowed. From 7.53.1 onward, only one value is allowed.
   The attribute should only be used if the repository is already assigned to the existing project.
   If not, the attribute will be ignored by Artifactory, but will remain in the Terraform state, which will create state
   drift during the update.

--- a/docs/resources/virtual.md
+++ b/docs/resources/virtual.md
@@ -33,6 +33,7 @@ The following arguments are supported:
   We don't recommend using this attribute to assign the repository to the project. Use the `repos` attribute in Project provider 
   to manage the list of repositories. Default value - `default`.
 * `project_environments` - (Optional) Project environment for assigning this repository to. Allow values: `DEV` or `PROD`.
+  Before Artifactory 7.53.1, up to 2 values (`DEV` and `PROD`) are allowed. From 7.53.1 onward, only one value is allowed.
   The attribute should only be used if the repository is already assigned to the existing project. 
   If not, the attribute will be ignored by Artifactory, but will remain in the Terraform state, which will create state 
   drift during the update.

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-log v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
-	github.com/jfrog/terraform-provider-shared v1.11.1
+	github.com/jfrog/terraform-provider-shared v1.12.0
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4
@@ -33,7 +33,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.4.3 // indirect
 	github.com/hashicorp/go-uuid v1.0.3 // indirect
-	github.com/hashicorp/go-version v1.4.0 // indirect
+	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hashicorp/hc-install v0.3.2 // indirect
 	github.com/hashicorp/hcl/v2 v2.12.0 // indirect
 	github.com/hashicorp/logutils v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -115,8 +115,9 @@ github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/C
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.3.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/go-version v1.4.0 h1:aAQzgqIrRKRa7w75CKpbBxYsmUoPjzVm1W59ca1L0J4=
 github.com/hashicorp/go-version v1.4.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
+github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=
+github.com/hashicorp/go-version v1.6.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/hc-install v0.3.2 h1:oiQdJZvXmkNcRcEOOfM5n+VTsvNjWQeOjfAoO6dKSH8=
 github.com/hashicorp/hc-install v0.3.2/go.mod h1:xMG6Tr8Fw1WFjlxH0A9v61cW15pFwgEGqEz0V4jisHs=
 github.com/hashicorp/hcl/v2 v2.12.0 h1:PsYxySWpMD4KPaoJLnsHwtK5Qptvj/4Q6s0t4sUxZf4=
@@ -145,8 +146,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v1.11.1 h1:oRK5c5Rt0wYTKrRqr+t+fspDPgn/PT5TKjCzxehfoz0=
-github.com/jfrog/terraform-provider-shared v1.11.1/go.mod h1:n6855hIUDhypnXsJl8UrstVFkcnL2uW4FLLr3cKGXjU=
+github.com/jfrog/terraform-provider-shared v1.12.0 h1:zJDP8J7gffniPzetHtoRpphOCcsoAZ0CirUT9EpWb+k=
+github.com/jfrog/terraform-provider-shared v1.12.0/go.mod h1:n6855hIUDhypnXsJl8UrstVFkcnL2uW4FLLr3cKGXjU=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/pkg/acctest/test.go
+++ b/pkg/acctest/test.go
@@ -200,9 +200,8 @@ func GetValidRandomDefaultRepoLayoutRef() string {
 // updateProxiesConfig is used by acctest.CreateProxy and acctest.DeleteProxy to interact with a proxy on Artifactory
 var updateProxiesConfig = func(t *testing.T, proxyKey string, getProxiesBody func() []byte) {
 	body := getProxiesBody()
-	restyClient := GetTestResty(t)
 
-	err := configuration.SendConfigurationPatch(body, restyClient)
+	err := configuration.SendConfigurationPatch(body, Provider.Meta())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/acctest/test.go
+++ b/pkg/acctest/test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/user"
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/test"
+	"github.com/jfrog/terraform-provider-shared/util"
 	"gopkg.in/yaml.v3"
 )
 
@@ -85,9 +86,9 @@ func VerifyDeleted(id string, check CheckFun) func(*terraform.State) error {
 			return fmt.Errorf("provider is not initialized. Please PreCheck() is included in your acceptance test")
 		}
 
-		c := Provider.Meta().(*resty.Client)
+		providerMeta := Provider.Meta().(util.ProvderMetadata)
 
-		resp, err := check(rs.Primary.ID, c.R())
+		resp, err := check(rs.Primary.ID, providerMeta.Client.R())
 		if err != nil {
 			if resp != nil {
 				switch resp.StatusCode() {

--- a/pkg/artifactory/datasource/datasource_artifactory_file.go
+++ b/pkg/artifactory/datasource/datasource_artifactory_file.go
@@ -6,10 +6,10 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 type FileInfo struct {
@@ -191,7 +191,7 @@ func downloadUsingFileInfo(ctx context.Context, outputPath string, forceOverwrit
 		"path":       path,
 	})
 
-	client := m.(*resty.Client)
+	client := m.(util.ProvderMetadata).Client
 	// switch to using Sprintf because Resty's SetPathParams() escape the path
 	// see https://github.com/go-resty/resty/blob/v2.7.0/middleware.go#L33
 	// should use url.JoinPath() eventually in go 1.20
@@ -242,7 +242,7 @@ func downloadUsingFileInfo(ctx context.Context, outputPath string, forceOverwrit
 		"fileInfo.DownloadUri": fileInfo.DownloadUri,
 		"outputPath":           outputPath,
 	})
-	_, err = m.(*resty.Client).R().SetOutput(outputPath).Get(fileInfo.DownloadUri)
+	_, err = m.(util.ProvderMetadata).Client.R().SetOutput(outputPath).Get(fileInfo.DownloadUri)
 	if err != nil {
 		return fileInfo, err
 	}
@@ -294,7 +294,7 @@ func downloadWithoutChecks(ctx context.Context, outputPath string, forceOverwrit
 		"outputPath": outputPath,
 	})
 
-	client := m.(*resty.Client)
+	client := m.(util.ProvderMetadata).Client
 	// switch to using Sprintf because Resty's SetPathParams() escape the path
 	// see https://github.com/go-resty/resty/blob/v2.7.0/middleware.go#L33
 	// should use url.JoinPath() eventually in go 1.20

--- a/pkg/artifactory/datasource/datasource_artifactory_fileinfo.go
+++ b/pkg/artifactory/datasource/datasource_artifactory_fileinfo.go
@@ -3,9 +3,9 @@ package datasource
 import (
 	"context"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/util"
 )
@@ -77,7 +77,7 @@ func dataSourceFileInfoRead(_ context.Context, d *schema.ResourceData, m interfa
 	path := d.Get("path").(string)
 
 	fileInfo := FileInfo{}
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetResult(&fileInfo).
 		SetPathParams(map[string]string{
 			"repoKey": repo,

--- a/pkg/artifactory/datasource/repository/repository.go
+++ b/pkg/artifactory/datasource/repository/repository.go
@@ -3,11 +3,12 @@ package repository
 import (
 	"context"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/packer"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 func MkRepoReadDataSource(pack packer.PackFunc, construct repository.Constructor) schema.ReadContextFunc {
@@ -19,7 +20,7 @@ func MkRepoReadDataSource(pack packer.PackFunc, construct repository.Constructor
 
 		key := d.Get("key").(string)
 		// repo must be a pointer
-		_, err = m.(*resty.Client).R().
+		_, err = m.(util.ProvderMetadata).Client.R().
 			SetResult(repo).
 			SetPathParam("key", key).
 			Get(repository.RepositoriesEndpoint)

--- a/pkg/artifactory/datasource/security/datasource_artifactory_group.go
+++ b/pkg/artifactory/datasource/security/datasource_artifactory_group.go
@@ -3,9 +3,9 @@ package security
 import (
 	"golang.org/x/net/context"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/security"
 	"github.com/jfrog/terraform-provider-shared/packer"
 	"github.com/jfrog/terraform-provider-shared/predicate"
@@ -17,7 +17,7 @@ func DataSourceArtifactoryGroup() *schema.Resource {
 		group := security.Group{}
 		name := d.Get("name").(string)
 		includeUsers := d.Get("include_users").(string)
-		_, err := m.(*resty.Client).R().SetResult(&group).SetQueryParam("includeUsers", includeUsers).Get(security.GroupsEndpoint + name)
+		_, err := m.(util.ProvderMetadata).Client.R().SetResult(&group).SetQueryParam("includeUsers", includeUsers).Get(security.GroupsEndpoint + name)
 
 		if err != nil {
 			return diag.FromErr(err)

--- a/pkg/artifactory/datasource/security/datasource_artifactory_permission_target.go
+++ b/pkg/artifactory/datasource/security/datasource_artifactory_permission_target.go
@@ -3,17 +3,18 @@ package security
 import (
 	"context"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/security"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 func DataSourceArtifactoryPermissionTarget() *schema.Resource {
 	dataSourcePermissionTargetRead := func(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		permissionTarget := new(security.PermissionTargetParams)
 		targetName := d.Get("name").(string)
-		_, err := m.(*resty.Client).R().SetResult(permissionTarget).Get(security.PermissionsEndPoint + targetName)
+		_, err := m.(util.ProvderMetadata).Client.R().SetResult(permissionTarget).Get(security.PermissionsEndPoint + targetName)
 
 		if err != nil {
 			return diag.FromErr(err)

--- a/pkg/artifactory/datasource/user/datasource_artifactory_user.go
+++ b/pkg/artifactory/datasource/user/datasource_artifactory_user.go
@@ -3,10 +3,10 @@ package user
 import (
 	"context"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/user"
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
@@ -70,7 +70,7 @@ func DataSourceArtifactoryUser() *schema.Resource {
 
 		userName := d.Get("name").(string)
 		userObj := user.User{}
-		_, err := m.(*resty.Client).R().SetResult(&userObj).Get(user.UsersEndpointPath + userName)
+		_, err := m.(util.ProvderMetadata).Client.R().SetResult(&userObj).Get(user.UsersEndpointPath + userName)
 
 		if err != nil {
 			return diag.FromErr(err)

--- a/pkg/artifactory/resource/configuration/configuration.go
+++ b/pkg/artifactory/resource/configuration/configuration.go
@@ -1,8 +1,8 @@
 package configuration
 
 import (
-	"github.com/go-resty/resty/v2"
 	"github.com/jfrog/terraform-provider-shared/client"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 /* SendConfigurationPatch updates system configuration using YAML data.
@@ -10,7 +10,7 @@ import (
 See https://www.jfrog.com/confluence/display/JFROG/Artifactory+YAML+Configuration
 */
 func SendConfigurationPatch(content []byte, m interface{}) error {
-	_, err := m.(*resty.Client).R().SetBody(content).
+	_, err := m.(util.ProvderMetadata).Client.R().SetBody(content).
 		SetHeader("Content-Type", "application/yaml").
 		AddRetryCondition(client.RetryOnMergeError).
 		Patch("artifactory/api/system/configuration")

--- a/pkg/artifactory/resource/configuration/resource_artifactory_backup.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_backup.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-shared/packer"
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
@@ -124,7 +124,7 @@ func ResourceArtifactoryBackup() *schema.Resource {
 		key := data.GetString("key", false)
 
 		backups := Backups{}
-		_, err := m.(*resty.Client).R().SetResult(&backups).Get("artifactory/api/system/configuration")
+		_, err := m.(util.ProvderMetadata).Client.R().SetResult(&backups).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}

--- a/pkg/artifactory/resource/configuration/resource_artifactory_backup_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_backup_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
@@ -178,7 +177,7 @@ func cronTestCase(cronExpression string, t *testing.T) (*testing.T, resource.Tes
 
 func testAccBackupDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		_, ok := s.RootModule().Resources["artifactory_backup."+id]
 		if !ok {

--- a/pkg/artifactory/resource/configuration/resource_artifactory_general_security.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_general_security.go
@@ -3,9 +3,9 @@ package configuration
 import (
 	"context"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 	"gopkg.in/yaml.v3"
 )
@@ -40,7 +40,7 @@ func ResourceArtifactoryGeneralSecurity() *schema.Resource {
 }
 
 func resourceGeneralSecurityRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*resty.Client)
+	c := m.(util.ProvderMetadata).Client
 
 	generalSettings := GeneralSettings{}
 

--- a/pkg/artifactory/resource/configuration/resource_artifactory_general_security_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_general_security_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/configuration"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 const GeneralSecurityTemplateFull = `
@@ -41,7 +41,7 @@ func TestAccGeneralSecurity_full(t *testing.T) {
 
 func testAccGeneralSecurityDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		_, ok := s.RootModule().Resources[id]
 		if !ok {

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting.go
@@ -3,14 +3,15 @@ package configuration
 import (
 	"context"
 	"encoding/xml"
+
 	"github.com/jfrog/terraform-provider-shared/packer"
 
-	"github.com/go-resty/resty/v2"
 	"gopkg.in/yaml.v3"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
@@ -111,7 +112,7 @@ Hierarchy: The user's DN is indicative of the groups the user belongs to by usin
 		name := data.GetString("name", false)
 
 		ldapGroupConfigs := XmlLdapGroupConfig{}
-		_, err := m.(*resty.Client).R().SetResult(&ldapGroupConfigs).Get("artifactory/api/system/configuration")
+		_, err := m.(util.ProvderMetadata).Client.R().SetResult(&ldapGroupConfigs).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}
@@ -161,7 +162,7 @@ Hierarchy: The user's DN is indicative of the groups the user belongs to by usin
 
 		rsrcLdapGroupSetting := unpackLdapGroupSetting(d)
 
-		response, err := m.(*resty.Client).R().SetResult(&ldapGroupConfigs).Get("artifactory/api/system/configuration")
+		response, err := m.(util.ProvderMetadata).Client.R().SetResult(&ldapGroupConfigs).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_test.go
@@ -5,11 +5,11 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/configuration"
+	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
@@ -109,7 +109,7 @@ func TestAccLdapGroupSetting_importNotFound(t *testing.T) {
 
 func testAccLdapGroupSettingDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		_, ok := s.RootModule().Resources["artifactory_ldap_group_setting."+id]
 		if !ok {

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting.go
@@ -3,15 +3,16 @@ package configuration
 import (
 	"context"
 	"encoding/xml"
+
 	"github.com/jfrog/terraform-provider-shared/packer"
 	"github.com/jfrog/terraform-provider-shared/predicate"
 
-	"github.com/go-resty/resty/v2"
 	"gopkg.in/yaml.v3"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
@@ -157,7 +158,7 @@ func ResourceArtifactoryLdapSetting() *schema.Resource {
 		key := data.GetString("key", false)
 
 		ldapConfigs := XmlLdapConfig{}
-		_, err := m.(*resty.Client).R().SetResult(&ldapConfigs).Get("artifactory/api/system/configuration")
+		_, err := m.(util.ProvderMetadata).Client.R().SetResult(&ldapConfigs).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}
@@ -212,7 +213,7 @@ func ResourceArtifactoryLdapSetting() *schema.Resource {
 
 		rsrcLdapSetting := unpackLdapSetting(d)
 
-		response, err := m.(*resty.Client).R().SetResult(&ldapConfigs).Get("artifactory/api/system/configuration")
+		response, err := m.(util.ProvderMetadata).Client.R().SetResult(&ldapConfigs).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting_test.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
+	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
@@ -272,7 +272,7 @@ resource "artifactory_ldap_setting" "ldaptestuserdnsearchfilter" {
 
 func testAccLdapSettingDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		_, ok := s.RootModule().Resources["artifactory_ldap_setting."+id]
 		if !ok {

--- a/pkg/artifactory/resource/configuration/resource_artifactory_oauth_settings.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_oauth_settings.go
@@ -3,9 +3,9 @@ package configuration
 import (
 	"context"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 	"gopkg.in/yaml.v3"
 )
@@ -191,7 +191,7 @@ func ResourceArtifactoryOauthSettings() *schema.Resource {
 	}
 
 	var resourceOauthSettingsRead = func(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-		c := m.(*resty.Client)
+		c := m.(util.ProvderMetadata).Client
 
 		oauthSettings := OauthSettings{}
 

--- a/pkg/artifactory/resource/configuration/resource_artifactory_oauth_settings_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_oauth_settings_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/configuration"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 const OauthSettingsTemplateFull = `
@@ -115,7 +115,7 @@ func TestAccOauthSettings_multipleProviders(t *testing.T) {
 
 func testAccOauthSettingsDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		_, ok := s.RootModule().Resources[id]
 		if !ok {

--- a/pkg/artifactory/resource/configuration/resource_artifactory_property_set.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_property_set.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
 	"gopkg.in/yaml.v3"
@@ -203,7 +203,7 @@ func ResourceArtifactoryPropertySet() *schema.Resource {
 
 		propertySetConfigs := PropertySets{}
 
-		_, err := m.(*resty.Client).R().SetResult(&propertySetConfigs).Get("artifactory/api/system/configuration")
+		_, err := m.(util.ProvderMetadata).Client.R().SetResult(&propertySetConfigs).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}
@@ -276,7 +276,7 @@ func ResourceArtifactoryPropertySet() *schema.Resource {
 	var resourcePropertySetDelete = func(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		propertySetConfigs := &PropertySets{}
 
-		response, err := m.(*resty.Client).R().SetResult(&propertySetConfigs).Get("artifactory/api/system/configuration")
+		response, err := m.(util.ProvderMetadata).Client.R().SetResult(&propertySetConfigs).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}

--- a/pkg/artifactory/resource/configuration/resource_artifactory_property_set_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_property_set_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
@@ -182,7 +181,7 @@ func verifyPropertySetUpdate(fqrn string, testData map[string]string) resource.T
 
 func testAccPropertySetDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		_, ok := s.RootModule().Resources["artifactory_property_set."+id]
 		if !ok {

--- a/pkg/artifactory/resource/configuration/resource_artifactory_proxy.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_proxy.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
 	"gopkg.in/yaml.v3"
@@ -162,7 +162,7 @@ func ResourceArtifactoryProxy() *schema.Resource {
 		key := data.GetString("key", false)
 
 		proxiesConfig := Proxies{}
-		_, err := m.(*resty.Client).R().SetResult(&proxiesConfig).Get("artifactory/api/system/configuration")
+		_, err := m.(util.ProvderMetadata).Client.R().SetResult(&proxiesConfig).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}
@@ -208,7 +208,7 @@ func ResourceArtifactoryProxy() *schema.Resource {
 	var resourceProxyDelete = func(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 		proxiesConfig := &Proxies{}
 
-		response, err := m.(*resty.Client).R().SetResult(&proxiesConfig).Get("artifactory/api/system/configuration")
+		response, err := m.(util.ProvderMetadata).Client.R().SetResult(&proxiesConfig).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}

--- a/pkg/artifactory/resource/configuration/resource_artifactory_proxy_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_proxy_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
@@ -199,7 +198,7 @@ func verifyProxy(fqrn string, testData map[string]string) resource.TestCheckFunc
 
 func testAccProxyDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		_, ok := s.RootModule().Resources["artifactory_proxy."+id]
 		if !ok {

--- a/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-shared/packer"
 	"github.com/jfrog/terraform-provider-shared/util"
 	"gopkg.in/yaml.v3"
@@ -88,7 +88,7 @@ func ResourceArtifactoryRepositoryLayout() *schema.Resource {
 		name := data.GetString("name", false)
 
 		layouts := Layouts{}
-		_, err := m.(*resty.Client).R().SetResult(&layouts).Get("artifactory/api/system/configuration")
+		_, err := m.(util.ProvderMetadata).Client.R().SetResult(&layouts).Get("artifactory/api/system/configuration")
 		if err != nil {
 			return diag.Errorf("failed to retrieve data from API: /artifactory/api/system/configuration during Read")
 		}

--- a/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout_test.go
@@ -5,7 +5,6 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
@@ -106,7 +105,7 @@ func TestAccLayout_importNotFound(t *testing.T) {
 
 func testAccLayoutDestroy(name string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		_, ok := s.RootModule().Resources["artifactory_repository_layout."+name]
 		if !ok {

--- a/pkg/artifactory/resource/configuration/resource_artifactory_saml_settings.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_saml_settings.go
@@ -3,10 +3,10 @@ package configuration
 import (
 	"context"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 	"gopkg.in/yaml.v3"
 )
@@ -127,7 +127,7 @@ func ResourceArtifactorySamlSettings() *schema.Resource {
 }
 
 func resourceSamlSettingsRead(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*resty.Client)
+	c := m.(util.ProvderMetadata).Client
 
 	samlSettings := SamlSettings{}
 

--- a/pkg/artifactory/resource/configuration/resource_artifactory_saml_settings_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_saml_settings_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/configuration"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 const SamlSettingsTemplateFull = `
@@ -65,7 +65,7 @@ func TestAccSamlSettings_full(t *testing.T) {
 
 func testAccSamlSettingsDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		c := acctest.Provider.Meta().(*resty.Client)
+		c := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		_, ok := s.RootModule().Resources[id]
 		if !ok {

--- a/pkg/artifactory/resource/replication/replication.go
+++ b/pkg/artifactory/resource/replication/replication.go
@@ -5,10 +5,11 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-shared/client"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 const EndpointPath = "artifactory/api/replications/"
@@ -23,7 +24,7 @@ var replicationSchemaEnableEventReplication = map[string]*schema.Schema{
 }
 
 func resourceReplicationDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	resp, err := m.(*resty.Client).R().
+	resp, err := m.(util.ProvderMetadata).Client.R().
 		AddRetryCondition(client.RetryOnMergeError).
 		Delete(EndpointPath + d.Id())
 	if err != nil && (resp != nil && (resp.StatusCode() == http.StatusBadRequest || resp.StatusCode() == http.StatusNotFound)) {
@@ -39,7 +40,7 @@ type repoConfiguration struct {
 
 func getRepositoryRclass(repoKey string, m interface{}) (string, error) {
 	repoConfig := repoConfiguration{}
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetResult(&repoConfig).
 		Get("artifactory/api/repositories/" + repoKey)
 	if err != nil {

--- a/pkg/artifactory/resource/replication/replication_test.go
+++ b/pkg/artifactory/resource/replication/replication_test.go
@@ -3,14 +3,15 @@ package replication_test
 import (
 	"fmt"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
+	"github.com/jfrog/terraform-provider-shared/util"
+
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/replication"
 )
 
 func repConfigExists(id string, m interface{}) (bool, error) {
-	_, err := m.(*resty.Client).R().Head(replication.EndpointPath + id)
+	_, err := m.(util.ProvderMetadata).Client.R().Head(replication.EndpointPath + id)
 	return err == nil, err
 }
 

--- a/pkg/artifactory/resource/replication/resource_artifactory_local_repository_multi_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_local_repository_multi_replication.go
@@ -5,10 +5,10 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/util"
@@ -312,7 +312,7 @@ func resourceLocalMultiReplicationCreate(ctx context.Context, d *schema.Resource
 	if verified, err := verifyRepoRclass(pushReplication.RepoKey, "local", m); !verified {
 		return diag.Errorf("source repository rclass is not local, only remote repositories are supported by this resource %v", err)
 	}
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(pushReplication).
 		Put(EndpointPath + "multiple/" + pushReplication.RepoKey)
 	if err != nil {
@@ -324,7 +324,7 @@ func resourceLocalMultiReplicationCreate(ctx context.Context, d *schema.Resource
 }
 
 func resourceLocalMultiReplicationRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*resty.Client)
+	c := m.(util.ProvderMetadata).Client
 	var replications []getLocalMultiReplicationBody
 	resp, err := c.R().SetResult(&replications).Get(EndpointPath + d.Id())
 
@@ -353,7 +353,7 @@ func resourceLocalMultiReplicationUpdate(ctx context.Context, d *schema.Resource
 	if verified, err := verifyRepoRclass(pushReplication.RepoKey, "local", m); !verified {
 		return diag.Errorf("source repository rclass is not local, only remote repositories are supported by this resource %v", err)
 	}
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(pushReplication).
 		AddRetryCondition(client.RetryOnMergeError).
 		Post(EndpointPath + "multiple/" + d.Id())

--- a/pkg/artifactory/resource/replication/resource_artifactory_local_repository_multi_replication_test.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_local_repository_multi_replication_test.go
@@ -12,23 +12,29 @@ import (
 )
 
 func TestAccLocalMultiReplicationInvalidPushCronFails(t *testing.T) {
-	const invalidCron = `
-		resource "artifactory_local_maven_repository" "lib-local" {
-			key = "lib-local"
+	_, _, name := test.MkNames("lib-local", "artifactory_local_repository_multi_replication")
+	params := map[string]interface{}{
+		"repo_name": name,
+	}
+	invalidCron := util.ExecuteTemplate(
+		"TestAccLocalMultiReplicationInvalidPushCronFails",
+		`resource "artifactory_local_maven_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
 		}
 
-		resource "artifactory_local_repository_multi_replication" "lib-local" {
-			repo_key = "${artifactory_local_maven_repository.lib-local.key}"
+		resource "artifactory_local_repository_multi_replication" "{{ .repo_name }}" {
+			repo_key = "${artifactory_local_maven_repository.{{ .repo_name }}.key}"
 			cron_exp = "0 0 blah foo boo ?"
 			enable_event_replication = true
 
 			replication {
 				url = "http://localhost:8080"
-				username = "%s"
-				password = "%s"
+				username = "test-user"
+				password = "test-password"
 			}
-		}
-	`
+		}`,
+		params)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,
@@ -42,23 +48,30 @@ func TestAccLocalMultiReplicationInvalidPushCronFails(t *testing.T) {
 }
 
 func TestAccLocalMultiReplicationInvalidUrlFails(t *testing.T) {
-	const invalidUrl = `
-		resource "artifactory_local_maven_repository" "lib-local" {
-			key = "lib-local"
+	_, _, name := test.MkNames("lib-local", "artifactory_local_repository_multi_replication")
+	params := map[string]interface{}{
+		"repo_name": name,
+	}
+	invalidUrl := util.ExecuteTemplate(
+		"TestAccLocalMultiReplicationInvalidUrlFails",
+		`resource "artifactory_local_maven_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
 		}
 
-		resource "artifactory_local_repository_multi_replication" "lib-local" {
-			repo_key = "${artifactory_local_maven_repository.lib-local.key}"
-			cron_exp = "0 0 * * * ?"
+		resource "artifactory_local_repository_multi_replication" "{{ .repo_name }}" {
+			repo_key = "${artifactory_local_maven_repository.{{ .repo_name }}.key}"
+			cron_exp = "0 0 blah foo boo ?"
 			enable_event_replication = true
 
 			replication {
 				url = "not a URL"
-				username = "%s"
-				password = "Passw0rd!"
+				username = "test-user"
+				password = "test-password"
 			}
-		}
-	`
+		}`,
+		params,
+	)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,

--- a/pkg/artifactory/resource/replication/resource_artifactory_local_repository_single_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_local_repository_single_replication.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/util"
 )
@@ -203,7 +203,7 @@ func resourceLocalSingleReplicationCreate(ctx context.Context, d *schema.Resourc
 	if verified, err := verifyRepoRclass(pushReplication.RepoKey, "local", m); !verified {
 		return diag.Errorf("source repository rclass is not local, only remote repositories are supported by this resource %v", err)
 	}
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(pushReplication).
 		Put(EndpointPath + pushReplication.RepoKey)
 	if err != nil {
@@ -215,7 +215,7 @@ func resourceLocalSingleReplicationCreate(ctx context.Context, d *schema.Resourc
 }
 
 func resourceLocalSingleReplicationRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*resty.Client)
+	c := m.(util.ProvderMetadata).Client
 
 	var replication []getLocalSingleReplicationBody
 
@@ -241,7 +241,7 @@ func resourceLocalSingleReplicationUpdate(ctx context.Context, d *schema.Resourc
 	if verified, err := verifyRepoRclass(pushReplication.RepoKey, "local", m); !verified {
 		return diag.Errorf("source repository rclass is not local, only remote repositories are supported by this resource %v", err)
 	}
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(pushReplication).
 		AddRetryCondition(client.RetryOnMergeError).
 		Post(EndpointPath + d.Id())

--- a/pkg/artifactory/resource/replication/resource_artifactory_pull_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_pull_replication.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"encoding/json"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/util"
 )
@@ -159,7 +159,7 @@ func packPullReplication(config PullReplication, d *schema.ResourceData) diag.Di
 func resourcePullReplicationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	replicationConfig := unpackPullReplication(d)
 	// The password is sent clear
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(replicationConfig).
 		AddRetryCondition(client.RetryOnMergeError).
 		Put(EndpointPath + replicationConfig.RepoKey)
@@ -174,7 +174,7 @@ func resourcePullReplicationCreate(ctx context.Context, d *schema.ResourceData, 
 func resourcePullReplicationRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var result interface{}
 
-	resp, err := m.(*resty.Client).R().SetResult(&result).Get(EndpointPath + d.Id())
+	resp, err := m.(util.ProvderMetadata).Client.R().SetResult(&result).Get(EndpointPath + d.Id())
 	// password comes back scrambled
 	if err != nil {
 		return diag.FromErr(err)
@@ -203,7 +203,7 @@ func resourcePullReplicationRead(_ context.Context, d *schema.ResourceData, m in
 
 func resourcePullReplicationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	replicationConfig := unpackPullReplication(d)
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(replicationConfig).
 		AddRetryCondition(client.RetryOnMergeError).
 		Post(EndpointPath + replicationConfig.RepoKey)

--- a/pkg/artifactory/resource/replication/resource_artifactory_push_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_push_replication.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/util"
@@ -277,7 +277,7 @@ func packPushReplication(pushReplication *GetPushReplication, d *schema.Resource
 func resourcePushReplicationCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	pushReplication := unpackPushReplication(d)
 
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(pushReplication).
 		Put(EndpointPath + "multiple/" + pushReplication.RepoKey)
 	if err != nil {
@@ -289,7 +289,7 @@ func resourcePushReplicationCreate(ctx context.Context, d *schema.ResourceData, 
 }
 
 func resourcePushReplicationRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*resty.Client)
+	c := m.(util.ProvderMetadata).Client
 	var replications []getReplicationBody
 	_, err := c.R().SetResult(&replications).Get(EndpointPath + d.Id())
 
@@ -311,7 +311,7 @@ func resourcePushReplicationRead(_ context.Context, d *schema.ResourceData, m in
 func resourcePushReplicationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	pushReplication := unpackPushReplication(d)
 
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(pushReplication).
 		AddRetryCondition(client.RetryOnMergeError).
 		Post(EndpointPath + "multiple/" + d.Id())

--- a/pkg/artifactory/resource/replication/resource_artifactory_remote_repository_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_remote_repository_replication.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/util"
 )
@@ -143,7 +143,7 @@ func resourceRemoteReplicationCreate(ctx context.Context, d *schema.ResourceData
 	if verified, err := verifyRepoRclass(pushReplication.RepoKey, "remote", m); !verified {
 		return diag.Errorf("source repository rclass is not remote or can't be verified, only remote repositories are supported by this resource: %v", err)
 	}
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(pushReplication).
 		Put(EndpointPath + pushReplication.RepoKey)
 	if err != nil {
@@ -155,7 +155,7 @@ func resourceRemoteReplicationCreate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceRemoteReplicationRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*resty.Client)
+	c := m.(util.ProvderMetadata).Client
 
 	var replication getRemoteReplicationBody
 
@@ -178,7 +178,7 @@ func resourceRemoteReplicationUpdate(ctx context.Context, d *schema.ResourceData
 	if verified, err := verifyRepoRclass(pushReplication.RepoKey, "remote", m); !verified {
 		return diag.Errorf("source repository rclass is not remote or can't be verified, only remote repositories are supported by this resource: %v", err)
 	}
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(pushReplication).
 		AddRetryCondition(client.RetryOnMergeError).
 		Post(EndpointPath + d.Id())

--- a/pkg/artifactory/resource/replication/resource_artifactory_replication_config.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_replication_config.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
@@ -237,7 +237,7 @@ func packReplicationConfig(replicationConfig *GetReplicationConfig, d *schema.Re
 func resourceReplicationConfigCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	replicationConfig := unpackReplicationConfig(d)
 
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(replicationConfig).
 		Put(EndpointPath + "multiple/" + replicationConfig.RepoKey)
 	if err != nil {
@@ -249,7 +249,7 @@ func resourceReplicationConfigCreate(ctx context.Context, d *schema.ResourceData
 }
 
 func resourceReplicationConfigRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	c := m.(*resty.Client)
+	c := m.(util.ProvderMetadata).Client
 	var replications []getReplicationBody
 	_, err := c.R().SetResult(&replications).Get(EndpointPath + d.Id())
 
@@ -271,7 +271,7 @@ func resourceReplicationConfigRead(_ context.Context, d *schema.ResourceData, m 
 func resourceReplicationConfigUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	replicationConfig := unpackReplicationConfig(d)
 
-	_, err := m.(*resty.Client).R().SetBody(replicationConfig).Post(EndpointPath + d.Id())
+	_, err := m.(util.ProvderMetadata).Client.R().SetBody(replicationConfig).Post(EndpointPath + d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/artifactory/resource/replication/resource_artifactory_single_replication_config.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_single_replication_config.go
@@ -5,9 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/util"
@@ -105,7 +105,7 @@ func packPullReplicationBody(config PullReplication, d *schema.ResourceData) dia
 func resourceSingleReplicationConfigCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	replicationConfig := unpackSingleReplicationConfig(d)
 	// The password is sent clear
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(replicationConfig).
 		AddRetryCondition(client.RetryOnMergeError).
 		Put(EndpointPath + replicationConfig.RepoKey)
@@ -126,7 +126,7 @@ func resourceSingleReplicationConfigRead(_ context.Context, d *schema.ResourceDa
 	// an entirely different resource because values like "url" are never available after submit.
 	var result interface{}
 
-	resp, err := m.(*resty.Client).R().SetResult(&result).Get(EndpointPath + d.Id())
+	resp, err := m.(util.ProvderMetadata).Client.R().SetResult(&result).Get(EndpointPath + d.Id())
 	// password comes back scrambled
 	if err != nil {
 		if resp != nil && (resp.StatusCode() == http.StatusBadRequest || resp.StatusCode() == http.StatusNotFound) {
@@ -159,7 +159,7 @@ func resourceSingleReplicationConfigRead(_ context.Context, d *schema.ResourceDa
 
 func resourceSingleReplicationConfigUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	replicationConfig := unpackSingleReplicationConfig(d)
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		SetBody(replicationConfig).
 		AddRetryCondition(client.RetryOnMergeError).
 		Post(EndpointPath + replicationConfig.RepoKey)

--- a/pkg/artifactory/resource/repository/local/local.go
+++ b/pkg/artifactory/resource/repository/local/local.go
@@ -6,7 +6,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/util"
-	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
 const rclass = "local"
@@ -59,107 +58,64 @@ func (bp RepositoryBaseParams) Id() string {
 	return bp.Key
 }
 
-var BaseLocalRepoSchema = map[string]*schema.Schema{
-	"key": {
-		Type:         schema.TypeString,
-		Required:     true,
-		ForceNew:     true,
-		ValidateFunc: repository.RepoKeyValidator,
-		Description:  "A mandatory identifier for the repository that must be unique. Must be 3 - 10 lowercase alphanumeric and hyphen characters. It cannot begin with a number or contain spaces or special characters.",
+var BaseLocalRepoSchema = util.MergeMaps(
+	repository.BaseRepoSchema,
+	map[string]*schema.Schema{
+		"includes_pattern": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "List of artifact patterns to include when evaluating artifact requests in the form of x/y/**/z/*. When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included (**/*).",
+		},
+		"excludes_pattern": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Computed:    true,
+			Description: "List of artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*. By default no artifacts are excluded.",
+		},
+		"blacked_out": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "When set, the repository does not participate in artifact resolution and new artifacts cannot be deployed.",
+		},
+		"xray_index": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Enable Indexing In Xray. Repository will be indexed with the default retention period. You will be able to change it via Xray settings.",
+		},
+		"priority_resolution": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Setting repositories with priority will cause metadata to be merged only from repositories set with this field",
+		},
+		"property_sets": {
+			Type:        schema.TypeSet,
+			Elem:        &schema.Schema{Type: schema.TypeString},
+			Set:         schema.HashString,
+			Optional:    true,
+			Description: "List of property set name",
+		},
+		"archive_browsing_enabled": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "When set, you may view content such as HTML or Javadoc files directly from Artifactory.\nThis may not be safe and therefore requires strict content moderation to prevent malicious users from uploading content that may compromise security (e.g., cross-site scripting attacks).",
+		},
+		"download_direct": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Description: "When set, download requests to this repository will redirect the client to download the artifact directly from the cloud storage provider. Available in Enterprise+ and Edge licenses only.",
+		},
+		"cdn_redirect": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "When set, download requests to this repository will redirect the client to download the artifact directly from AWS CloudFront. Available in Enterprise+ and Edge licenses only. Default value is 'false'",
+		},
 	},
-	"project_key": {
-		Type:             schema.TypeString,
-		Optional:         true,
-		Default:          "default",
-		ValidateDiagFunc: validator.ProjectKey,
-		Description:      "Project key for assigning this repository to. Must be 2 - 20 lowercase alphanumeric and hyphen characters. When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.",
-	},
-	"project_environments": {
-		Type:     schema.TypeSet,
-		Elem:     &schema.Schema{Type: schema.TypeString},
-		MinItems: 1,
-		MaxItems: 2,
-		Set:      schema.HashString,
-		Optional: true,
-		Computed: true,
-		Description: "Project environment for assigning this repository to. Allow values: \"DEV\" or \"PROD\". " +
-			"The attribute should only be used if the repository is already assigned to the existing project. If not, " +
-			"the attribute will be ignored by Artifactory, but will remain in the Terraform state, which will create " +
-			"state drift during the update.",
-	},
-	"package_type": {
-		Type:     schema.TypeString,
-		Required: false,
-		Computed: true,
-		ForceNew: true,
-	},
-	"description": {
-		Type:     schema.TypeString,
-		Optional: true,
-	},
-	"notes": {
-		Type:     schema.TypeString,
-		Optional: true,
-	},
-	"includes_pattern": {
-		Type:     schema.TypeString,
-		Optional: true,
-		Computed: true, Description: "List of artifact patterns to include when evaluating artifact requests in the form of x/y/**/z/*. When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included (**/*).",
-	},
-	"excludes_pattern": {
-		Type:        schema.TypeString,
-		Optional:    true,
-		Computed:    true,
-		Description: "List of artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*. By default no artifacts are excluded.",
-	},
-	"repo_layout_ref": {
-		Type:             schema.TypeString,
-		Optional:         true,
-		ValidateDiagFunc: repository.ValidateRepoLayoutRefSchemaOverride,
-		Description:      "Sets the layout that the repository should use for storing and identifying modules. A recommended layout that corresponds to the package type defined is suggested, and index packages uploaded and calculate metadata accordingly.",
-	},
-	"blacked_out": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Default:     false,
-		Description: "When set, the repository does not participate in artifact resolution and new artifacts cannot be deployed.",
-	},
-	"xray_index": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Default:     false,
-		Description: "Enable Indexing In Xray. Repository will be indexed with the default retention period. You will be able to change it via Xray settings.",
-	},
-	"priority_resolution": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Default:     false,
-		Description: "Setting repositories with priority will cause metadata to be merged only from repositories set with this field",
-	},
-	"property_sets": {
-		Type:        schema.TypeSet,
-		Elem:        &schema.Schema{Type: schema.TypeString},
-		Set:         schema.HashString,
-		Optional:    true,
-		Description: "List of property set name",
-	},
-	"archive_browsing_enabled": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When set, you may view content such as HTML or Javadoc files directly from Artifactory.\nThis may not be safe and therefore requires strict content moderation to prevent malicious users from uploading content that may compromise security (e.g., cross-site scripting attacks).",
-	},
-	"download_direct": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Description: "When set, download requests to this repository will redirect the client to download the artifact directly from the cloud storage provider. Available in Enterprise+ and Edge licenses only.",
-	},
-	"cdn_redirect": {
-		Type:        schema.TypeBool,
-		Optional:    true,
-		Default:     false,
-		Description: "When set, download requests to this repository will redirect the client to download the artifact directly from AWS CloudFront. Available in Enterprise+ and Edge licenses only. Default value is 'false'",
-	},
-}
+)
 
 // GetPackageType `packageType` in the API call payload for Terraform repositories must be "terraform", but we use
 // `terraform_module` and `terraform_provider` as a package types in the Provider. GetPackageType function corrects this discrepancy.

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_alpine_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_alpine_repository.go
@@ -7,6 +7,8 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
+const alpinePackageType = "alpine"
+
 var AlpineLocalSchema = util.MergeMaps(
 	BaseLocalRepoSchema,
 	map[string]*schema.Schema{
@@ -17,7 +19,7 @@ var AlpineLocalSchema = util.MergeMaps(
 				"See: https://www.jfrog.com/confluence/display/JFROG/Alpine+Linux+Repositories#AlpineLinuxRepositories-SigningAlpineLinuxIndex",
 		},
 	},
-	repository.RepoLayoutRefSchema("local", "alpine"),
+	repository.RepoLayoutRefSchema(rclass, alpinePackageType),
 	repository.CompressionFormats,
 )
 
@@ -29,7 +31,7 @@ type AlpineLocalRepoParams struct {
 func UnpackLocalAlpineRepository(data *schema.ResourceData, rclass string) AlpineLocalRepoParams {
 	d := &util.ResourceData{ResourceData: data}
 	return AlpineLocalRepoParams{
-		RepositoryBaseParams: UnpackBaseRepo(rclass, data, "alpine"),
+		RepositoryBaseParams: UnpackBaseRepo(rclass, data, alpinePackageType),
 		PrimaryKeyPairRef:    d.GetString("primary_keypair_ref", false),
 	}
 }
@@ -43,7 +45,7 @@ func ResourceArtifactoryLocalAlpineRepository() *schema.Resource {
 	constructor := func() (interface{}, error) {
 		return &AlpineLocalRepoParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				PackageType: "alpine",
+				PackageType: alpinePackageType,
 				Rclass:      rclass,
 			},
 		}, nil

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_cargo_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_cargo_repository.go
@@ -7,6 +7,8 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
+const cargoPackageType = "cargo"
+
 var CargoLocalSchema = util.MergeMaps(
 	BaseLocalRepoSchema,
 	map[string]*schema.Schema{
@@ -23,7 +25,7 @@ var CargoLocalSchema = util.MergeMaps(
 			Description: "Enable internal index support based on Cargo sparse index specifications, instead of the default git index. Default value is 'false'.",
 		},
 	},
-	repository.RepoLayoutRefSchema("local", "cargo"),
+	repository.RepoLayoutRefSchema(rclass, cargoPackageType),
 	repository.CompressionFormats,
 )
 
@@ -36,7 +38,7 @@ type CargoLocalRepoParams struct {
 func UnpackLocalCargoRepository(data *schema.ResourceData, rclass string) CargoLocalRepoParams {
 	d := &util.ResourceData{ResourceData: data}
 	return CargoLocalRepoParams{
-		RepositoryBaseParams: UnpackBaseRepo(rclass, data, "cargo"),
+		RepositoryBaseParams: UnpackBaseRepo(rclass, data, cargoPackageType),
 		AnonymousAccess:      d.GetBool("anonymous_access", false),
 		EnableSparseIndex:    d.GetBool("enable_sparse_index", false),
 	}
@@ -52,8 +54,8 @@ func ResourceArtifactoryLocalCargoRepository() *schema.Resource {
 	constructor := func() (interface{}, error) {
 		return &CargoLocalRepoParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				PackageType: "cargo",
-				Rclass:      "local",
+				PackageType: cargoPackageType,
+				Rclass:      rclass,
 			},
 		}, nil
 	}

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_debian_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_debian_repository.go
@@ -7,6 +7,8 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
+const debianPackageType = "debian"
+
 var DebianLocalSchema = util.MergeMaps(
 	BaseLocalRepoSchema,
 	map[string]*schema.Schema{
@@ -28,7 +30,7 @@ var DebianLocalSchema = util.MergeMaps(
 			Deprecated:  "You shouldn't be using this",
 		},
 	},
-	repository.RepoLayoutRefSchema("local", "debian"),
+	repository.RepoLayoutRefSchema(rclass, debianPackageType),
 	repository.CompressionFormats,
 )
 
@@ -43,7 +45,7 @@ type DebianLocalRepositoryParams struct {
 func UnpackLocalDebianRepository(data *schema.ResourceData, rclass string) DebianLocalRepositoryParams {
 	d := &util.ResourceData{ResourceData: data}
 	return DebianLocalRepositoryParams{
-		RepositoryBaseParams:    UnpackBaseRepo(rclass, data, "debian"),
+		RepositoryBaseParams:    UnpackBaseRepo(rclass, data, debianPackageType),
 		PrimaryKeyPairRef:       d.GetString("primary_keypair_ref", false),
 		SecondaryKeyPairRef:     d.GetString("secondary_keypair_ref", false),
 		TrivialLayout:           d.GetBool("trivial_layout", false),
@@ -61,8 +63,8 @@ func ResourceArtifactoryLocalDebianRepository() *schema.Resource {
 	constructor := func() (interface{}, error) {
 		return &DebianLocalRepositoryParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				PackageType: "debian",
-				Rclass:      "local",
+				PackageType: debianPackageType,
+				Rclass:      rclass,
 			},
 		}, nil
 	}

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_docker_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_docker_repository.go
@@ -8,7 +8,7 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-const packageType = "docker"
+const dockerPackageType = "docker"
 
 type DockerLocalRepositoryParams struct {
 	RepositoryBaseParams
@@ -55,7 +55,7 @@ var DockerV2LocalSchema = util.MergeMaps(
 func UnpackLocalDockerV2Repository(data *schema.ResourceData, rclass string) DockerLocalRepositoryParams {
 	d := &util.ResourceData{ResourceData: data}
 	return DockerLocalRepositoryParams{
-		RepositoryBaseParams: UnpackBaseRepo(rclass, data, packageType),
+		RepositoryBaseParams: UnpackBaseRepo(rclass, data, dockerPackageType),
 		MaxUniqueTags:        d.GetInt("max_unique_tags", false),
 		DockerApiVersion:     "V2",
 		TagRetention:         d.GetInt("tag_retention", false),
@@ -74,7 +74,7 @@ func ResourceArtifactoryLocalDockerV2Repository() *schema.Resource {
 	constructor := func() (interface{}, error) {
 		return &DockerLocalRepositoryParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				PackageType: packageType,
+				PackageType: dockerPackageType,
 				Rclass:      rclass,
 			},
 			DockerApiVersion:    "V2",
@@ -108,12 +108,12 @@ var DockerV1LocalSchema = util.MergeMaps(
 			Computed: true,
 		},
 	},
-	repository.RepoLayoutRefSchema("local", "docker"),
+	repository.RepoLayoutRefSchema(rclass, "docker"),
 )
 
 func UnpackLocalDockerV1Repository(data *schema.ResourceData, rclass string) DockerLocalRepositoryParams {
 	return DockerLocalRepositoryParams{
-		RepositoryBaseParams: UnpackBaseRepo(rclass, data, packageType),
+		RepositoryBaseParams: UnpackBaseRepo(rclass, data, dockerPackageType),
 		DockerApiVersion:     "V1",
 		MaxUniqueTags:        0,
 		TagRetention:         1,
@@ -133,7 +133,7 @@ func ResourceArtifactoryLocalDockerV1Repository() *schema.Resource {
 	constructor := func() (interface{}, error) {
 		return &DockerLocalRepositoryParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				PackageType: packageType,
+				PackageType: dockerPackageType,
 				Rclass:      rclass,
 			},
 			DockerApiVersion:    "V1",

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_docker_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_docker_repository.go
@@ -49,7 +49,7 @@ var DockerV2LocalSchema = util.MergeMaps(
 			Description: "The Docker API version to use. This cannot be set",
 		},
 	},
-	repository.RepoLayoutRefSchema("local", "docker"),
+	repository.RepoLayoutRefSchema(rclass, dockerPackageType),
 )
 
 func UnpackLocalDockerV2Repository(data *schema.ResourceData, rclass string) DockerLocalRepositoryParams {
@@ -108,7 +108,7 @@ var DockerV1LocalSchema = util.MergeMaps(
 			Computed: true,
 		},
 	},
-	repository.RepoLayoutRefSchema(rclass, "docker"),
+	repository.RepoLayoutRefSchema(rclass, dockerPackageType),
 )
 
 func UnpackLocalDockerV1Repository(data *schema.ResourceData, rclass string) DockerLocalRepositoryParams {

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_java_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_java_repository.go
@@ -9,7 +9,7 @@ import (
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
-func GetJavaRepoSchema(repoType string, suppressPom bool) map[string]*schema.Schema {
+func GetJavaRepoSchema(packageType string, suppressPom bool) map[string]*schema.Schema {
 	return util.MergeMaps(
 		BaseLocalRepoSchema,
 		map[string]*schema.Schema{
@@ -65,7 +65,7 @@ func GetJavaRepoSchema(repoType string, suppressPom bool) map[string]*schema.Sch
 					"behavior by setting the Suppress POM Consistency Checks checkbox.",
 			},
 		},
-		repository.RepoLayoutRefSchema("local", repoType),
+		repository.RepoLayoutRefSchema(rclass, packageType),
 	)
 }
 
@@ -79,10 +79,10 @@ type JavaLocalRepositoryParams struct {
 	SuppressPomConsistencyChecks bool   `hcl:"suppress_pom_consistency_checks" json:"suppressPomConsistencyChecks"`
 }
 
-var UnpackLocalJavaRepository = func(data *schema.ResourceData, rclass string, repoType string) JavaLocalRepositoryParams {
+var UnpackLocalJavaRepository = func(data *schema.ResourceData, rclass string, packageType string) JavaLocalRepositoryParams {
 	d := &util.ResourceData{ResourceData: data}
 	return JavaLocalRepositoryParams{
-		RepositoryBaseParams:         UnpackBaseRepo(rclass, data, repoType),
+		RepositoryBaseParams:         UnpackBaseRepo(rclass, data, packageType),
 		ChecksumPolicyType:           d.GetString("checksum_policy_type", false),
 		SnapshotVersionBehavior:      d.GetString("snapshot_version_behavior", false),
 		MaxUniqueSnapshots:           d.GetInt("max_unique_snapshots", false),
@@ -92,19 +92,19 @@ var UnpackLocalJavaRepository = func(data *schema.ResourceData, rclass string, r
 	}
 }
 
-func ResourceArtifactoryLocalJavaRepository(repoType string, suppressPom bool) *schema.Resource {
+func ResourceArtifactoryLocalJavaRepository(packageType string, suppressPom bool) *schema.Resource {
 	var unPackLocalJavaRepository = func(data *schema.ResourceData) (interface{}, string, error) {
-		repo := UnpackLocalJavaRepository(data, "local", repoType)
+		repo := UnpackLocalJavaRepository(data, rclass, packageType)
 		return repo, repo.Id(), nil
 	}
 
-	javaLocalSchema := GetJavaRepoSchema(repoType, suppressPom)
+	javaLocalSchema := GetJavaRepoSchema(packageType, suppressPom)
 
 	constructor := func() (interface{}, error) {
 		return &JavaLocalRepositoryParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				PackageType: repoType,
-				Rclass:      "local",
+				PackageType: packageType,
+				Rclass:      rclass,
 			},
 			SuppressPomConsistencyChecks: suppressPom,
 		}, nil

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_nuget_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_nuget_repository.go
@@ -7,6 +7,8 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
+const nugetPackageType = "nuget"
+
 var NugetLocalSchema = util.MergeMaps(
 	BaseLocalRepoSchema,
 	map[string]*schema.Schema{
@@ -25,7 +27,7 @@ var NugetLocalSchema = util.MergeMaps(
 			Description: "Force basic authentication credentials in order to use this repository.",
 		},
 	},
-	repository.RepoLayoutRefSchema("local", "nuget"),
+	repository.RepoLayoutRefSchema(rclass, nugetPackageType),
 )
 
 type NugetLocalRepositoryParams struct {
@@ -37,7 +39,7 @@ type NugetLocalRepositoryParams struct {
 func UnpackLocalNugetRepository(data *schema.ResourceData, rclass string) NugetLocalRepositoryParams {
 	d := &util.ResourceData{ResourceData: data}
 	return NugetLocalRepositoryParams{
-		RepositoryBaseParams:     UnpackBaseRepo(rclass, data, "nuget"),
+		RepositoryBaseParams:     UnpackBaseRepo(rclass, data, nugetPackageType),
 		MaxUniqueSnapshots:       d.GetInt("max_unique_snapshots", false),
 		ForceNugetAuthentication: d.GetBool("force_nuget_authentication", false),
 	}
@@ -53,8 +55,8 @@ func ResourceArtifactoryLocalNugetRepository() *schema.Resource {
 	constructor := func() (interface{}, error) {
 		return &NugetLocalRepositoryParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				PackageType: "nuget",
-				Rclass:      "local",
+				PackageType: nugetPackageType,
+				Rclass:      rclass,
 			},
 			MaxUniqueSnapshots:       0,
 			ForceNugetAuthentication: false,

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_repository_test.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_repository_test.go
@@ -815,44 +815,6 @@ func TestAccLocalGenericRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 	})
 }
 
-func TestAccLocalGenericRepositoryWithInvalidProjectEnvironmentsGH318(t *testing.T) {
-	rand.Seed(time.Now().UnixNano())
-	projectKey := fmt.Sprintf("t%d", test.RandomInt())
-	repoName := fmt.Sprintf("%s-generic-local", projectKey)
-
-	_, fqrn, name := test.MkNames(repoName, "artifactory_local_generic_repository")
-
-	params := map[string]interface{}{
-		"name":       name,
-		"projectKey": projectKey,
-	}
-	localRepositoryBasic := util.ExecuteTemplate("TestAccLocalGenericRepository", `
-		resource "artifactory_local_generic_repository" "{{ .name }}" {
-		  key                  = "{{ .name }}"
-	 	  project_key          = "{{ .projectKey }}"
-	 	  project_environments = ["Foo"]
-		}
-	`, params)
-
-	resource.Test(t, resource.TestCase{
-		PreCheck: func() {
-			acctest.PreCheck(t)
-			acctest.CreateProject(t, projectKey)
-		},
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy: acctest.VerifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
-			acctest.DeleteProject(t, projectKey)
-			return acctest.CheckRepo(id, request)
-		}),
-		Steps: []resource.TestStep{
-			{
-				Config:      localRepositoryBasic,
-				ExpectError: regexp.MustCompile(".*project_environment Foo not allowed.*"),
-			},
-		},
-	})
-}
-
 func TestAccLocalNpmRepository(t *testing.T) {
 	_, fqrn, name := test.MkNames("npm-local", "artifactory_local_npm_repository")
 	params := map[string]interface{}{

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_rpm_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_rpm_repository.go
@@ -9,6 +9,8 @@ import (
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
+const rpmPackageType = "rpm"
+
 var RpmLocalSchema = util.MergeMaps(
 	BaseLocalRepoSchema,
 	map[string]*schema.Schema{
@@ -53,7 +55,7 @@ var RpmLocalSchema = util.MergeMaps(
 			Description:      "Secondary keypair used to sign artifacts.",
 		},
 	},
-	repository.RepoLayoutRefSchema(rclass, "rpm"),
+	repository.RepoLayoutRefSchema(rclass, rpmPackageType),
 )
 
 type RpmLocalRepositoryParams struct {
@@ -69,7 +71,7 @@ type RpmLocalRepositoryParams struct {
 func UnpackLocalRpmRepository(data *schema.ResourceData, rclass string) RpmLocalRepositoryParams {
 	d := &util.ResourceData{ResourceData: data}
 	return RpmLocalRepositoryParams{
-		RepositoryBaseParams:    UnpackBaseRepo(rclass, data, "rpm"),
+		RepositoryBaseParams:    UnpackBaseRepo(rclass, data, rpmPackageType),
 		RootDepth:               d.GetInt("yum_root_depth", false),
 		CalculateYumMetadata:    d.GetBool("calculate_yum_metadata", false),
 		EnableFileListsIndexing: d.GetBool("enable_file_lists_indexing", false),
@@ -89,7 +91,7 @@ func ResourceArtifactoryLocalRpmRepository() *schema.Resource {
 	constructor := func() (interface{}, error) {
 		return &RpmLocalRepositoryParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				PackageType: "rpm",
+				PackageType: rpmPackageType,
 				Rclass:      rclass,
 			},
 			RootDepth:               0,

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_terraform_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_terraform_repository.go
@@ -10,7 +10,7 @@ import (
 func GetTerraformLocalSchema(registryType string) map[string]*schema.Schema {
 	return util.MergeMaps(
 		BaseLocalRepoSchema,
-		repository.RepoLayoutRefSchema("local", "terraform_"+registryType),
+		repository.RepoLayoutRefSchema(rclass, "terraform_"+registryType),
 	)
 }
 

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -99,322 +99,267 @@ var PackageTypesLikeBasic = []string{
 }
 
 var BaseRemoteRepoSchema = func(isResource bool) map[string]*schema.Schema {
-	return map[string]*schema.Schema{
-		"key": {
-			Type:         schema.TypeString,
-			Required:     true,
-			ForceNew:     true,
-			ValidateFunc: repository.RepoKeyValidator,
-			Description:  "A mandatory identifier for the repository that must be unique. It cannot begin with a number or contain spaces or special characters.",
-		},
-		"project_key": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			Default:          "default",
-			ValidateDiagFunc: validator.ProjectKey,
-			Description:      "Project key for assigning this repository to. Must be 2 - 20 lowercase alphanumeric and hyphen characters. When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.",
-		},
-		"project_environments": {
-			Type:     schema.TypeSet,
-			Elem:     &schema.Schema{Type: schema.TypeString},
-			MaxItems: 2,
-			Set:      schema.HashString,
-			Optional: true,
-			Computed: true,
-			Description: "Project environment for assigning this repository to. Allow values: \"DEV\" or \"PROD\". " +
-				"The attribute should only be used if the repository is already assigned to the existing project. If not, " +
-				"the attribute will be ignored by Artifactory, but will remain in the Terraform state, which will create " +
-				"state drift during the update.",
-		},
-		"package_type": {
-			Type:     schema.TypeString,
-			Required: false,
-			Computed: true,
-			ForceNew: true,
-		},
-		"url": {
-			Type:         schema.TypeString,
-			Required:     isResource,
-			Optional:     !isResource,
-			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
-			Description:  "The remote repo URL.",
-		},
-		"username": {
-			Type:     schema.TypeString,
-			Optional: true,
-		},
-		"password": {
-			Type:      schema.TypeString,
-			Optional:  true,
-			Sensitive: true,
-		},
-		"proxy": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Proxy key from Artifactory Proxies settings",
-		},
-		"description": {
-			Type:     schema.TypeString,
-			Optional: true,
-			DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
-				// this is literally what comes back from the server
-				return old == fmt.Sprintf("%s (local file cache)", new)
+	return util.MergeMaps(
+		repository.BaseRepoSchema,
+		map[string]*schema.Schema{
+			"url": {
+				Type:         schema.TypeString,
+				Required:     isResource,
+				Optional:     !isResource,
+				ValidateFunc: validation.IsURLWithHTTPorHTTPS,
+				Description:  "The remote repo URL.",
 			},
-			Description: "Public description.",
-		},
-		"notes": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Internal description.",
-		},
-		"includes_pattern": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Default:  "**/*",
-			Description: "List of comma-separated artifact patterns to include when evaluating artifact requests in the form of x/y/**/z/*. " +
-				"When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included (**/*).",
-		},
-		"excludes_pattern": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Description: "List of comma-separated artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*. " +
-				"By default no artifacts are excluded.",
-		},
-		"repo_layout_ref": {
-			Type:     schema.TypeString,
-			Optional: true,
-			// The default value in the UI is simple-default, in API maven-2-default. Provider will always override it ro math the UI.
-			ValidateDiagFunc: repository.ValidateRepoLayoutRefSchemaOverride,
-			Description: "Sets the layout that the repository should use for storing and identifying modules. " +
-				"A recommended layout that corresponds to the package type defined is suggested, and index packages uploaded and calculate metadata accordingly.",
-		},
-		"remote_repo_layout_ref": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "Repository layout key for the remote layout mapping.",
-		},
-		"hard_fail": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-			Description: "When set, Artifactory will return an error to the client that causes the build to fail if there " +
-				"is a failure to communicate with this repository.",
-		},
-		"offline": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "If set, Artifactory does not try to fetch remote artifacts. Only locally-cached artifacts are retrieved.",
-		},
-		"blacked_out": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "(A.K.A 'Ignore Repository' on the UI) When set, the repository or its local cache do not participate in artifact resolution.",
-		},
-		"xray_index": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-			Description: "Enable Indexing In Xray. Repository will be indexed with the default retention period. " +
-				"You will be able to change it via Xray settings.",
-		},
-		"store_artifacts_locally": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  true,
-			Description: "When set, the repository should store cached artifacts locally. When not set, artifacts are not " +
-				"stored locally, and direct repository-to-client streaming is used. This can be useful for multi-server " +
-				"setups over a high-speed LAN, with one Artifactory caching certain data on central storage, and streaming " +
-				"it directly to satellite pass-though Artifactory servers.",
-		},
-		"socket_timeout_millis": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			Default:      15000,
-			ValidateFunc: validation.IntAtLeast(0),
-			Description: "Network timeout (in ms) to use when establishing a connection and for unanswered requests. " +
-				"Timing out on a network operation is considered a retrieval failure.",
-		},
-		"local_address": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Description: "The local address to be used when creating connections. " +
-				"Useful for specifying the interface to use on systems with multiple network interfaces.",
-		},
-		"retrieval_cache_period_seconds": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			Default:      7200,
-			ValidateFunc: validation.IntAtLeast(0),
-			Description: "Metadata Retrieval Cache Period (Sec) in the UI. This value refers to the number of seconds to cache " +
-				"metadata files before checking for newer versions on remote server. A value of 0 indicates no caching.",
-		},
-		"metadata_retrieval_timeout_secs": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			Default:      60,
-			ValidateFunc: validation.IntAtLeast(0),
-			Description: "Metadata Retrieval Cache Timeout (Sec) in the UI.This value refers to the number of seconds to wait " +
-				"for retrieval from the remote before serving locally cached artifact or fail the request.",
-		},
-		"missed_cache_period_seconds": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			Default:      1800,
-			ValidateFunc: validation.IntAtLeast(0),
-			Description: "Missed Retrieval Cache Period (Sec) in the UI. The number of seconds to cache artifact retrieval " +
-				"misses (artifact not found). A value of 0 indicates no caching.",
-		},
-		"unused_artifacts_cleanup_period_hours": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			Default:      0,
-			ValidateFunc: validation.IntAtLeast(0),
-			Description: "Unused Artifacts Cleanup Period (Hr) in the UI. The number of hours to wait before an artifact is " +
-				"deemed 'unused' and eligible for cleanup from the repository. A value of 0 means automatic cleanup of cached artifacts is disabled.",
-		},
-		"assumed_offline_period_secs": {
-			Type:         schema.TypeInt,
-			Optional:     true,
-			Default:      300,
-			ValidateFunc: validation.IntAtLeast(0),
-			Description: "The number of seconds the repository stays in assumed offline state after a connection error. " +
-				"At the end of this time, an online check is attempted in order to reset the offline status. " +
-				"A value of 0 means the repository is never assumed offline.",
-		},
-		// There is no corresponding field in the UI, but the attribute is returned by Get, default is 'false'.
-		"share_configuration": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Computed: true,
-		},
-		"synchronize_properties": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "When set, remote artifacts are fetched along with their properties.",
-		},
-		// Default value in UI is 'true', at the same time if the repo was created with API, the default is 'false'.
-		// We are repeating the UI behavior.
-		"block_mismatching_mime_types": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  true,
-			Description: "If set, artifacts will fail to download if a mismatch is detected between requested and received " +
-				"mimetype, according to the list specified in the system properties file under blockedMismatchingMimeTypes. " +
-				"You can override by adding mimetypes to the override list 'mismatching_mime_types_override_list'.",
-		},
-		"property_sets": {
-			Type:        schema.TypeSet,
-			Elem:        &schema.Schema{Type: schema.TypeString},
-			Set:         schema.HashString,
-			Optional:    true,
-			Description: "List of property set names",
-		},
-		"allow_any_host_auth": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "'Lenient Host Authentication' in the UI. Allow credentials of this repository to be used on requests redirected to any other host.",
-		},
-		"enable_cookie_management": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "Enables cookie management if the remote repository uses cookies to manage client state.",
-		},
-		"bypass_head_requests": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-			Description: "Before caching an artifact, Artifactory first sends a HEAD request to the remote resource. " +
-				"In some remote resources, HEAD requests are disallowed and therefore rejected, even though downloading the " +
-				"artifact is allowed. When checked, Artifactory will bypass the HEAD request and cache the artifact directly using a GET request.",
-		},
-		"priority_resolution": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-			Description: "Setting Priority Resolution takes precedence over the resolution order when resolving virtual " +
-				"repositories. Setting repositories with priority will cause metadata to be merged only from repositories " +
-				"set with a priority. If a package is not found in those repositories, Artifactory will merge from repositories marked as non-priority.",
-		},
-		"client_tls_certificate": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Computed:    true,
-			Description: "Client TLS certificate name.",
-		},
-		"content_synchronisation": {
-			Type:     schema.TypeList,
-			Optional: true,
-			Computed: true,
-			MaxItems: 1,
-			Elem: &schema.Resource{
-				Schema: map[string]*schema.Schema{
-					"enabled": {
-						Type:        schema.TypeBool,
-						Optional:    true,
-						Default:     false,
-						Description: "If set, Remote repository proxies a local or remote repository from another instance of Artifactory. Default value is 'false'.",
-					},
-					"statistics_enabled": {
-						Type:        schema.TypeBool,
-						Optional:    true,
-						Default:     false,
-						Description: "If set, Artifactory will notify the remote instance whenever an artifact in the Smart Remote Repository is downloaded locally so that it can update its download counter. Note that if this option is not set, there may be a discrepancy between the number of artifacts reported to have been downloaded in the different Artifactory instances of the proxy chain. Default value is 'false'.",
-					},
-					"properties_enabled": {
-						Type:        schema.TypeBool,
-						Optional:    true,
-						Default:     false,
-						Description: "If set, properties for artifacts that have been cached in this repository will be updated if they are modified in the artifact hosted at the remote Artifactory instance. The trigger to synchronize the properties is download of the artifact from the remote repository cache of the local Artifactory instance. Default value is 'false'.",
-					},
-					"source_origin_absence_detection": {
-						Type:        schema.TypeBool,
-						Optional:    true,
-						Default:     false,
-						Description: "If set, Artifactory displays an indication on cached items if they have been deleted from the corresponding repository in the remote Artifactory instance. Default value is 'false'",
+			"username": {
+				Type:     schema.TypeString,
+				Optional: true,
+			},
+			"password": {
+				Type:      schema.TypeString,
+				Optional:  true,
+				Sensitive: true,
+			},
+			"proxy": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Proxy key from Artifactory Proxies settings",
+			},
+			"description": {
+				Type:     schema.TypeString,
+				Optional: true,
+				DiffSuppressFunc: func(_, old, new string, _ *schema.ResourceData) bool {
+					// this is literally what comes back from the server
+					return old == fmt.Sprintf("%s (local file cache)", new)
+				},
+				Description: "Public description.",
+			},
+			"remote_repo_layout_ref": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Description: "Repository layout key for the remote layout mapping.",
+			},
+			"hard_fail": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "When set, Artifactory will return an error to the client that causes the build to fail if there " +
+					"is a failure to communicate with this repository.",
+			},
+			"offline": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "If set, Artifactory does not try to fetch remote artifacts. Only locally-cached artifacts are retrieved.",
+			},
+			"blacked_out": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "(A.K.A 'Ignore Repository' on the UI) When set, the repository or its local cache do not participate in artifact resolution.",
+			},
+			"xray_index": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Enable Indexing In Xray. Repository will be indexed with the default retention period. " +
+					"You will be able to change it via Xray settings.",
+			},
+			"store_artifacts_locally": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				Description: "When set, the repository should store cached artifacts locally. When not set, artifacts are not " +
+					"stored locally, and direct repository-to-client streaming is used. This can be useful for multi-server " +
+					"setups over a high-speed LAN, with one Artifactory caching certain data on central storage, and streaming " +
+					"it directly to satellite pass-though Artifactory servers.",
+			},
+			"socket_timeout_millis": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      15000,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description: "Network timeout (in ms) to use when establishing a connection and for unanswered requests. " +
+					"Timing out on a network operation is considered a retrieval failure.",
+			},
+			"local_address": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "The local address to be used when creating connections. " +
+					"Useful for specifying the interface to use on systems with multiple network interfaces.",
+			},
+			"retrieval_cache_period_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      7200,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description: "Metadata Retrieval Cache Period (Sec) in the UI. This value refers to the number of seconds to cache " +
+					"metadata files before checking for newer versions on remote server. A value of 0 indicates no caching.",
+			},
+			"metadata_retrieval_timeout_secs": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      60,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description: "Metadata Retrieval Cache Timeout (Sec) in the UI.This value refers to the number of seconds to wait " +
+					"for retrieval from the remote before serving locally cached artifact or fail the request.",
+			},
+			"missed_cache_period_seconds": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      1800,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description: "Missed Retrieval Cache Period (Sec) in the UI. The number of seconds to cache artifact retrieval " +
+					"misses (artifact not found). A value of 0 indicates no caching.",
+			},
+			"unused_artifacts_cleanup_period_hours": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      0,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description: "Unused Artifacts Cleanup Period (Hr) in the UI. The number of hours to wait before an artifact is " +
+					"deemed 'unused' and eligible for cleanup from the repository. A value of 0 means automatic cleanup of cached artifacts is disabled.",
+			},
+			"assumed_offline_period_secs": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				Default:      300,
+				ValidateFunc: validation.IntAtLeast(0),
+				Description: "The number of seconds the repository stays in assumed offline state after a connection error. " +
+					"At the end of this time, an online check is attempted in order to reset the offline status. " +
+					"A value of 0 means the repository is never assumed offline.",
+			},
+			// There is no corresponding field in the UI, but the attribute is returned by Get, default is 'false'.
+			"share_configuration": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Computed: true,
+			},
+			"synchronize_properties": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "When set, remote artifacts are fetched along with their properties.",
+			},
+			// Default value in UI is 'true', at the same time if the repo was created with API, the default is 'false'.
+			// We are repeating the UI behavior.
+			"block_mismatching_mime_types": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				Description: "If set, artifacts will fail to download if a mismatch is detected between requested and received " +
+					"mimetype, according to the list specified in the system properties file under blockedMismatchingMimeTypes. " +
+					"You can override by adding mimetypes to the override list 'mismatching_mime_types_override_list'.",
+			},
+			"property_sets": {
+				Type:        schema.TypeSet,
+				Elem:        &schema.Schema{Type: schema.TypeString},
+				Set:         schema.HashString,
+				Optional:    true,
+				Description: "List of property set names",
+			},
+			"allow_any_host_auth": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "'Lenient Host Authentication' in the UI. Allow credentials of this repository to be used on requests redirected to any other host.",
+			},
+			"enable_cookie_management": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "Enables cookie management if the remote repository uses cookies to manage client state.",
+			},
+			"bypass_head_requests": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Before caching an artifact, Artifactory first sends a HEAD request to the remote resource. " +
+					"In some remote resources, HEAD requests are disallowed and therefore rejected, even though downloading the " +
+					"artifact is allowed. When checked, Artifactory will bypass the HEAD request and cache the artifact directly using a GET request.",
+			},
+			"priority_resolution": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "Setting Priority Resolution takes precedence over the resolution order when resolving virtual " +
+					"repositories. Setting repositories with priority will cause metadata to be merged only from repositories " +
+					"set with a priority. If a package is not found in those repositories, Artifactory will merge from repositories marked as non-priority.",
+			},
+			"client_tls_certificate": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				Description: "Client TLS certificate name.",
+			},
+			"content_synchronisation": {
+				Type:     schema.TypeList,
+				Optional: true,
+				Computed: true,
+				MaxItems: 1,
+				Elem: &schema.Resource{
+					Schema: map[string]*schema.Schema{
+						"enabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "If set, Remote repository proxies a local or remote repository from another instance of Artifactory. Default value is 'false'.",
+						},
+						"statistics_enabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "If set, Artifactory will notify the remote instance whenever an artifact in the Smart Remote Repository is downloaded locally so that it can update its download counter. Note that if this option is not set, there may be a discrepancy between the number of artifacts reported to have been downloaded in the different Artifactory instances of the proxy chain. Default value is 'false'.",
+						},
+						"properties_enabled": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "If set, properties for artifacts that have been cached in this repository will be updated if they are modified in the artifact hosted at the remote Artifactory instance. The trigger to synchronize the properties is download of the artifact from the remote repository cache of the local Artifactory instance. Default value is 'false'.",
+						},
+						"source_origin_absence_detection": {
+							Type:        schema.TypeBool,
+							Optional:    true,
+							Default:     false,
+							Description: "If set, Artifactory displays an indication on cached items if they have been deleted from the corresponding repository in the remote Artifactory instance. Default value is 'false'",
+						},
 					},
 				},
 			},
+			"query_params": {
+				Type:     schema.TypeString,
+				Optional: true,
+				Description: "Custom HTTP query parameters that will be automatically included in all remote resource requests. " +
+					"For example: `param1=val1&param2=val2&param3=val3`",
+			},
+			"list_remote_folder_items": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  true,
+				Description: "Lists the items of remote folders in simple and list browsing. The remote content is cached " +
+					"according to the value of the 'Retrieval Cache Period'. Default value is 'true'.",
+			},
+			"mismatching_mime_types_override_list": {
+				Type:             schema.TypeString,
+				Optional:         true,
+				ValidateDiagFunc: validator.CommaSeperatedList,
+				StateFunc:        util.FormatCommaSeparatedString,
+				Description: "The set of mime types that should override the block_mismatching_mime_types setting. " +
+					"Eg: 'application/json,application/xml'. Default value is empty.",
+			},
+			"download_direct": {
+				Type:     schema.TypeBool,
+				Optional: true,
+				Default:  false,
+				Description: "When set, download requests to this repository will redirect the client to download the artifact " +
+					"directly from the cloud storage provider. Available in Enterprise+ and Edge licenses only. Default value is 'false'.",
+			},
+			"cdn_redirect": {
+				Type:        schema.TypeBool,
+				Optional:    true,
+				Default:     false,
+				Description: "When set, download requests to this repository will redirect the client to download the artifact directly from AWS CloudFront. Available in Enterprise+ and Edge licenses only. Default value is 'false'",
+			},
 		},
-		"query_params": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Description: "Custom HTTP query parameters that will be automatically included in all remote resource requests. " +
-				"For example: `param1=val1&param2=val2&param3=val3`",
-		},
-		"list_remote_folder_items": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  true,
-			Description: "Lists the items of remote folders in simple and list browsing. The remote content is cached " +
-				"according to the value of the 'Retrieval Cache Period'. Default value is 'true'.",
-		},
-		"mismatching_mime_types_override_list": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			ValidateDiagFunc: validator.CommaSeperatedList,
-			StateFunc:        util.FormatCommaSeparatedString,
-			Description: "The set of mime types that should override the block_mismatching_mime_types setting. " +
-				"Eg: 'application/json,application/xml'. Default value is empty.",
-		},
-		"download_direct": {
-			Type:     schema.TypeBool,
-			Optional: true,
-			Default:  false,
-			Description: "When set, download requests to this repository will redirect the client to download the artifact " +
-				"directly from the cloud storage provider. Available in Enterprise+ and Edge licenses only. Default value is 'false'.",
-		},
-		"cdn_redirect": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "When set, download requests to this repository will redirect the client to download the artifact directly from AWS CloudFront. Available in Enterprise+ and Edge licenses only. Default value is 'false'",
-		},
-	}
+	)
 }
 
 var baseRemoteRepoSchemaV1 = util.MergeMaps(

--- a/pkg/artifactory/resource/repository/repository.go
+++ b/pkg/artifactory/resource/repository/repository.go
@@ -48,6 +48,7 @@ var BaseRepoSchema = map[string]*schema.Schema{
 		Optional: true,
 		Computed: true,
 		Description: "Project environment for assigning this repository to. Allow values: \"DEV\", \"PROD\", or one of custom environment. " +
+			"Before Artifactory 7.53.1, up to 2 values (\"DEV\" and \"PROD\") are allowed. From 7.53.1 onward, only one value is allowed. " +
 			"The attribute should only be used if the repository is already assigned to the existing project. If not, " +
 			"the attribute will be ignored by Artifactory, but will remain in the Terraform state, which will create " +
 			"state drift during the update.",

--- a/pkg/artifactory/resource/repository/repository.go
+++ b/pkg/artifactory/resource/repository/repository.go
@@ -12,15 +12,82 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/packer"
 	"github.com/jfrog/terraform-provider-shared/test"
 	"github.com/jfrog/terraform-provider-shared/unpacker"
 	"github.com/jfrog/terraform-provider-shared/util"
-	"golang.org/x/exp/slices"
+	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
 const defaultProjectKey = "default"
+
+var BaseRepoSchema = map[string]*schema.Schema{
+	"key": {
+		Type:         schema.TypeString,
+		Required:     true,
+		ForceNew:     true,
+		ValidateFunc: RepoKeyValidator,
+		Description:  "A mandatory identifier for the repository that must be unique. Must be 3 - 10 lowercase alphanumeric and hyphen characters. It cannot begin with a number or contain spaces or special characters.",
+	},
+	"project_key": {
+		Type:             schema.TypeString,
+		Optional:         true,
+		Default:          "default",
+		ValidateDiagFunc: validator.ProjectKey,
+		Description:      "Project key for assigning this repository to. Must be 2 - 20 lowercase alphanumeric and hyphen characters. When assigning repository to a project, repository key must be prefixed with project key, separated by a dash.",
+	},
+	"project_environments": {
+		Type:     schema.TypeSet,
+		Elem:     &schema.Schema{Type: schema.TypeString},
+		MinItems: 1,
+		MaxItems: 2,
+		Set:      schema.HashString,
+		Optional: true,
+		Computed: true,
+		Description: "Project environment for assigning this repository to. Allow values: \"DEV\", \"PROD\", or one of custom environment. " +
+			"The attribute should only be used if the repository is already assigned to the existing project. If not, " +
+			"the attribute will be ignored by Artifactory, but will remain in the Terraform state, which will create " +
+			"state drift during the update.",
+	},
+	"package_type": {
+		Type:     schema.TypeString,
+		Required: false,
+		Computed: true,
+		ForceNew: true,
+	},
+	"description": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Public description.",
+	},
+	"notes": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "Internal description.",
+	},
+	"includes_pattern": {
+		Type:     schema.TypeString,
+		Optional: true,
+		Default:  "**/*",
+		Description: "List of comma-separated artifact patterns to include when evaluating artifact requests in the form of x/y/**/z/*. " +
+			"When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included (**/*).",
+	},
+	"excludes_pattern": {
+		Type:     schema.TypeString,
+		Optional: true,
+		Description: "List of artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*." +
+			"By default no artifacts are excluded.",
+	},
+	"repo_layout_ref": {
+		Type:     schema.TypeString,
+		Optional: true,
+		// The default value in the UI is simple-default, in API maven-2-default. Provider will always override it ro math the UI.
+		ValidateDiagFunc: ValidateRepoLayoutRefSchemaOverride,
+		Description:      "Sets the layout that the repository should use for storing and identifying modules. A recommended layout that corresponds to the package type defined is suggested, and index packages uploaded and calculate metadata accordingly.",
+	},
+}
 
 var CompressionFormats = map[string]*schema.Schema{
 	"index_compression_formats": {
@@ -263,14 +330,20 @@ func HandleResetWithNonExistentValue(d *util.ResourceData, key string) string {
 	return value
 }
 
-func ProjectEnvironmentsDiff(_ context.Context, diff *schema.ResourceDiff, _ interface{}) error {
+const CustomProjectEnvironmentSupportedVersion = "7.53.1"
+
+func ProjectEnvironmentsDiff(ctx context.Context, diff *schema.ResourceDiff, meta interface{}) error {
 	if data, ok := diff.GetOk("project_environments"); ok {
 		projectEnvironments := data.(*schema.Set).List()
+		providerMetadata := meta.(util.ProvderMetadata)
 
-		for _, projectEnvironment := range projectEnvironments {
-			if !slices.Contains(ProjectEnvironmentsSupported, projectEnvironment.(string)) {
-				return fmt.Errorf("project_environment %s not allowed", projectEnvironment)
-			}
+		isSupported, err := util.CheckVersion(providerMetadata.ArtifactoryVersion, CustomProjectEnvironmentSupportedVersion)
+		if err != nil {
+			return fmt.Errorf("Failed to check version %s", err)
+		}
+
+		if len(projectEnvironments) == 2 && isSupported {
+			return fmt.Errorf("For Artifactory %s or later, only one environment can be assigned to a repository.", CustomProjectEnvironmentSupportedVersion)
 		}
 	}
 

--- a/pkg/artifactory/resource/repository/repository.go
+++ b/pkg/artifactory/resource/repository/repository.go
@@ -65,7 +65,7 @@ func MkRepoCreate(unpack unpacker.UnpackFunc, read schema.ReadContextFunc) schem
 			return diag.FromErr(err)
 		}
 		// repo must be a pointer
-		_, err = m.(*resty.Client).R().
+		_, err = m.(util.ProvderMetadata).Client.R().
 			AddRetryCondition(client.RetryOnMergeError).
 			SetBody(repo).
 			SetPathParam("key", key).
@@ -87,7 +87,7 @@ func MkRepoRead(pack packer.PackFunc, construct Constructor) schema.ReadContextF
 		}
 
 		// repo must be a pointer
-		resp, err := m.(*resty.Client).R().
+		resp, err := m.(util.ProvderMetadata).Client.R().
 			SetResult(repo).
 			SetPathParam("key", d.Id()).
 			Get(RepositoriesEndpoint)
@@ -110,7 +110,7 @@ func MkRepoUpdate(unpack unpacker.UnpackFunc, read schema.ReadContextFunc) schem
 			return diag.FromErr(err)
 		}
 
-		_, err = m.(*resty.Client).R().
+		_, err = m.(util.ProvderMetadata).Client.R().
 			AddRetryCondition(client.RetryOnMergeError).
 			SetBody(repo).
 			SetPathParam("key", d.Id()).
@@ -135,9 +135,9 @@ func MkRepoUpdate(unpack unpacker.UnpackFunc, read schema.ReadContextFunc) schem
 
 			var err error
 			if assignToProject {
-				err = assignRepoToProject(key, newProjectKey, m.(*resty.Client))
+				err = assignRepoToProject(key, newProjectKey, m.(util.ProvderMetadata).Client)
 			} else if unassignFromProject {
-				err = unassignRepoFromProject(key, m.(*resty.Client))
+				err = unassignRepoFromProject(key, m.(util.ProvderMetadata).Client)
 			}
 
 			if err != nil {
@@ -167,7 +167,7 @@ func unassignRepoFromProject(repoKey string, client *resty.Client) error {
 }
 
 func DeleteRepo(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	resp, err := m.(*resty.Client).R().
+	resp, err := m.(util.ProvderMetadata).Client.R().
 		AddRetryCondition(client.RetryOnMergeError).
 		SetPathParam("key", d.Id()).
 		Delete(RepositoriesEndpoint)
@@ -184,7 +184,7 @@ func Retry400(response *resty.Response, _ error) bool {
 }
 
 func repoExists(d *schema.ResourceData, m interface{}) (bool, error) {
-	_, err := CheckRepo(d.Id(), m.(*resty.Client).R().AddRetryCondition(Retry400))
+	_, err := CheckRepo(d.Id(), m.(util.ProvderMetadata).Client.R().AddRetryCondition(Retry400))
 	return err == nil, err
 }
 

--- a/pkg/artifactory/resource/repository/repository_test.go
+++ b/pkg/artifactory/resource/repository/repository_test.go
@@ -3,12 +3,14 @@ package repository_test
 import (
 	"fmt"
 	"math/rand"
+	"regexp"
 	"testing"
 	"time"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/test"
 	"github.com/jfrog/terraform-provider-shared/util"
 )
@@ -118,6 +120,96 @@ func TestAccRepository_unassign_project_key_gh_329(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "key", name),
 					resource.TestCheckResourceAttr(fqrn, "project_key", "default"),
 				),
+			},
+		},
+	})
+}
+
+func TestAccRepository_CanSetTwoProjectEnvironments(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	projectKey := fmt.Sprintf("t%d", test.RandomInt())
+	repoName := fmt.Sprintf("%s-generic-local", projectKey)
+
+	_, fqrn, name := test.MkNames(repoName, "artifactory_local_generic_repository")
+
+	params := map[string]interface{}{
+		"name":       name,
+		"projectKey": projectKey,
+	}
+	localRepositoryBasic := util.ExecuteTemplate("TestAccLocalGenericRepository", `
+		resource "artifactory_local_generic_repository" "{{ .name }}" {
+		  key                  = "{{ .name }}"
+	 	  project_key          = "{{ .projectKey }}"
+	 	  project_environments = ["DEV", "PROD"]
+		}
+	`, params)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.CreateProject(t, projectKey)
+		},
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy: acctest.VerifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
+			acctest.DeleteProject(t, projectKey)
+			return acctest.CheckRepo(id, request)
+		}),
+		Steps: []resource.TestStep{
+			{
+				SkipFunc: func() (bool, error) {
+					meta := acctest.Provider.Meta().(util.ProvderMetadata)
+					isSupported, err := util.CheckVersion(meta.ArtifactoryVersion, repository.CustomProjectEnvironmentSupportedVersion)
+					return isSupported, err
+				},
+				Config: localRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "project_environments.#", "2"),
+					resource.TestCheckResourceAttr(fqrn, "project_environments.0", "DEV"),
+					resource.TestCheckResourceAttr(fqrn, "project_environments.1", "PROD"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRepository_InvalidProjectEnvironments_7_53_1(t *testing.T) {
+	rand.Seed(time.Now().UnixNano())
+	projectKey := fmt.Sprintf("t%d", test.RandomInt())
+	repoName := fmt.Sprintf("%s-generic-local", projectKey)
+
+	_, fqrn, name := test.MkNames(repoName, "artifactory_local_generic_repository")
+
+	params := map[string]interface{}{
+		"name":       name,
+		"projectKey": projectKey,
+	}
+	localRepositoryBasic := util.ExecuteTemplate("TestAccLocalGenericRepository", `
+		resource "artifactory_local_generic_repository" "{{ .name }}" {
+		  key                  = "{{ .name }}"
+	 	  project_key          = "{{ .projectKey }}"
+	 	  project_environments = ["DEV", "PROD"]
+		}
+	`, params)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.CreateProject(t, projectKey)
+		},
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy: acctest.VerifyDeleted(fqrn, func(id string, request *resty.Request) (*resty.Response, error) {
+			acctest.DeleteProject(t, projectKey)
+			return acctest.CheckRepo(id, request)
+		}),
+		Steps: []resource.TestStep{
+			{
+				SkipFunc: func() (bool, error) {
+					meta := acctest.Provider.Meta().(util.ProvderMetadata)
+					isSupported, err := util.CheckVersion(meta.ArtifactoryVersion, repository.CustomProjectEnvironmentSupportedVersion)
+					return !isSupported, err
+				},
+				Config:      localRepositoryBasic,
+				ExpectError: regexp.MustCompile(fmt.Sprintf(".*For Artifactory %s or later, only one environment can be assigned to a repository..*", repository.CustomProjectEnvironmentSupportedVersion)),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/security/resource_artifactory_access_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_access_token.go
@@ -16,6 +16,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
@@ -162,7 +163,7 @@ func resourceAccessTokenCreate(_ context.Context, d *schema.ResourceData, m inte
 		RefreshToken string `json:"refresh_token,omitempty"`
 	}
 
-	client := m.(*resty.Client)
+	client := m.(util.ProvderMetadata).Client
 	grantType := "client_credentials" // client_credentials is the only supported type
 
 	tokenOptions := AccessTokenOptions{}
@@ -209,7 +210,7 @@ func resourceAccessTokenCreate(_ context.Context, d *schema.ResourceData, m inte
 	if err != nil {
 		return diag.FromErr(err)
 	}
-	_, err = m.(*resty.Client).R().
+	_, err = m.(util.ProvderMetadata).Client.R().
 		SetHeader("Content-Type", "application/x-www-form-urlencoded").
 		SetResult(&accessToken).
 		SetFormDataFromValues(values).Post("artifactory/api/security/token")
@@ -270,7 +271,7 @@ func resourceAccessTokenDelete(ctx context.Context, d *schema.ResourceData, m in
 		revokeOptions := AccessTokenRevokeOptions{}
 		revokeOptions.Token = d.Get("access_token").(string)
 		values, err := query.Values(revokeOptions)
-		resp, err := m.(*resty.Client).R().
+		resp, err := m.(util.ProvderMetadata).Client.R().
 			SetHeader("Content-Type", "application/x-www-form-urlencoded").
 			SetFormDataFromValues(values).Post("artifactory/api/security/token/revoke")
 		if err != nil {

--- a/pkg/artifactory/resource/security/resource_artifactory_api_key.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_api_key.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"strconv"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
@@ -58,7 +58,7 @@ func packApiKey(apiKey string, d *schema.ResourceData) diag.Diagnostics {
 func resourceApiKeyCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	data := ApiKey{}
 
-	_, err := m.(*resty.Client).R().SetResult(&data).Post(ApiKeyEndpoint)
+	_, err := m.(util.ProvderMetadata).Client.R().SetResult(&data).Post(ApiKeyEndpoint)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -72,7 +72,7 @@ func resourceApiKeyCreate(ctx context.Context, d *schema.ResourceData, m interfa
 
 func resourceApiKeyRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	data := ApiKey{}
-	_, err := m.(*resty.Client).R().SetResult(&data).Get(ApiKeyEndpoint)
+	_, err := m.(util.ProvderMetadata).Client.R().SetResult(&data).Get(ApiKeyEndpoint)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -84,6 +84,6 @@ func resourceApiKeyRead(_ context.Context, d *schema.ResourceData, m interface{}
 }
 
 func apiKeyRevoke(_ context.Context, _ *schema.ResourceData, m interface{}) diag.Diagnostics {
-	_, err := m.(*resty.Client).R().Delete(ApiKeyEndpoint)
+	_, err := m.(util.ProvderMetadata).Client.R().Delete(ApiKeyEndpoint)
 	return diag.FromErr(err)
 }

--- a/pkg/artifactory/resource/security/resource_artifactory_api_key_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_api_key_test.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/security"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
 
 func TestAccApiKey(t *testing.T) {
@@ -39,7 +39,7 @@ func TestAccApiKey(t *testing.T) {
 
 func testAccCheckApiKeyDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 		rs, ok := s.RootModule().Resources[id]
 		if !ok {
 			return fmt.Errorf("err: Resource id[%s] not found", id)

--- a/pkg/artifactory/resource/security/resource_artifactory_certificate.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_certificate.go
@@ -11,10 +11,10 @@ import (
 	"os"
 	"strings"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
@@ -165,7 +165,7 @@ func calculateFingerPrint(pemData string) (string, error) {
 }
 
 func FindCertificate(alias string, m interface{}) (*CertificateDetails, error) {
-	c := m.(*resty.Client)
+	c := m.(util.ProvderMetadata).Client
 	certificates := new([]CertificateDetails)
 	_, err := c.R().SetResult(certificates).Get(CertificateEndpoint)
 
@@ -258,7 +258,7 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, m in
 		return diag.FromErr(err)
 	}
 
-	_, err = m.(*resty.Client).R().SetBody(content).SetHeader("content-type", "text/plain").Post(CertificateEndpoint + d.Id())
+	_, err = m.(util.ProvderMetadata).Client.R().SetBody(content).SetHeader("content-type", "text/plain").Post(CertificateEndpoint + d.Id())
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -268,7 +268,7 @@ func resourceCertificateUpdate(ctx context.Context, d *schema.ResourceData, m in
 }
 
 func resourceCertificateDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	_, err := m.(*resty.Client).R().Delete(CertificateEndpoint + d.Id())
+	_, err := m.(util.ProvderMetadata).Client.R().Delete(CertificateEndpoint + d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/artifactory/resource/security/resource_artifactory_group_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_group_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
@@ -320,7 +319,7 @@ func TestAccGroup_unmanagedmembers(t *testing.T) {
 
 func testAccCheckGroupDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		rs, ok := s.RootModule().Resources[id]
 		if !ok {
@@ -341,7 +340,7 @@ func testAccCheckGroupDestroy(id string) func(*terraform.State) error {
 
 func testAccDirectCheckGroupMembership(id string, expectedCount int) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		rs, ok := s.RootModule().Resources[id]
 		if !ok {

--- a/pkg/artifactory/resource/security/resource_artifactory_keypair.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_keypair.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/go-cty/cty"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -221,7 +220,7 @@ func createKeyPair(ctx context.Context, d *schema.ResourceData, m interface{}) d
 func readKeyPair(_ context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 
 	data := KeyPairPayLoad{}
-	resp, err := meta.(*resty.Client).R().SetResult(&data).Get(KeypairEndPoint + d.Id())
+	resp, err := meta.(util.ProvderMetadata).Client.R().SetResult(&data).Get(KeypairEndPoint + d.Id())
 	if err != nil {
 		if resp != nil && resp.StatusCode() == http.StatusNotFound {
 			d.SetId("")

--- a/pkg/artifactory/resource/security/resource_artifactory_keypair.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_keypair.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/packer"
 	"github.com/jfrog/terraform-provider-shared/predicate"
@@ -206,7 +207,7 @@ var keyPairPacker = packer.Universal(
 func createKeyPair(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	keyPair, key, _ := unpackKeyPair(d)
 
-	_, err := m.(*resty.Client).R().
+	_, err := m.(util.ProvderMetadata).Client.R().
 		AddRetryCondition(client.RetryOnMergeError).
 		SetBody(keyPair).
 		Post(KeypairEndPoint)
@@ -236,7 +237,7 @@ func readKeyPair(_ context.Context, d *schema.ResourceData, meta interface{}) di
 }
 
 func rmKeyPair(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	_, err := m.(*resty.Client).R().Delete(KeypairEndPoint + d.Id())
+	_, err := m.(util.ProvderMetadata).Client.R().Delete(KeypairEndPoint + d.Id())
 	if err != nil {
 		return diag.FromErr(err)
 	}

--- a/pkg/artifactory/resource/security/resource_artifactory_permission_target.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_permission_target.go
@@ -5,10 +5,10 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/util"
 )
@@ -331,7 +331,7 @@ func PackPermissionTarget(permissionTarget *PermissionTargetParams, d *schema.Re
 func resourcePermissionTargetCreate(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	permissionTarget := unpackPermissionTarget(d)
 
-	if _, err := m.(*resty.Client).R().AddRetryCondition(repository.Retry400).SetBody(permissionTarget).Post(PermissionsEndPoint + permissionTarget.Name); err != nil {
+	if _, err := m.(util.ProvderMetadata).Client.R().AddRetryCondition(repository.Retry400).SetBody(permissionTarget).Post(PermissionsEndPoint + permissionTarget.Name); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -341,7 +341,7 @@ func resourcePermissionTargetCreate(_ context.Context, d *schema.ResourceData, m
 
 func resourcePermissionTargetRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	permissionTarget := new(PermissionTargetParams)
-	resp, err := m.(*resty.Client).R().SetResult(permissionTarget).Get(PermissionsEndPoint + d.Id())
+	resp, err := m.(util.ProvderMetadata).Client.R().SetResult(permissionTarget).Get(PermissionsEndPoint + d.Id())
 	if err != nil {
 		if resp != nil && resp.StatusCode() == http.StatusNotFound {
 			d.SetId("")
@@ -356,7 +356,7 @@ func resourcePermissionTargetRead(_ context.Context, d *schema.ResourceData, m i
 func resourcePermissionTargetUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	permissionTarget := unpackPermissionTarget(d)
 
-	if _, err := m.(*resty.Client).R().SetBody(permissionTarget).Put(PermissionsEndPoint + d.Id()); err != nil {
+	if _, err := m.(util.ProvderMetadata).Client.R().SetBody(permissionTarget).Put(PermissionsEndPoint + d.Id()); err != nil {
 		return diag.FromErr(err)
 	}
 
@@ -365,13 +365,13 @@ func resourcePermissionTargetUpdate(ctx context.Context, d *schema.ResourceData,
 }
 
 func resourcePermissionTargetDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	_, err := m.(*resty.Client).R().Delete(PermissionsEndPoint + d.Id())
+	_, err := m.(util.ProvderMetadata).Client.R().Delete(PermissionsEndPoint + d.Id())
 
 	return diag.FromErr(err)
 }
 
 func PermTargetExists(id string, m interface{}) (bool, error) {
-	resp, err := m.(*resty.Client).R().Head(PermissionsEndPoint + id)
+	resp, err := m.(util.ProvderMetadata).Client.R().Head(PermissionsEndPoint + id)
 	if err != nil && resp != nil && resp.StatusCode() == http.StatusNotFound {
 		// Do not error on 404s as this causes errors when the upstream permission has been manually removed
 		return false, nil

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
@@ -3,16 +3,18 @@ package security
 import (
 	"context"
 	"fmt"
-	"github.com/jfrog/terraform-provider-shared/packer"
-	"github.com/jfrog/terraform-provider-shared/predicate"
 	"net/http"
 	"regexp"
 	"strings"
+
+	"github.com/jfrog/terraform-provider-shared/packer"
+	"github.com/jfrog/terraform-provider-shared/predicate"
 
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
@@ -248,7 +250,7 @@ func ResourceArtifactoryScopedToken() *schema.Resource {
 
 		id := data.Id()
 
-		resp, err := m.(*resty.Client).R().
+		resp, err := m.(util.ProvderMetadata).Client.R().
 			SetPathParam("id", id).
 			SetResult(&accessToken).
 			Get("access/api/v1/tokens/{id}")
@@ -301,7 +303,7 @@ func ResourceArtifactoryScopedToken() *schema.Resource {
 		accessToken.GrantType = "client_credentials"
 
 		result := AccessTokenPostResponse{}
-		_, err = m.(*resty.Client).R().
+		_, err = m.(util.ProvderMetadata).Client.R().
 			SetBody(accessToken).
 			SetResult(&result).
 			Post("access/api/v1/tokens")
@@ -323,7 +325,7 @@ func ResourceArtifactoryScopedToken() *schema.Resource {
 		respError := AccessTokenErrorResponse{}
 		id := data.Id()
 
-		_, err := m.(*resty.Client).R().
+		_, err := m.(util.ProvderMetadata).Client.R().
 			SetPathParam("id", id).
 			SetError(&respError).
 			Delete("access/api/v1/tokens/{id}")

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
@@ -7,14 +7,12 @@ import (
 	"regexp"
 	"strings"
 
-	"github.com/jfrog/terraform-provider-shared/packer"
-	"github.com/jfrog/terraform-provider-shared/predicate"
-
 	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
-
+	"github.com/jfrog/terraform-provider-shared/packer"
+	"github.com/jfrog/terraform-provider-shared/predicate"
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
 )

--- a/pkg/artifactory/resource/user/resource_artifactory_anonymous_user.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_anonymous_user.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
@@ -44,7 +44,7 @@ func ResourceArtifactoryAnonymousUser() *schema.Resource {
 
 		userName := d.Id()
 		user := &AnonymousUser{}
-		resp, err := m.(*resty.Client).R().SetResult(user).Get(UsersEndpointPath + userName)
+		resp, err := m.(util.ProvderMetadata).Client.R().SetResult(user).Get(UsersEndpointPath + userName)
 
 		if err != nil {
 			if resp != nil && resp.StatusCode() == http.StatusNotFound {

--- a/pkg/artifactory/resource/user/resource_artifactory_managed_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_managed_user_test.go
@@ -5,11 +5,11 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
 	"github.com/jfrog/terraform-provider-shared/test"
+	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
@@ -142,7 +142,7 @@ func TestAccManagedUser(t *testing.T) {
 
 func testAccCheckManagedUserDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		rs, ok := s.RootModule().Resources[id]
 

--- a/pkg/artifactory/resource/user/resource_artifactory_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_user_test.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 	"testing"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
@@ -281,7 +280,7 @@ func TestAccUser_EmptyGroups(t *testing.T) {
 
 func testAccCheckUserDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(*resty.Client)
+		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
 
 		rs, ok := s.RootModule().Resources[id]
 

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook.go
@@ -11,6 +11,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+
 	"github.com/jfrog/terraform-provider-shared/util"
 	"golang.org/x/exp/slices"
 )
@@ -261,7 +262,7 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 
 		webhook.EventFilter.Criteria = domainCriteriaLookup[webhookType]
 
-		_, err := m.(*resty.Client).R().
+		_, err := m.(util.ProvderMetadata).Client.R().
 			SetPathParam("webhookKey", data.Id()).
 			SetResult(&webhook).
 			Get(WhUrl)
@@ -287,7 +288,7 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 			return diag.FromErr(err)
 		}
 
-		_, err = m.(*resty.Client).R().
+		_, err = m.(util.ProvderMetadata).Client.R().
 			SetBody(webhook).
 			AddRetryCondition(retryOnProxyError).
 			Post(webhooksUrl)
@@ -308,7 +309,7 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 			return diag.FromErr(err)
 		}
 
-		_, err = m.(*resty.Client).R().
+		_, err = m.(util.ProvderMetadata).Client.R().
 			SetPathParam("webhookKey", data.Id()).
 			SetBody(webhook).
 			AddRetryCondition(retryOnProxyError).
@@ -325,7 +326,7 @@ func ResourceArtifactoryWebhook(webhookType string) *schema.Resource {
 	var deleteWebhook = func(ctx context.Context, data *schema.ResourceData, m interface{}) diag.Diagnostics {
 		tflog.Debug(ctx, "deleteWebhook")
 
-		resp, err := m.(*resty.Client).R().
+		resp, err := m.(util.ProvderMetadata).Client.R().
 			SetPathParam("webhookKey", data.Id()).
 			Delete(WhUrl)
 


### PR DESCRIPTION
Closes #705 

No need for PR for `v6` branch, as this API change occurs *after* 7.49.10.

- Refactor Terraform schema so the common attributes for all repos are shared.
- Refactor provider configuration function to fetch Artifactory version from API. Then store the version string in provider's metadata variable.
- Update all usages of provider's metadata.
- Add validations based on Artifactory version
  - Keep existing validation for <7.53.1
  - Only allow 1 item (of any string) in list >=7.53.1
- Clean up magic strings