### PR TITLE
Fix scoped token expires_in not set correctly when 0 is used as value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.4.3 (March 29, 2023)
+## 7.4.3 (March 29, 2023). Tested on Artifactory 7.55.9
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 7.4.3 (March 29, 2023)
+
+BUG FIXES:
+
+* resource/artifactory_scoped_token: Fix not able to set `expires_in` with `0` value for non-expiring token.
+
+PR: [#708](https://github.com/jfrog/terraform-provider-artifactory/pull/708)
+
 ## 7.4.2 (March 28, 2023). Tested on Artifactory 7.55.9
 
 IMPROVEMENTS:

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/terraform-plugin-log v0.4.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.16.0
-	github.com/jfrog/terraform-provider-shared v1.13.0
+	github.com/jfrog/terraform-provider-shared v1.14.0
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4

--- a/go.sum
+++ b/go.sum
@@ -146,8 +146,8 @@ github.com/imdario/mergo v0.3.12/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v1.13.0 h1:U492Yq6YeTF02ZVmwHfr9YcAUGM+Nqk7/EQnGHiOL6I=
-github.com/jfrog/terraform-provider-shared v1.13.0/go.mod h1:n6855hIUDhypnXsJl8UrstVFkcnL2uW4FLLr3cKGXjU=
+github.com/jfrog/terraform-provider-shared v1.14.0 h1:C9EGwZKLAtzts543zpXANjYYwM3/pX64H7oMbhimA8g=
+github.com/jfrog/terraform-provider-shared v1.14.0/go.mod h1:n6855hIUDhypnXsJl8UrstVFkcnL2uW4FLLr3cKGXjU=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=

--- a/pkg/artifactory/provider/provider.go
+++ b/pkg/artifactory/provider/provider.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-log/tflog"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -100,7 +99,7 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVer
 		}
 	}
 
-	version, err := getArtifactoryVersion(restyBase)
+	version, err := util.GetArtifactoryVersion(restyBase)
 	if err != nil {
 		return nil, diag.FromErr(err)
 	}
@@ -112,21 +111,4 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVer
 		Client:             restyBase,
 		ArtifactoryVersion: version,
 	}, nil
-}
-
-func getArtifactoryVersion(client *resty.Client) (string, error) {
-	type ArtifactoryVersion struct {
-		Version string `json:"version"`
-	}
-
-	artifactoryVersion := ArtifactoryVersion{}
-	_, err := client.R().
-		SetResult(&artifactoryVersion).
-		Get("/artifactory/api/system/version")
-
-	if err != nil {
-		return "", fmt.Errorf("Failed to get Artifactory version. %s", err)
-	}
-
-	return artifactoryVersion.Version, nil
 }

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
@@ -42,7 +42,7 @@ func ResourceArtifactoryScopedToken() *schema.Resource {
 		GrantType   string `json:"grant_type"`
 		Username    string `json:"username,omitempty"`
 		Scope       string `json:"scope,omitempty"`
-		ExpiresIn   int    `json:"expires_in,omitempty"`
+		ExpiresIn   int    `json:"expires_in"`
 		Refreshable bool   `json:"refreshable"`
 		Description string `json:"description"`
 		Audience    string `json:"audience,omitempty"`

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
@@ -404,3 +404,39 @@ func TestAccScopedToken_WithExpiresInLessThanPersistencyThreshold(t *testing.T) 
 		},
 	})
 }
+
+func TestAccScopedToken_WithExpiresInSetToZeroForNonExpiringToken(t *testing.T) {
+	_, fqrn, name := test.MkNames("test-access-token", "artifactory_scoped_token")
+
+	accessTokenConfig := util.ExecuteTemplate(
+		"TestAccScopedToken",
+		`resource "artifactory_user" "test-user" {
+			name              = "testuser"
+		    email             = "testuser@tempurl.org"
+			admin             = true
+			disable_ui_access = false
+			groups            = ["readers"]
+			password          = "Passw0rd!"
+		}
+
+		resource "artifactory_scoped_token" "{{ .name }}" {
+			username    = artifactory_user.test-user.name
+			description = "test description"
+			expires_in  = 0
+		}`,
+		map[string]interface{}{
+			"name": name,
+		},
+	)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: accessTokenConfig,
+				Check:  resource.TestCheckResourceAttr(fqrn, "expires_in", "0"),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Use latest version of shared module and remove redundant func to get Artifactory version.