### PR TITLE
PTRENG-5027 project verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.4.2 (March 28, 2023)
+## 7.4.2 (March 28, 2023). Tested on Artifactory 7.55.9
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 7.4.2 (March 28, 2023)
+
+IMPROVEMENTS:
+
+* `project_key` attribute validation for all the resources has been changed to match Artifactory requirements since 7.56.2 - the length should be between 2-32 characters.
+  PR: [#]()
+
 ## 7.4.1 (March 28, 2023). Tested on Artifactory 7.55.9
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 IMPROVEMENTS:
 
 * `project_key` attribute validation for all the resources has been changed to match Artifactory requirements since 7.56.2 - the length should be between 2-32 characters.
-  PR: [#]()
+  PR: [#707](https://github.com/jfrog/terraform-provider-artifactory/pull/707)
 
 ## 7.4.1 (March 28, 2023). Tested on Artifactory 7.55.9
 

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-log v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
-	github.com/jfrog/terraform-provider-shared v1.12.0
+	github.com/jfrog/terraform-provider-shared v1.13.0
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v1.12.0 h1:zJDP8J7gffniPzetHtoRpphOCcsoAZ0CirUT9EpWb+k=
-github.com/jfrog/terraform-provider-shared v1.12.0/go.mod h1:n6855hIUDhypnXsJl8UrstVFkcnL2uW4FLLr3cKGXjU=
+github.com/jfrog/terraform-provider-shared v1.13.0 h1:U492Yq6YeTF02ZVmwHfr9YcAUGM+Nqk7/EQnGHiOL6I=
+github.com/jfrog/terraform-provider-shared v1.13.0/go.mod h1:n6855hIUDhypnXsJl8UrstVFkcnL2uW4FLLr3cKGXjU=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_repository_test.go
+++ b/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_repository_test.go
@@ -243,7 +243,7 @@ func TestAccFederatedRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 	federatedRepositoryConfig := util.ExecuteTemplate("TestAccFederatedRepositoryConfig", `
 		resource "artifactory_federated_generic_repository" "{{ .name }}" {
 			key         = "{{ .name }}"
-		 	project_key = "invalid-project-key-too-long"
+		 	project_key = "invalid-project-key-too-long-really-long"
 
 			member {
 				url     = "{{ .memberUrl }}"
@@ -265,7 +265,7 @@ func TestAccFederatedRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      federatedRepositoryConfig,
-				ExpectError: regexp.MustCompile(".*project_key must be 2 - 20 lowercase alphanumeric and hyphen characters"),
+				ExpectError: regexp.MustCompile(".*project_key must be 2 - 32 lowercase alphanumeric and hyphen characters"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_repository_test.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_repository_test.go
@@ -792,7 +792,7 @@ func TestAccLocalGenericRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 	localRepositoryBasic := util.ExecuteTemplate("TestAccLocalGenericRepository", `
 		resource "artifactory_local_generic_repository" "{{ .name }}" {
 		  key                  = "{{ .name }}"
-	 	  project_key          = "invalid-project-key-too-long"
+	 	  project_key          = "invalid-project-key-too-long-really-long"
 		}
 	`, params)
 
@@ -809,7 +809,7 @@ func TestAccLocalGenericRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      localRepositoryBasic,
-				ExpectError: regexp.MustCompile(".*project_key must be 2 - 20 lowercase alphanumeric and hyphen characters"),
+				ExpectError: regexp.MustCompile(".*project_key must be 2 - 32 lowercase alphanumeric and hyphen characters"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
@@ -1273,7 +1273,7 @@ func TestAccRemoteRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 	remoteRepositoryBasic := util.ExecuteTemplate("TestAccRemotePyPiRepository", `
 		resource "artifactory_remote_pypi_repository" "{{ .name }}" {
 		  key                  = "{{ .name }}"
-	 	  project_key          = "invalid-project-key-too-long"
+	 	  project_key          = "invalid-project-key-too-long-really-long"
 		  url                  = "http://tempurl.org"
 		}
 	`, params)
@@ -1291,7 +1291,7 @@ func TestAccRemoteRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      remoteRepositoryBasic,
-				ExpectError: regexp.MustCompile(".*project_key must be 2 - 20 lowercase alphanumeric and hyphen characters"),
+				ExpectError: regexp.MustCompile(".*project_key must be 2 - 32 lowercase alphanumeric and hyphen characters"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
@@ -702,7 +702,7 @@ func TestAccVirtualRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 	virualRepositoryBasic := util.ExecuteTemplate("TestAccVirtualGenericRepository", `
 		resource "artifactory_virtual_generic_repository" "{{ .name }}" {
 		  key                  = "{{ .name }}"
-	 	  project_key          = "invalid-project-key-too-long"
+	 	  project_key          = "invalid-project-key-too-long-really-long"
 		}
 	`, params)
 
@@ -719,7 +719,7 @@ func TestAccVirtualRepositoryWithInvalidProjectKeyGH318(t *testing.T) {
 		Steps: []resource.TestStep{
 			{
 				Config:      virualRepositoryBasic,
-				ExpectError: regexp.MustCompile(".*project_key must be 2 - 20 lowercase alphanumeric and hyphen characters"),
+				ExpectError: regexp.MustCompile(".*project_key must be 2 - 32 lowercase alphanumeric and hyphen characters"),
 			},
 		},
 	})


### PR DESCRIPTION
Artifactory 7.56.2 expands the maximum length for project key to 32. 
Use `terraform-provider-shared` module v1.13.0 with the corresponding verification change. 

This change is not required for `v6` branch.