### PR TITLE
Add smoke tests to make file and Pipeline configure

### DIFF
--- a/.jfrog-pipelines/TFproviderSmokeTest.yml
+++ b/.jfrog-pipelines/TFproviderSmokeTest.yml
@@ -1,0 +1,74 @@
+resources:
+  - name: GitHubTFProviderRepoJFrog
+    type: GitRepo
+    configuration:
+      gitProvider: partnership_github
+      path: jfrog/terraform-provider-artifactory # if path is modified, change the name as well, per Pipelines doc
+      branches:
+        include: master
+      buildOn:
+        commit: false
+        pullRequestCreate: false
+      cancelPendingRunsOn:
+        pullRequestUpdate: false
+pipelines:
+  - name: tf_provider_artifactory_smoke
+    steps:
+      - name: build_and_run_tf_provider
+        type: Bash
+        configuration:
+          priority: 1
+          timeoutSeconds: 300 # 5 minutes
+          runtime:
+            type: image
+            image:
+              auto:
+                language: go
+                versions:
+                  - "1.18"
+          integrations:
+            - name: partnership_slack
+            - name: terraform_artifactory_smoke_test
+          inputResources:
+            - name: GitHubTFProviderRepoJFrog
+        execution:
+          onStart:
+            - echo "Preparing for work. Install Terraform, and GoReleaser"
+            - ls -al && pwd
+            - sudo apt update
+            - go version
+            - echo "Install latest Terraform version"
+            - wget -O- https://apt.releases.hashicorp.com/gpg | gpg --dearmor | sudo tee /usr/share/keyrings/hashicorp-archive-keyring.gpg
+            - gpg --no-default-keyring --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg --fingerprint
+            - echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
+            - sudo apt update && apt-get install terraform && terraform -version
+            - echo "Install GoReleaser"
+            - echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
+            - sudo apt update
+            - sudo apt install goreleaser
+          onExecute:
+            - add_run_variables TFProviderRepo=$(echo ${res_GitHubTFProviderRepoJFrog_gitRepoRepositorySshUrl} | sed -e 's/git@/@/g' -e 's/:/\//g')
+            - cd ${res_GitHubTFProviderRepoJFrog_resourcePath} # we need to manually move into the resource path
+            - echo "Verify the code contents merged feature branch with master branch (detached mode)"
+            - git branch && ls -al
+            - add_run_variables PROVIDER_VERSION=$(git describe --tags --abbrev=0 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')
+            - echo "Provider version is ${PROVIDER_VERSION}"
+            - echo "Rename the build to make it work on Ubuntu"
+            - cat GNUmakefile | sed -e "s/darwin_amd64/linux_amd64/g" > GNUmakefile.tmp
+            - cp GNUmakefile.tmp GNUmakefile && rm GNUmakefile.tmp
+            - cat GNUmakefile
+            - cat sample.tf | sed -e "s/version =.*/version = \"${PROVIDER_VERSION}\"/g" > sample.tf.tmp
+            - cp sample.tf.tmp sample.tf && rm sample.tf.tmp
+            - cat sample.tf
+            - echo "Add variables needed to run Terraform Provider"
+            - export JFROG_URL=${int_terraform_artifactory_smoke_test_jfrog_url}
+            - export JFROG_ACCESS_TOKEN=${int_terraform_artifactory_smoke_test_jfrog_access_token}
+            - export TF_ACC=true
+            - make smoke
+          onSuccess:
+            - echo "Success"
+            - send_notification partnership_slack --text "${pipeline_name} step <${step_url}|${step_name}> is completed. Version ${PROVIDER_VERSION:-" wasn't set"}."
+          onFailure:
+            - send_notification partnership_slack --text "${pipeline_name} pipeline failed on <${step_url}|${step_name}> step"
+          onComplete:
+            - echo "Complete"

--- a/.jfrog-pipelines/TFproviderSmokeTest.yml
+++ b/.jfrog-pipelines/TFproviderSmokeTest.yml
@@ -13,6 +13,10 @@ resources:
         pullRequestUpdate: false
 pipelines:
   - name: tf_provider_artifactory_smoke
+    configuration:
+      environmentVariables:
+        JFROG_URL: "http://localhost:8082"
+        JFROG_ACCESS_TOKEN: ""
     steps:
       - name: build_and_run_tf_provider
         type: Bash
@@ -28,12 +32,16 @@ pipelines:
                   - "1.18"
           integrations:
             - name: partnership_slack
-            - name: terraform_artifactory_smoke_test
           inputResources:
             - name: GitHubTFProviderRepoSmoke
               trigger: false
         execution:
           onStart:
+            - >-
+              if [[ -z ${JFROG_URL} || -z ${JFROG_ACCESS_TOKEN} ]]; then
+                echo "JFROG_URL, JFROG_ACCESS_TOKEN must be supplied to this pipeline"
+                exit 1
+              fi
             - echo "Preparing for work. Install Terraform"
             - ls -al && pwd
             - sudo apt update
@@ -57,8 +65,6 @@ pipelines:
             - cp sample.tf.tmp sample.tf && rm sample.tf.tmp
             - cat sample.tf
             - echo "Add variables needed to run Terraform Provider"
-            - export JFROG_URL=${int_terraform_artifactory_smoke_test_jfrog_url}
-            - export JFROG_ACCESS_TOKEN=${int_terraform_artifactory_smoke_test_jfrog_access_token}
             - export TF_ACC=true
             - make smoke
           onSuccess:

--- a/.jfrog-pipelines/TFproviderSmokeTest.yml
+++ b/.jfrog-pipelines/TFproviderSmokeTest.yml
@@ -22,6 +22,7 @@ pipelines:
       - name: build_and_run_tf_provider
         type: Bash
         configuration:
+          nodePool: default
           priority: 1
           timeoutSeconds: 300 # 5 minutes
           runtime:

--- a/.jfrog-pipelines/TFproviderSmokeTest.yml
+++ b/.jfrog-pipelines/TFproviderSmokeTest.yml
@@ -15,8 +15,9 @@ pipelines:
   - name: tf_provider_artifactory_smoke
     configuration:
       environmentVariables:
-        JFROG_URL: "http://localhost:8082"
-        JFROG_ACCESS_TOKEN: ""
+        readOnly:
+          JFROG_URL: ""
+          JFROG_ACCESS_TOKEN: ""
     steps:
       - name: build_and_run_tf_provider
         type: Bash

--- a/.jfrog-pipelines/TFproviderSmokeTest.yml
+++ b/.jfrog-pipelines/TFproviderSmokeTest.yml
@@ -30,7 +30,7 @@ pipelines:
             - name: partnership_slack
             - name: terraform_artifactory_smoke_test
           inputResources:
-            - name: GitHubTFProviderRepoJFrog
+            - name: GitHubTFProviderRepoSmoke
               trigger: false
         execution:
           onStart:
@@ -44,7 +44,7 @@ pipelines:
             - echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
             - sudo apt update && apt-get install terraform && terraform -version
           onExecute:
-            - cd ${res_GitHubTFProviderRepoJFrog_resourcePath} # we need to manually move into the resource path
+            - cd ${res_GitHubTFProviderRepoSmoke_resourcePath} # we need to manually move into the resource path
             - echo "Verify the code contents merged feature branch with master branch (detached mode)"
             - git branch && ls -al
             - add_run_variables PROVIDER_VERSION=$(git describe --tags --abbrev=0 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')

--- a/.jfrog-pipelines/TFproviderSmokeTest.yml
+++ b/.jfrog-pipelines/TFproviderSmokeTest.yml
@@ -1,11 +1,11 @@
 resources:
-  - name: GitHubTFProviderRepoJFrog
+  - name: GitHubTFProviderRepoSmoke
     type: GitRepo
     configuration:
       gitProvider: partnership_github
       path: jfrog/terraform-provider-artifactory # if path is modified, change the name as well, per Pipelines doc
       branches:
-        include: master
+        include: add-smoke-tests
       buildOn:
         commit: false
         pullRequestCreate: false
@@ -31,9 +31,10 @@ pipelines:
             - name: terraform_artifactory_smoke_test
           inputResources:
             - name: GitHubTFProviderRepoJFrog
+              trigger: false
         execution:
           onStart:
-            - echo "Preparing for work. Install Terraform, and GoReleaser"
+            - echo "Preparing for work. Install Terraform"
             - ls -al && pwd
             - sudo apt update
             - go version
@@ -42,12 +43,7 @@ pipelines:
             - gpg --no-default-keyring --keyring /usr/share/keyrings/hashicorp-archive-keyring.gpg --fingerprint
             - echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" | sudo tee /etc/apt/sources.list.d/hashicorp.list
             - sudo apt update && apt-get install terraform && terraform -version
-            - echo "Install GoReleaser"
-            - echo 'deb [trusted=yes] https://repo.goreleaser.com/apt/ /' | sudo tee /etc/apt/sources.list.d/goreleaser.list
-            - sudo apt update
-            - sudo apt install goreleaser
           onExecute:
-            - add_run_variables TFProviderRepo=$(echo ${res_GitHubTFProviderRepoJFrog_gitRepoRepositorySshUrl} | sed -e 's/git@/@/g' -e 's/:/\//g')
             - cd ${res_GitHubTFProviderRepoJFrog_resourcePath} # we need to manually move into the resource path
             - echo "Verify the code contents merged feature branch with master branch (detached mode)"
             - git branch && ls -al

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -16,6 +16,8 @@ BUILD_PATH=terraform.d/plugins/registry.terraform.io/jfrog/${PRODUCT}/${NEXT_PRO
 SONAR_SCANNER_VERSION?=4.7.0.2747
 SONAR_SCANNER_HOME?=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-macosx
 
+SMOKE_TESTS=(TestAccDataSourceUser_basic|TestAccLocalGenericRepository|TestAccLocalGenericRepositoryWithProjectAttributes|TestAccRemoteRepository_basic|TestAccRemoteRepositoryWithProjectAttributes|TestAccVirtualRepository_basic|TestAccVirtualGenericRepositoryWithProjectAttributes|TestAccFederatedRepoWithMembers|TestAccFederatedRepoWithProjectAttributes|TestAccWebhookAllTypes|TestAccUser_basic|TestAccGroup_basic|TestAccScopedToken_WithDefaults|TestAccPermissionTarget_full|TestAccBackup_full|TestAccGeneralSecurity_full|TestAccLdapGroupSetting_full|TestAccLdapSetting_full|TestAccOauthSettings_full|TestAccPropertySet|TestAccProxy|TestAccLayout_full|TestAccSamlSettings_full)
+
 default: build
 
 install: clean build
@@ -47,6 +49,10 @@ test:
 
 attach:
 	dlv --listen=:2345 --headless=true --api-version=2 --accept-multiclient attach $$(pgrep terraform-provider-${PRODUCT})
+
+smoke: fmt
+	export TF_ACC=true && \
+		go test -run '${SMOKE_TESTS}' -ldflags="-X '${PKG_VERSION_PATH}.Version=${NEXT_PROVIDER_VERSION}-test'" -v -p 1 -timeout 5m ./pkg/... -count=1
 
 acceptance: fmt
 	export TF_ACC=true && \

--- a/pkg/artifactory/datasource/user/datasource_artifactory_user_test.go
+++ b/pkg/artifactory/datasource/user/datasource_artifactory_user_test.go
@@ -7,17 +7,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
-	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/user"
 	"github.com/jfrog/terraform-provider-shared/test"
 	"github.com/jfrog/terraform-provider-shared/util"
 )
-
-func deleteUser(t *testing.T, name string) error {
-	restyClient := acctest.GetTestResty(t)
-	_, err := restyClient.R().Delete(user.UsersEndpointPath + name)
-
-	return err
-}
 
 func TestAccDataSourceUser_basic(t *testing.T) {
 	id := test.RandomInt()


### PR DESCRIPTION
Considered a few ways to do this. Tried build tags but 1) it somehow doesn't work with TF tests, 2) would involve changing a lot of files, and 3) we may miss compilation issues with build tags.

Other ways like env vars or using `Testing.IsShort()` also involves updating lots of code, unnecessarily in my opinion.

So settled on a maintaining a list of test names in the make file for now.