### PR TITLE
GH-548 add virtual repos data sources to v6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 FEATURES:
 
 * datasource/artifactory_virtual_*_repository: Adds new data sources for all virtual repository package types.
-  PR:     [#719](https://github.com/jfrog/terraform-provider-artifactory/pull/719)
+  PR:     [#720](https://github.com/jfrog/terraform-provider-artifactory/pull/720)
   Issues: [#548](https://github.com/jfrog/terraform-provider-artifactory/issues/548)
 
 ## 6.35.0 (April 10, 2023). Tested on Artifactory 7.49.8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 6.36.0 (April 17, 2023). Tested on Artifactory 7.49.8
+
+FEATURES:
+
+* datasource/artifactory_virtual_*_repository: Adds new data sources for all virtual repository package types.
+  PR:     [#719](https://github.com/jfrog/terraform-provider-artifactory/pull/719)
+  Issues: [#548](https://github.com/jfrog/terraform-provider-artifactory/issues/548)
+
 ## 6.35.0 (April 10, 2023). Tested on Artifactory 7.49.8
 
 IMPROVEMENTS:

--- a/docs/data-sources/remote_alpine_repository.md
+++ b/docs/data-sources/remote_alpine_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_bower_repository.md
+++ b/docs/data-sources/remote_bower_repository.md
@@ -21,6 +21,6 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `bower_registry_url` - (Optional) Proxy remote Bower repository. Default value is `https://registry.bower.io`.

--- a/docs/data-sources/remote_cargo_repository.md
+++ b/docs/data-sources/remote_cargo_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `anonymous_access` - (Required) Cargo client does not send credentials when performing download and search for crates. Enable this to allow anonymous access to these resources (only), note that this will override the security anonymous access option. Default value is `false`.
 * `enable_sparse_index` - (Optional) Enable internal index support based on Cargo sparse index specifications, instead of the default git index. Default value is `false`.

--- a/docs/data-sources/remote_chef_repository.md
+++ b/docs/data-sources/remote_chef_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_cocoapods_repository.md
+++ b/docs/data-sources/remote_cocoapods_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `vcs_git_provider` - (Optional) Artifactory supports proxying the following Git providers out-of-the-box: GitHub or a remote Artifactory instance. Default value is `GITHUB`. Possible values are: `GITHUB`, `BITBUCKET`, `OLDSTASH`, `STASH`, `ARTIFACTORY`, `CUSTOM`.
 * `vcs_git_download_url` - (Optional) This attribute is used when vcs_git_provider is set to `CUSTOM`. Provided URL will be used as proxy.

--- a/docs/data-sources/remote_composer_repository.md
+++ b/docs/data-sources/remote_composer_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `vcs_git_provider` - (Optional) Artifactory supports proxying the following Git providers out-of-the-box: GitHub or a remote Artifactory instance. Default value is `GITHUB`. Possible values are: `GITHUB`, `BITBUCKET`, `OLDSTASH`, `STASH`, `ARTIFACTORY`, `CUSTOM`.
 * `vcs_git_download_url` - (Optional) This attribute is used when vcs_git_provider is set to `CUSTOM`. Provided URL will be used as proxy.

--- a/docs/data-sources/remote_conan_repository.md
+++ b/docs/data-sources/remote_conan_repository.md
@@ -21,6 +21,6 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `force_conan_authentication` - (Optional) Force basic authentication credentials in order to use this repository. Default value is `false`.

--- a/docs/data-sources/remote_conda_repository.md
+++ b/docs/data-sources/remote_conda_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_cran_repository.md
+++ b/docs/data-sources/remote_cran_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_debian_repository.md
+++ b/docs/data-sources/remote_debian_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_docker_repository.md
+++ b/docs/data-sources/remote_docker_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `block_pushing_schema1` - (Optional) When set, Artifactory will block the pulling of Docker images with manifest v2 schema 1 from the remote repository (i.e. the upstream). It will be possible to pull images with manifest v2 schema 1 that exist in the cache.
 * `enable_token_authentication` - (Optional) Enable token (Bearer) based authentication.

--- a/docs/data-sources/remote_gems_repository.md
+++ b/docs/data-sources/remote_gems_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_generic_repository.md
+++ b/docs/data-sources/remote_generic_repository.md
@@ -21,6 +21,6 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `propagate_query_params` - (Optional, Default: `false`) When set, if query params are included in the request to Artifactory, they will be passed on to the remote repository.

--- a/docs/data-sources/remote_gitlfs_repository.md
+++ b/docs/data-sources/remote_gitlfs_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_go_repository.md
+++ b/docs/data-sources/remote_go_repository.md
@@ -21,6 +21,6 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `vcs_git_provider` - (Optional) Artifactory supports proxying the following Git providers out-of-the-box: GitHub or a remote Artifactory instance. Default value is `ARTIFACTORY`.

--- a/docs/data-sources/remote_gradle_repository.md
+++ b/docs/data-sources/remote_gradle_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `fetch_jars_eagerly` - (Optional, Default: `false`) When set, if a POM is requested, Artifactory attempts to fetch the corresponding jar in the background. This will accelerate first access time to the jar when it is subsequently requested. 
 * `fetch_sources_eagerly` - (Optional, Default: `false`) When set, if a binaries jar is requested, Artifactory attempts to fetch the corresponding source jar in the background. This will accelerate first access time to the source jar when it is subsequently requested.

--- a/docs/data-sources/remote_helm_repository.md
+++ b/docs/data-sources/remote_helm_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `helm_charts_base_url` - (Optional) No documentation is available. Hopefully you know what this means.
 * `external_dependencies_enabled` - (Optional) When set, external dependencies are rewritten. `External Dependency Rewrite` in the UI.

--- a/docs/data-sources/remote_ivy_repository.md
+++ b/docs/data-sources/remote_ivy_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `fetch_jars_eagerly` - (Optional, Default: `false`) When set, if a POM is requested, Artifactory attempts to fetch the corresponding jar in the background. This will accelerate first access time to the jar when it is subsequently requested. 
 * `fetch_sources_eagerly` - (Optional, Default: `false`) When set, if a binaries jar is requested, Artifactory attempts to fetch the corresponding source jar in the background. This will accelerate first access time to the source jar when it is subsequently requested.

--- a/docs/data-sources/remote_maven_repository.md
+++ b/docs/data-sources/remote_maven_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `fetch_jars_eagerly` - (Optional, Default: `false`) When set, if a POM is requested, Artifactory attempts to fetch the corresponding jar in the background. This will accelerate first access time to the jar when it is subsequently requested.
 * `fetch_sources_eagerly` - (Optional, Default: `false`) When set, if a binaries jar is requested, Artifactory attempts to fetch the corresponding source jar in the background. This will accelerate first access time to the source jar when it is subsequently requested.

--- a/docs/data-sources/remote_npm_repository.md
+++ b/docs/data-sources/remote_npm_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_nuget_repository.md
+++ b/docs/data-sources/remote_nuget_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `feed_context_path` - (Optional) When proxying a remote NuGet repository, customize feed resource location using this attribute. Default value is `api/v2`.
 * `download_context_path` - (Optional) The context path prefix through which NuGet downloads are served. For example, the NuGet Gallery download URL is `https://nuget.org/api/v2/package`, so the repository URL should be configured as `https://nuget.org` and the download context path should be configured as `api/v2/package`. Default value is `api/v2/package`.

--- a/docs/data-sources/remote_opkg_repository.md
+++ b/docs/data-sources/remote_opkg_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_p2_repository.md
+++ b/docs/data-sources/remote_p2_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_pub_repository.md
+++ b/docs/data-sources/remote_pub_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_puppet_repository.md
+++ b/docs/data-sources/remote_puppet_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_pypi_repository.md
+++ b/docs/data-sources/remote_pypi_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `pypi_registry_url` - (Optional) To configure the remote repo to proxy public external PyPI repository, or a PyPI repository hosted on another Artifactory server. See JFrog Pypi documentation [here](https://www.jfrog.com/confluence/display/JFROG/PyPI+Repositories) for the usage details. Default value is `https://pypi.org`.
 * `pypi_repository_suffix` - (Optional) Usually should be left as a default for `simple`, unless the remote is a PyPI server that has custom registry suffix, like +simple in DevPI. Default value is `simple`.

--- a/docs/data-sources/remote_rpm_repository.md
+++ b/docs/data-sources/remote_rpm_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_sbt_repository.md
+++ b/docs/data-sources/remote_sbt_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `fetch_jars_eagerly` - (Optional, Default: `false`) When set, if a POM is requested, Artifactory attempts to fetch the corresponding jar in the background. This will accelerate first access time to the jar when it is subsequently requested. 
 * `fetch_sources_eagerly` - (Optional, Default: `false`) - When set, if a binaries jar is requested, Artifactory attempts to fetch the corresponding source jar in the background. This will accelerate first access time to the source jar when it is subsequently requested.

--- a/docs/data-sources/remote_swift_repository.md
+++ b/docs/data-sources/remote_swift_repository.md
@@ -21,4 +21,4 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The [common list of attributes for the remote repositories](remote.md) are supported.
+The [common list of attributes for the remote repositories](../resources/remote.md) is supported.

--- a/docs/data-sources/remote_terraform_repository.md
+++ b/docs/data-sources/remote_terraform_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `terraform_registry_url` - (Optional) The base URL of the registry API. When using Smart Remote Repositories, set the URL to `<base_Artifactory_URL>/api/terraform/repokey`.
 * `terraform_providers_url` - (Optional) The base URL of the Provider's storage API. When using Smart remote repositories, set the URL to `<base_Artifactory_URL>/api/terraform/repokey/providers`.

--- a/docs/data-sources/remote_vcs_repository.md
+++ b/docs/data-sources/remote_vcs_repository.md
@@ -21,7 +21,7 @@ The following argument is supported:
 
 ## Attribute Reference
 
-The following attributes are supported, along with the [common list of attributes for the remote repositories](remote.md):
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
 
 * `vcs_git_provider` - (Optional) Artifactory supports proxying the following Git providers out-of-the-box: GitHub, Bitbucket, Stash, a remote Artifactory instance or a custom Git repository. Allowed values are: `GITHUB`, `BITBUCKET`, `OLDSTASH`, `STASH`, `ARTIFACTORY`, `CUSTOM`. Default value is `GITHUB`
 * `vcs_git_download_url` - (Optional) This attribute is used when vcs_git_provider is set to `CUSTOM`. Provided URL will be used as proxy.

--- a/docs/data-sources/virtual_alpine_repository.md
+++ b/docs/data-sources/virtual_alpine_repository.md
@@ -1,0 +1,27 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Alpine Repository Data Source
+
+Retrieves a virtual Alpine repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_alpine_repository" "virtual-alpine" {
+  key = "virtual-alpine"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/virtual.md):
+
+* `primary_keypair_ref` - (Optional) Primary keypair used to sign artifacts. Default value is empty.
+* `retrieval_cache_period_seconds` - (Optional, Default: `7200`) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.

--- a/docs/data-sources/virtual_bower_repository.md
+++ b/docs/data-sources/virtual_bower_repository.md
@@ -1,0 +1,28 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Bower Repository Data Source
+
+Retrieves a virtual Bower repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_bower_repository" "virtual-alpine" {
+  key = "virtual-alpine"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `external_dependencies_enabled` - (Optional) When set, external dependencies are rewritten. Default value is false.
+* `external_dependencies_remote_repo` - (Optional) The remote repository aggregated by this virtual repository in which the external dependency will be cached.
+* `external_dependencies_patterns` - (Optional) An Allow List of Ant-style path expressions that specify where external dependencies may be downloaded from. By default, this is set to ** which means that dependencies may be downloaded from any external source.

--- a/docs/data-sources/virtual_chef_repository.md
+++ b/docs/data-sources/virtual_chef_repository.md
@@ -1,0 +1,26 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Chef Repository Data Source
+
+Retrieves a virtual Chef repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_chef_repository" "virtual-chef" {
+  key = "virtual-chef"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `retrieval_cache_period_seconds` - (Optional, Default: `7200`) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.

--- a/docs/data-sources/virtual_composer_repository.md
+++ b/docs/data-sources/virtual_composer_repository.md
@@ -1,0 +1,24 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual PHP Composer Repository Data Source
+
+Retrieves a virtual PHP Composer repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_composer_repository" "virtual-composer" {
+  key = "virtual-composer"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The [common list of attributes for the virtual repositories](../resources/virtual.md) is supported.

--- a/docs/data-sources/virtual_conan_repository.md
+++ b/docs/data-sources/virtual_conan_repository.md
@@ -1,0 +1,26 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Conan Repository Data Source
+
+Retrieves a virtual Conan repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_conan_repository" "virtual-conan" {
+  key = "virtual-conan"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `retrieval_cache_period_seconds` - (Optional, Default: `7200`) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.

--- a/docs/data-sources/virtual_conda_repository.md
+++ b/docs/data-sources/virtual_conda_repository.md
@@ -1,0 +1,26 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Conda Repository Data Source
+
+Retrieves a virtual Conda repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_conda_repository" "virtual-conda" {
+  key = "virtual-conda"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `retrieval_cache_period_seconds` - (Optional, Default: `7200`) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.

--- a/docs/data-sources/virtual_cran_repository.md
+++ b/docs/data-sources/virtual_cran_repository.md
@@ -1,0 +1,26 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Cran Repository Data Source
+
+Retrieves a virtual Cran repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_cran_repository" "virtual-cran" {
+  key = "virtual-cran"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `retrieval_cache_period_seconds` - (Optional, Default: `7200`) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.

--- a/docs/data-sources/virtual_debian_repository.md
+++ b/docs/data-sources/virtual_debian_repository.md
@@ -1,0 +1,30 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Debian Repository Data Source
+
+Retrieves a virtual Debian repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_debian_repository" "virtual-debian" {
+  key = "virtual-debian"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `retrieval_cache_period_seconds` - (Optional, Default: `7200`) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.
+* `primary_keypair_ref` - (Optional) Primary keypair used to sign artifacts. Default is empty.
+* `secondary_keypair_ref` - (Optional) Secondary keypair used to sign artifacts. Default is empty.
+* `optional_index_compression_formats` - (Optional) Index file formats you would like to create in addition to the default Gzip (.gzip extension). Supported values are `bz2`,`lzma` and `xz`. Default value is `bz2`.
+* `debian_default_architectures` - (Optional) Specifying  architectures will speed up Artifactory's initial metadata indexing process. The default architecture values are amd64 and i386.

--- a/docs/data-sources/virtual_docker_repository.md
+++ b/docs/data-sources/virtual_docker_repository.md
@@ -1,0 +1,26 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Docker Repository Data Source
+
+Retrieves a virtual Docker repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_docker_repository" "virtual-docker" {
+  key = "virtual-docker"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `resolve_docker_tags_by_timestamp` - (Optional) When enabled, in cases where the same Docker tag exists in two or more of the aggregated repositories, Artifactory will return the tag that has the latest timestamp. Default values is `false`.

--- a/docs/data-sources/virtual_gems_repository.md
+++ b/docs/data-sources/virtual_gems_repository.md
@@ -1,0 +1,24 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Gems Repository Data Source
+
+Retrieves a virtual Gems repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_gems_repository" "virtual-gems" {
+  key = "virtual-gems"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The [common list of attributes for the virtual repositories](../resources/virtual.md) is supported.

--- a/docs/data-sources/virtual_generic_repository.md
+++ b/docs/data-sources/virtual_generic_repository.md
@@ -1,0 +1,24 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Generic Repository Data Source
+
+Retrieves a virtual Generic repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_generic_repository" "virtual-generic" {
+  key = "virtual-generic"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The [common list of attributes for the virtual repositories](../resources/virtual.md) is supported.

--- a/docs/data-sources/virtual_gitlfs_repository.md
+++ b/docs/data-sources/virtual_gitlfs_repository.md
@@ -1,0 +1,24 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Git LFS Repository Data Source
+
+Retrieves a virtual Git LFS repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_gitlfs_repository" "virtual-gitlfs" {
+  key = "virtual-gitlfs"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The [common list of attributes for the virtual repositories](../resources/virtual.md) is supported.

--- a/docs/data-sources/virtual_go_repository.md
+++ b/docs/data-sources/virtual_go_repository.md
@@ -1,0 +1,28 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Go Repository Data Source
+
+Retrieves a virtual Go repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_go_repository" "virtual-go" {
+  key = "virtual-go"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `external_dependencies_enabled` - (Optional) Shorthand for "Enable 'go-import' Meta Tags" on the UI. This must be set to true in order to use the allow list. 
+  When checked (default), Artifactory will automatically follow remote VCS roots in 'go-import' meta tags to download remote modules.
+* `external_dependencies_patterns` - (Optional) 'go-import' Allow List on the UI.

--- a/docs/data-sources/virtual_gradle_repository.md
+++ b/docs/data-sources/virtual_gradle_repository.md
@@ -1,0 +1,30 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Gradle Repository Data Source
+
+Retrieves a virtual Gradle repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_gradle_repository" "virtual-gradle" {
+  key = "virtual-gradle"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `pom_repository_references_cleanup_policy` - (Optional)
+  - (1: discard_active_reference) Discard Active References - Removes repository elements that are declared directly under project or under a profile in the same POM that is activeByDefault.
+  - (2: discard_any_reference) Discard Any References - Removes all repository elements regardless of whether they are included in an active profile or not.
+  - (3: nothing) Nothing - Does not remove any repository elements declared in the POM.
+* `key_pair` - (Optional) The keypair used to sign artifacts.

--- a/docs/data-sources/virtual_helm_repository.md
+++ b/docs/data-sources/virtual_helm_repository.md
@@ -1,0 +1,27 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Helm Repository Data Source
+
+Retrieves a virtual Helm repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_helm_repository" "virtual-helm" {
+  key = "virtual-helm"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `retrieval_cache_period_seconds` - (Optional, Default: `7200`) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.
+* `use_namespaces` - (Optional) From Artifactory 7.24.1 (SaaS Version), you can explicitly state a specific aggregated local or remote repository to fetch from a virtual by assigning namespaces to local and remote repositories. See the documentation [here](https://www.jfrog.com/confluence/display/JFROG/Kubernetes+Helm+Chart+Repositories#KubernetesHelmChartRepositories-NamespaceSupportforHelmVirtualRepositories). Default is `false`.

--- a/docs/data-sources/virtual_ivy_repository.md
+++ b/docs/data-sources/virtual_ivy_repository.md
@@ -1,0 +1,30 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Ivy Repository Data Source
+
+Retrieves a virtual Ivy repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_ivy_repository" "virtual-ivy" {
+  key = "virtual-ivy"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `pom_repository_references_cleanup_policy` - (Optional)
+    - (1: discard_active_reference) Discard Active References - Removes repository elements that are declared directly under project or under a profile in the same POM that is activeByDefault.
+    - (2: discard_any_reference) Discard Any References - Removes all repository elements regardless of whether they are included in an active profile or not.
+    - (3: nothing) Nothing - Does not remove any repository elements declared in the POM.
+* `key_pair` - (Optional) The keypair used to sign artifacts.

--- a/docs/data-sources/virtual_maven_repository.md
+++ b/docs/data-sources/virtual_maven_repository.md
@@ -1,0 +1,27 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Maven Repository Data Source
+
+Retrieves a virtual Maven repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_maven_repository" "virtual-maven" {
+  key = "virtual-maven"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `pom_repository_references_cleanup_policy` - (Optional) One of: `"discard_active_reference", "discard_any_reference", "nothing"`
+* `force_maven_authentication` - (Optional) Forces authentication when fetching from remote repos.

--- a/docs/data-sources/virtual_npm_repository.md
+++ b/docs/data-sources/virtual_npm_repository.md
@@ -1,0 +1,26 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual NPM Repository Data Source
+
+Retrieves a virtual NPM repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_npm_repository" "virtual-npm" {
+  key = "virtual-npm"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `retrieval_cache_period_seconds` - (Optional, Default: `7200`) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.

--- a/docs/data-sources/virtual_nuget_repository.md
+++ b/docs/data-sources/virtual_nuget_repository.md
@@ -1,0 +1,26 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual NPM Repository Data Source
+
+Retrieves a virtual NPM repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_npm_repository" "virtual-npm" {
+  key = "virtual-npm"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `force_nuget_authentication` - (Optional) If set, user authentication is required when accessing the repository. An anonymous request will display an HTTP 401 error. This is also enforced when aggregated repositories support anonymous requests. Default is `false`.

--- a/docs/data-sources/virtual_p2_repository.md
+++ b/docs/data-sources/virtual_p2_repository.md
@@ -1,0 +1,24 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual P2 Repository Data Source
+
+Retrieves a virtual P2 repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_p2_repository" "virtual-p2" {
+  key = "virtual-p2"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The [common list of attributes for the virtual repositories](../resources/virtual.md) is supported.

--- a/docs/data-sources/virtual_pub_repository.md
+++ b/docs/data-sources/virtual_pub_repository.md
@@ -1,0 +1,24 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Pub Repository Data Source
+
+Retrieves a virtual Pub repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_pub_repository" "virtual-pub" {
+  key = "virtual-pub"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The [common list of attributes for the virtual repositories](../resources/virtual.md) is supported.

--- a/docs/data-sources/virtual_puppet_repository.md
+++ b/docs/data-sources/virtual_puppet_repository.md
@@ -1,0 +1,24 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Puppet Repository Data Source
+
+Retrieves a virtual Puppet repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_puppet_repository" "virtual-puppet" {
+  key = "virtual-puppet"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The [common list of attributes for the virtual repositories](../resources/virtual.md) is supported.

--- a/docs/data-sources/virtual_pypi_repository.md
+++ b/docs/data-sources/virtual_pypi_repository.md
@@ -1,0 +1,24 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Pypi Repository Data Source
+
+Retrieves a virtual Pypi repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_pypi_repository" "virtual-pypi" {
+  key = "virtual-pypi"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The [common list of attributes for the virtual repositories](../resources/virtual.md) is supported.

--- a/docs/data-sources/virtual_rpm_repository.md
+++ b/docs/data-sources/virtual_rpm_repository.md
@@ -1,0 +1,27 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Rpm Repository Data Source
+
+Retrieves a virtual Rpm repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_rpm_repository" "virtual-rpm" {
+  key = "virtual-rpm"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `primary_keypair_ref` - (Optional) The primary GPG key to be used to sign packages.
+* `secondary_keypair_ref` - (Optional) The secondary GPG key to be used to sign packages.

--- a/docs/data-sources/virtual_sbt_repository.md
+++ b/docs/data-sources/virtual_sbt_repository.md
@@ -1,0 +1,30 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual SBT Repository Data Source
+
+Retrieves a virtual SBT repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_sbt_repository" "virtual-sbt" {
+  key = "virtual-sbt"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `pom_repository_references_cleanup_policy` - (Optional)
+    - (1: discard_active_reference) Discard Active References - Removes repository elements that are declared directly under project or under a profile in the same POM that is activeByDefault.
+    - (2: discard_any_reference) Discard Any References - Removes all repository elements regardless of whether they are included in an active profile or not.
+    - (3: nothing) Nothing - Does not remove any repository elements declared in the POM.
+* `key_pair` - (Optional) The keypair used to sign artifacts.

--- a/docs/data-sources/virtual_swift_repository.md
+++ b/docs/data-sources/virtual_swift_repository.md
@@ -1,0 +1,24 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Swift Repository Data Source
+
+Retrieves a virtual Swift repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_swift_repository" "virtual-swift" {
+  key = "virtual-swift"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The [common list of attributes for the virtual repositories](../resources/virtual.md) is supported.

--- a/docs/data-sources/virtual_terraform_repository.md
+++ b/docs/data-sources/virtual_terraform_repository.md
@@ -1,0 +1,24 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Terraform Repository Data Source
+
+Retrieves a virtual Terraform repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_terraform_repository" "virtual-terraform" {
+  key = "virtual-terraform"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The [common list of attributes for the virtual repositories](../resources/virtual.md) is supported.

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_alpine_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_alpine_repository.go
@@ -1,0 +1,34 @@
+package virtual
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository"
+	resource_repository "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/packer"
+)
+
+func DatasourceArtifactoryVirtualAlpineRepository() *schema.Resource {
+	constructor := func() (interface{}, error) {
+		repoLayout, err := resource_repository.GetDefaultRepoLayoutRef(rclass, virtual.AlpinePackageType)()
+		if err != nil {
+			return nil, err
+		}
+
+		return &virtual.RepositoryBaseParams{
+			PackageType:   virtual.AlpinePackageType,
+			Rclass:        rclass,
+			RepoLayoutRef: repoLayout.(string),
+		}, nil
+	}
+
+	alpineSchema := virtual.AlpineVirtualSchema
+
+	return &schema.Resource{
+		Schema:      alpineSchema,
+		ReadContext: repository.MkRepoReadDataSource(packer.Default(alpineSchema), constructor),
+		Description: fmt.Sprintf("Provides a data source for a virtual %s repository", virtual.AlpinePackageType),
+	}
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_bower_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_bower_repository.go
@@ -1,0 +1,34 @@
+package virtual
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository"
+	resource_repository "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/packer"
+)
+
+func DatasourceArtifactoryVirtualBowerRepository() *schema.Resource {
+	constructor := func() (interface{}, error) {
+		repoLayout, err := resource_repository.GetDefaultRepoLayoutRef(rclass, virtual.BowerPackageType)()
+		if err != nil {
+			return nil, err
+		}
+
+		return &virtual.RepositoryBaseParams{
+			PackageType:   virtual.BowerPackageType,
+			Rclass:        rclass,
+			RepoLayoutRef: repoLayout.(string),
+		}, nil
+	}
+
+	bowerSchema := virtual.BowerVirtualSchema
+
+	return &schema.Resource{
+		Schema:      bowerSchema,
+		ReadContext: repository.MkRepoReadDataSource(packer.Default(bowerSchema), constructor),
+		Description: fmt.Sprintf("Provides a data source for a virtual %s repository", virtual.BowerPackageType),
+	}
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_debian_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_debian_repository.go
@@ -1,0 +1,34 @@
+package virtual
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository"
+	resource_repository "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/packer"
+)
+
+func DatasourceArtifactoryVirtualDebianRepository() *schema.Resource {
+	constructor := func() (interface{}, error) {
+		repoLayout, err := resource_repository.GetDefaultRepoLayoutRef(rclass, virtual.DebianPackageType)()
+		if err != nil {
+			return nil, err
+		}
+
+		return &virtual.RepositoryBaseParams{
+			PackageType:   virtual.DebianPackageType,
+			Rclass:        rclass,
+			RepoLayoutRef: repoLayout.(string),
+		}, nil
+	}
+
+	debianSchema := virtual.DebianVirtualSchema
+
+	return &schema.Resource{
+		Schema:      debianSchema,
+		ReadContext: repository.MkRepoReadDataSource(packer.Default(debianSchema), constructor),
+		Description: fmt.Sprintf("Provides a data source for a virtual %s repository", virtual.DebianPackageType),
+	}
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_docker_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_docker_repository.go
@@ -1,0 +1,34 @@
+package virtual
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository"
+	resource_repository "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/packer"
+)
+
+func DatasourceArtifactoryVirtualDockerRepository() *schema.Resource {
+	constructor := func() (interface{}, error) {
+		repoLayout, err := resource_repository.GetDefaultRepoLayoutRef(rclass, virtual.DockerPackageType)()
+		if err != nil {
+			return nil, err
+		}
+
+		return &virtual.RepositoryBaseParams{
+			PackageType:   virtual.DockerPackageType,
+			Rclass:        rclass,
+			RepoLayoutRef: repoLayout.(string),
+		}, nil
+	}
+
+	dockerSchema := virtual.DockerVirtualSchema
+
+	return &schema.Resource{
+		Schema:      dockerSchema,
+		ReadContext: repository.MkRepoReadDataSource(packer.Default(dockerSchema), constructor),
+		Description: fmt.Sprintf("Provides a data source for a virtual %s repository", virtual.DockerPackageType),
+	}
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_generic_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_generic_repository.go
@@ -1,0 +1,62 @@
+package virtual
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository"
+	resource_repository "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/packer"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func DataSourceArtifactoryVirtualGenericRepository(packageType string) *schema.Resource {
+	constructor := func() (interface{}, error) {
+		repoLayout, err := resource_repository.GetDefaultRepoLayoutRef(rclass, packageType)()
+		if err != nil {
+			return nil, err
+		}
+
+		return &virtual.RepositoryBaseParams{
+			PackageType:   packageType,
+			Rclass:        rclass,
+			RepoLayoutRef: repoLayout.(string),
+		}, nil
+	}
+
+	genericSchema := virtual.BaseVirtualRepoSchema
+
+	return &schema.Resource{
+		Schema:      genericSchema,
+		ReadContext: repository.MkRepoReadDataSource(packer.Default(genericSchema), constructor),
+		Description: fmt.Sprintf("Provides a data source for a virtual %s repository", packageType),
+	}
+}
+
+func DataSourceArtifactoryVirtualRepositoryWithRetrievalCachePeriodSecs(packageType string) *schema.Resource {
+	constructor := func() (interface{}, error) {
+		repoLayout, err := resource_repository.GetDefaultRepoLayoutRef(rclass, packageType)()
+		if err != nil {
+			return nil, err
+		}
+		return &virtual.RepositoryBaseParamsWithRetrievalCachePeriodSecs{
+			RepositoryBaseParams: virtual.RepositoryBaseParams{
+				Rclass:        rclass,
+				PackageType:   packageType,
+				RepoLayoutRef: repoLayout.(string),
+			},
+		}, nil
+	}
+
+	var repoWithRetrievalCachePeriodSecsVirtualSchema = util.MergeMaps(
+		virtual.BaseVirtualRepoSchema,
+		virtual.RetrievalCachePeriodSecondsSchema,
+	)
+
+	return &schema.Resource{
+		Schema:      repoWithRetrievalCachePeriodSecsVirtualSchema,
+		ReadContext: repository.MkRepoReadDataSource(packer.Default(repoWithRetrievalCachePeriodSecsVirtualSchema), constructor),
+		Description: fmt.Sprintf("Provides a data source for a virtual %s repository", packageType),
+	}
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_go_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_go_repository.go
@@ -1,0 +1,34 @@
+package virtual
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository"
+	resource_repository "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/packer"
+)
+
+func DatasourceArtifactoryVirtualGoRepository() *schema.Resource {
+	constructor := func() (interface{}, error) {
+		repoLayout, err := resource_repository.GetDefaultRepoLayoutRef(rclass, virtual.GoPackageType)()
+		if err != nil {
+			return nil, err
+		}
+
+		return &virtual.RepositoryBaseParams{
+			PackageType:   virtual.GoPackageType,
+			Rclass:        rclass,
+			RepoLayoutRef: repoLayout.(string),
+		}, nil
+	}
+
+	goSchema := virtual.GoVirtualSchema
+
+	return &schema.Resource{
+		Schema:      goSchema,
+		ReadContext: repository.MkRepoReadDataSource(packer.Default(goSchema), constructor),
+		Description: fmt.Sprintf("Provides a data source for a virtual %s repository", virtual.GoPackageType),
+	}
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_helm_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_helm_repository.go
@@ -1,0 +1,34 @@
+package virtual
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository"
+	resource_repository "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/packer"
+)
+
+func DatasourceArtifactoryVirtualHelmRepository() *schema.Resource {
+	constructor := func() (interface{}, error) {
+		repoLayout, err := resource_repository.GetDefaultRepoLayoutRef(rclass, virtual.HelmPackageType)()
+		if err != nil {
+			return nil, err
+		}
+
+		return &virtual.RepositoryBaseParams{
+			PackageType:   virtual.HelmPackageType,
+			Rclass:        rclass,
+			RepoLayoutRef: repoLayout.(string),
+		}, nil
+	}
+
+	helmSchema := virtual.HelmVirtualSchema
+
+	return &schema.Resource{
+		Schema:      helmSchema,
+		ReadContext: repository.MkRepoReadDataSource(packer.Default(helmSchema), constructor),
+		Description: fmt.Sprintf("Provides a data source for a virtual %s repository", virtual.HelmPackageType),
+	}
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_java_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_java_repository.go
@@ -1,0 +1,38 @@
+package virtual
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository"
+	resource_repository "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/packer"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func DataSourceArtifactoryVirtualJavaRepository(packageType string) *schema.Resource {
+	constructor := func() (interface{}, error) {
+		repoLayout, err := resource_repository.GetDefaultRepoLayoutRef(rclass, packageType)()
+		if err != nil {
+			return nil, err
+		}
+
+		return &virtual.RepositoryBaseParams{
+			PackageType:   packageType,
+			Rclass:        rclass,
+			RepoLayoutRef: repoLayout.(string),
+		}, nil
+	}
+
+	var javaSchema = util.MergeMaps(
+		virtual.BaseVirtualRepoSchema,
+		virtual.JavaVirtualSchema,
+	)
+
+	return &schema.Resource{
+		Schema:      javaSchema,
+		ReadContext: repository.MkRepoReadDataSource(packer.Default(javaSchema), constructor),
+		Description: fmt.Sprintf("Provides a data source for a virtual %s repository", packageType),
+	}
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_npm_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_npm_repository.go
@@ -1,0 +1,34 @@
+package virtual
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository"
+	resource_repository "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/packer"
+)
+
+func DatasourceArtifactoryVirtualNpmRepository() *schema.Resource {
+	constructor := func() (interface{}, error) {
+		repoLayout, err := resource_repository.GetDefaultRepoLayoutRef(rclass, virtual.NpmPackageType)()
+		if err != nil {
+			return nil, err
+		}
+
+		return &virtual.RepositoryBaseParams{
+			PackageType:   virtual.NpmPackageType,
+			Rclass:        rclass,
+			RepoLayoutRef: repoLayout.(string),
+		}, nil
+	}
+
+	npmSchema := virtual.NpmVirtualSchema
+
+	return &schema.Resource{
+		Schema:      npmSchema,
+		ReadContext: repository.MkRepoReadDataSource(packer.Default(npmSchema), constructor),
+		Description: fmt.Sprintf("Provides a data source for a virtual %s repository", virtual.NpmPackageType),
+	}
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_nuget_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_nuget_repository.go
@@ -1,0 +1,34 @@
+package virtual
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository"
+	resource_repository "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/packer"
+)
+
+func DatasourceArtifactoryVirtualNugetRepository() *schema.Resource {
+	constructor := func() (interface{}, error) {
+		repoLayout, err := resource_repository.GetDefaultRepoLayoutRef(rclass, virtual.NugetPackageType)()
+		if err != nil {
+			return nil, err
+		}
+
+		return &virtual.RepositoryBaseParams{
+			PackageType:   virtual.NugetPackageType,
+			Rclass:        rclass,
+			RepoLayoutRef: repoLayout.(string),
+		}, nil
+	}
+
+	nugetSchema := virtual.NugetVirtualSchema
+
+	return &schema.Resource{
+		Schema:      nugetSchema,
+		ReadContext: repository.MkRepoReadDataSource(packer.Default(nugetSchema), constructor),
+		Description: fmt.Sprintf("Provides a data source for a virtual %s repository", virtual.NugetPackageType),
+	}
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_repository_test.go
@@ -1,0 +1,318 @@
+package virtual_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/security"
+	"github.com/jfrog/terraform-provider-shared/test"
+	"github.com/jfrog/terraform-provider-shared/util"
+	"golang.org/x/text/cases"
+	"golang.org/x/text/language"
+)
+
+func TestAccDataSourceVirtualAllGenericLikePackageTypes(t *testing.T) {
+	for _, packageType := range virtual.PackageTypesLikeGeneric {
+		title := fmt.Sprintf(
+			"TestVirtual%sRepo",
+			cases.Title(language.AmericanEnglish).String(strings.ToLower(packageType)),
+		)
+		t.Run(title, func(t *testing.T) {
+			resource.Test(mkNewVirtualTestCase(packageType, t, map[string]interface{}{
+				"description": fmt.Sprintf("%s virtual repository public description testing.", packageType),
+			}))
+		})
+	}
+}
+
+func TestAccDataSourceVirtualAllGenericLikeRetrievalPackageTypes(t *testing.T) {
+	for _, packageType := range virtual.PackageTypesLikeGenericWithRetrievalCachePeriodSecs {
+		title := fmt.Sprintf(
+			"TestVirtual%sRepo",
+			cases.Title(language.AmericanEnglish).String(strings.ToLower(packageType)),
+		)
+		t.Run(title, func(t *testing.T) {
+			resource.Test(mkNewVirtualTestCase(packageType, t, map[string]interface{}{
+				"description":                    fmt.Sprintf("%s virtual repository public description testing.", packageType),
+				"retrieval_cache_period_seconds": 650,
+			}))
+		})
+	}
+}
+
+func TestAccDataSourceVirtualAllGradleLikePackageTypes(t *testing.T) {
+	for _, packageType := range repository.GradleLikePackageTypes {
+		title := fmt.Sprintf("TestVirtual%sRepo",
+			cases.Title(language.AmericanEnglish).String(strings.ToLower(packageType)))
+		t.Run(title, func(t *testing.T) {
+			resource.Test(mkNewVirtualTestCase(packageType, t, map[string]interface{}{
+				"description":                              fmt.Sprintf("%s virtual repository public description testing.", packageType),
+				"force_maven_authentication":               true,
+				"pom_repository_references_cleanup_policy": "discard_active_reference",
+			}))
+		})
+	}
+}
+
+func TestAccDataSourceVirtualAlpineRepository(t *testing.T) {
+	resource.Test(mkNewVirtualTestCase(virtual.AlpinePackageType, t, map[string]interface{}{
+		"description":                    "alpine virtual repository public description testing.",
+		"retrieval_cache_period_seconds": 0,
+	}))
+}
+
+func TestAccDataSourceVirtualBowerRepository(t *testing.T) {
+	resource.Test(mkNewVirtualTestCase(virtual.BowerPackageType, t, map[string]interface{}{
+		"description":                    "bower virtual repository public description testing.",
+		"external_dependencies_enabled":  true,
+		"external_dependencies_patterns": util.CastToInterfaceArr([]string{"**/github.com/**", "**/go.googlesource.com/**"}),
+	}))
+}
+
+func TestAccDataSourceVirtualDebianRepository(t *testing.T) {
+	resource.Test(mkNewVirtualTestCase(virtual.DebianPackageType, t, map[string]interface{}{
+		"description":                        "bower virtual repository public description testing.",
+		"debian_default_architectures":       "i386,amd64",
+		"retrieval_cache_period_seconds":     650,
+		"optional_index_compression_formats": util.CastToInterfaceArr([]string{"bz2", "xz"}),
+	}))
+}
+
+func TestAccDataSourceVirtualDockerRepository(t *testing.T) {
+	resource.Test(mkNewVirtualTestCase(virtual.DockerPackageType, t, map[string]interface{}{
+		"description":                      "bower virtual repository public description testing.",
+		"resolve_docker_tags_by_timestamp": true,
+	}))
+}
+
+func TestAccDataSourceVirtualGoRepository(t *testing.T) {
+	resource.Test(mkNewVirtualTestCase(virtual.GoPackageType, t, map[string]interface{}{
+		"description":                    "go virtual repository public description testing.",
+		"external_dependencies_enabled":  true,
+		"external_dependencies_patterns": util.CastToInterfaceArr([]string{"**/github.com/**", "**/go.googlesource.com/**"}),
+	}))
+}
+
+func TestAccDataSourceVirtualHelmRepository(t *testing.T) {
+	resource.Test(mkNewVirtualTestCase(virtual.HelmPackageType, t, map[string]interface{}{
+		"description":                    "helm virtual repository public description testing.",
+		"use_namespaces":                 true,
+		"retrieval_cache_period_seconds": 650,
+	}))
+}
+
+func TestAccDataSourceVirtualNpmRepository(t *testing.T) {
+	resource.Test(mkNewVirtualTestCase(virtual.NpmPackageType, t, map[string]interface{}{
+		"description":                    "npm virtual repository public description testing.",
+		"external_dependencies_enabled":  true,
+		"retrieval_cache_period_seconds": 650,
+		"external_dependencies_patterns": util.CastToInterfaceArr([]string{"**/github.com/**", "**/go.googlesource.com/**"}),
+	}))
+}
+
+func TestAccDataSourceVirtualNugetRepository(t *testing.T) {
+	resource.Test(mkNewVirtualTestCase(virtual.NugetPackageType, t, map[string]interface{}{
+		"description":                "nuget virtual repository public description testing.",
+		"force_nuget_authentication": true,
+		"artifactory_requests_can_retrieve_remote_artifacts": true,
+	}))
+}
+
+func TestAccDataSourceVirtualRpmRepository(t *testing.T) {
+	const packageType = "rpm"
+	_, fqrn, name := test.MkNames("virtual-rpm-repo", "artifactory_virtual_rpm_repository")
+	kpId, kpFqrn, kpName := test.MkNames("some-keypair1-", "artifactory_keypair")
+	kpId2, kpFqrn2, kpName2 := test.MkNames("some-keypair2-", "artifactory_keypair")
+	virtualRepositoryBasic := util.ExecuteTemplate("keypair", `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "GPG"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+		-----BEGIN PGP PRIVATE KEY BLOCK-----
+	
+		lIYEYYU7tRYJKwYBBAHaRw8BAQdAZ8vVdEyrWGssb7cdreG5GDGv6taHX/vWQdDG
+		jn7zib/+BwMCFjb4odY28+n0NWj7KZ53BkA0qzzqT9IpIfsW/tLNPTxYEFrDVbcF
+		1CuiAgAhyUfBEr9HQaMJBLfIIvo/B3nlWvwWHkiQFuWpsnJ2pj8F8LQqQ2hyaXN0
+		aWFuIEJvbmdpb3JubyA8Y2hyaXN0aWFuYkBqZnJvZy5jb20+iJoEExYKAEIWIQSS
+		w8jt+9pdVC3Gts7AvzSEkhHbJAUCYYU7tQIbAwUJA8JnAAULCQgHAgMiAgEGFQoJ
+		CAsCBBYCAwECHgcCF4AACgkQwL80hJIR2yRQDgD/X1t/hW9+uXdSY59FOClhQw/t
+		AzTYjDW+KLKadYJ3RAIBALD53rj7EnrXsSqv9Vqj3mJ7O38eXu50P57tD8ErpHMD
+		nIsEYYU7tRIKKwYBBAGXVQEFAQEHQCfT+jXHVkslGAJqVafoeWO8Nwz/oPPzNDJb
+		EOASsMRcAwEIB/4HAwK+Wi8OaidLuvQ6yknLUspoRL8KJlQu0JkfLxj6Wl6GrRtf
+		MdUBxaGUQX5UzMIqyYstgHKz2kBYvrJijWdOkkRuL82FySSh4yi/97FBikOBiHgE
+		GBYKACAWIQSSw8jt+9pdVC3Gts7AvzSEkhHbJAUCYYU7tQIbDAAKCRDAvzSEkhHb
+		JNR/AQCQjGWljmP8pYj6ohP8bOwVB4VE5qxjdfWQvBCUA0LFwgEAxLGVeT88pw3+
+		x7Cwd7SsuxlIOOCIJssFnUhA9Qsq2wE=
+		=qCzy
+		-----END PGP PRIVATE KEY BLOCK-----
+		EOF
+			public_key = <<EOF
+		-----BEGIN PGP PUBLIC KEY BLOCK-----
+	
+		mDMEYYU7tRYJKwYBBAHaRw8BAQdAZ8vVdEyrWGssb7cdreG5GDGv6taHX/vWQdDG
+		jn7zib+0KkNocmlzdGlhbiBCb25naW9ybm8gPGNocmlzdGlhbmJAamZyb2cuY29t
+		PoiaBBMWCgBCFiEEksPI7fvaXVQtxrbOwL80hJIR2yQFAmGFO7UCGwMFCQPCZwAF
+		CwkIBwIDIgIBBhUKCQgLAgQWAgMBAh4HAheAAAoJEMC/NISSEdskUA4A/19bf4Vv
+		frl3UmOfRTgpYUMP7QM02Iw1viiymnWCd0QCAQCw+d64+xJ617Eqr/Vao95iezt/
+		Hl7udD+e7Q/BK6RzA7g4BGGFO7USCisGAQQBl1UBBQEBB0An0/o1x1ZLJRgCalWn
+		6HljvDcM/6Dz8zQyWxDgErDEXAMBCAeIeAQYFgoAIBYhBJLDyO372l1ULca2zsC/
+		NISSEdskBQJhhTu1AhsMAAoJEMC/NISSEdsk1H8BAJCMZaWOY/yliPqiE/xs7BUH
+		hUTmrGN19ZC8EJQDQsXCAQDEsZV5PzynDf7HsLB3tKy7GUg44IgmywWdSED1Cyrb
+		AQ==
+		=2kMe
+		-----END PGP PUBLIC KEY BLOCK-----
+		EOF
+			lifecycle {
+				ignore_changes = [
+					private_key,
+					passphrase,
+				]
+			}
+		}
+		resource "artifactory_keypair" "{{ .kp_name2 }}" {
+			pair_name  = "{{ .kp_name2 }}"
+			pair_type = "GPG"
+			alias = "foo-alias{{ .kp_id2 }}"
+			private_key = <<EOF
+		-----BEGIN PGP PRIVATE KEY BLOCK-----
+	
+		lIYEYYU7tRYJKwYBBAHaRw8BAQdAZ8vVdEyrWGssb7cdreG5GDGv6taHX/vWQdDG
+		jn7zib/+BwMCFjb4odY28+n0NWj7KZ53BkA0qzzqT9IpIfsW/tLNPTxYEFrDVbcF
+		1CuiAgAhyUfBEr9HQaMJBLfIIvo/B3nlWvwWHkiQFuWpsnJ2pj8F8LQqQ2hyaXN0
+		aWFuIEJvbmdpb3JubyA8Y2hyaXN0aWFuYkBqZnJvZy5jb20+iJoEExYKAEIWIQSS
+		w8jt+9pdVC3Gts7AvzSEkhHbJAUCYYU7tQIbAwUJA8JnAAULCQgHAgMiAgEGFQoJ
+		CAsCBBYCAwECHgcCF4AACgkQwL80hJIR2yRQDgD/X1t/hW9+uXdSY59FOClhQw/t
+		AzTYjDW+KLKadYJ3RAIBALD53rj7EnrXsSqv9Vqj3mJ7O38eXu50P57tD8ErpHMD
+		nIsEYYU7tRIKKwYBBAGXVQEFAQEHQCfT+jXHVkslGAJqVafoeWO8Nwz/oPPzNDJb
+		EOASsMRcAwEIB/4HAwK+Wi8OaidLuvQ6yknLUspoRL8KJlQu0JkfLxj6Wl6GrRtf
+		MdUBxaGUQX5UzMIqyYstgHKz2kBYvrJijWdOkkRuL82FySSh4yi/97FBikOBiHgE
+		GBYKACAWIQSSw8jt+9pdVC3Gts7AvzSEkhHbJAUCYYU7tQIbDAAKCRDAvzSEkhHb
+		JNR/AQCQjGWljmP8pYj6ohP8bOwVB4VE5qxjdfWQvBCUA0LFwgEAxLGVeT88pw3+
+		x7Cwd7SsuxlIOOCIJssFnUhA9Qsq2wE=
+		=qCzy
+		-----END PGP PRIVATE KEY BLOCK-----
+		EOF
+			public_key = <<EOF
+		-----BEGIN PGP PUBLIC KEY BLOCK-----
+	
+		mDMEYYU7tRYJKwYBBAHaRw8BAQdAZ8vVdEyrWGssb7cdreG5GDGv6taHX/vWQdDG
+		jn7zib+0KkNocmlzdGlhbiBCb25naW9ybm8gPGNocmlzdGlhbmJAamZyb2cuY29t
+		PoiaBBMWCgBCFiEEksPI7fvaXVQtxrbOwL80hJIR2yQFAmGFO7UCGwMFCQPCZwAF
+		CwkIBwIDIgIBBhUKCQgLAgQWAgMBAh4HAheAAAoJEMC/NISSEdskUA4A/19bf4Vv
+		frl3UmOfRTgpYUMP7QM02Iw1viiymnWCd0QCAQCw+d64+xJ617Eqr/Vao95iezt/
+		Hl7udD+e7Q/BK6RzA7g4BGGFO7USCisGAQQBl1UBBQEBB0An0/o1x1ZLJRgCalWn
+		6HljvDcM/6Dz8zQyWxDgErDEXAMBCAeIeAQYFgoAIBYhBJLDyO372l1ULca2zsC/
+		NISSEdskBQJhhTu1AhsMAAoJEMC/NISSEdsk1H8BAJCMZaWOY/yliPqiE/xs7BUH
+		hUTmrGN19ZC8EJQDQsXCAQDEsZV5PzynDf7HsLB3tKy7GUg44IgmywWdSED1Cyrb
+		AQ==
+		=2kMe
+		-----END PGP PUBLIC KEY BLOCK-----
+		EOF
+			lifecycle {
+				ignore_changes = [
+					private_key,
+					passphrase,
+				]
+			}
+		}
+		resource "artifactory_virtual_rpm_repository" "{{ .repo_name }}" {
+			key 	              = "{{ .repo_name }}"
+			primary_keypair_ref   = artifactory_keypair.{{ .kp_name }}.pair_name
+			secondary_keypair_ref = artifactory_keypair.{{ .kp_name2 }}.pair_name
+	
+			depends_on = [
+				artifactory_keypair.{{ .kp_name }},
+				artifactory_keypair.{{ .kp_name2 }},
+			]
+		}
+
+		data "artifactory_virtual_rpm_repository" "{{ .repo_name }}" {
+		    key = artifactory_virtual_rpm_repository.{{ .repo_name }}.id
+		}
+
+	`, map[string]interface{}{
+		"kp_id":     kpId,
+		"kp_name":   kpName,
+		"kp_id2":    kpId2,
+		"kp_name2":  kpName2,
+		"repo_name": name,
+	}) // we use randomness so that, in the case of failure and dangle, the next test can run without collision
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
+			acctest.VerifyDeleted(kpFqrn, security.VerifyKeyPair),
+			acctest.VerifyDeleted(kpFqrn2, security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: virtualRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", packageType),
+					resource.TestCheckResourceAttr(fqrn, "primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "secondary_keypair_ref", kpName2),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef(virtual.Rclass, packageType)()
+						return r.(string)
+					}()), //Check to ensure repository layout is set as per default even when it is not passed.
+				),
+			},
+		},
+	})
+}
+
+func mkNewVirtualTestCase(packageType string, t *testing.T, extraFields map[string]interface{}) (*testing.T, resource.TestCase) {
+	_, fqrn, name := test.MkNames(fmt.Sprintf("terraform-virtual-%s-repo-full-", packageType),
+		fmt.Sprintf("artifactory_virtual_%s_repository", packageType))
+	remoteRepoName := fmt.Sprintf("%s-remote", name)
+	defaultFields := map[string]interface{}{
+		"key":         name,
+		"description": "A test virtual repo",
+		"notes":       "Internal description",
+	}
+	allFields := util.MergeMaps(defaultFields, extraFields)
+	allFieldsHcl := util.FmtMapToHcl(allFields)
+	const virtualRepoFull = `
+        resource "artifactory_remote_%[1]s_repository" "%[3]s" {
+			key = "%[3]s"
+            url = "https://tempurl.org"
+			bypass_head_requests = true
+		}
+
+		resource "artifactory_virtual_%[1]s_repository" "%[2]s" {
+%[4]s
+            repositories = ["%[3]s"]
+            depends_on = [artifactory_remote_%[1]s_repository.%[3]s]
+		}
+
+		data "artifactory_virtual_%[1]s_repository" "%[2]s" {
+		    key = artifactory_virtual_%[1]s_repository.%[2]s.id
+		}
+	`
+	extraChecks := test.MapToTestChecks(fqrn, extraFields)
+	defaultChecks := test.MapToTestChecks(fqrn, allFields)
+
+	checks := append(defaultChecks, extraChecks...)
+	config := fmt.Sprintf(virtualRepoFull, packageType, name, remoteRepoName, allFieldsHcl)
+
+	return t, resource.TestCase{
+		PreCheck:          func() { acctest.PreCheck(t) },
+		ProviderFactories: acctest.ProviderFactories,
+		CheckDestroy:      acctest.VerifyDeleted(fqrn, acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check:  resource.ComposeTestCheckFunc(checks...),
+			},
+		},
+	}
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_rpm_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_rpm_repository.go
@@ -1,0 +1,34 @@
+package virtual
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository"
+	resource_repository "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/packer"
+)
+
+func DatasourceArtifactoryVirtualRpmRepository() *schema.Resource {
+	constructor := func() (interface{}, error) {
+		repoLayout, err := resource_repository.GetDefaultRepoLayoutRef(rclass, virtual.RpmPackageType)()
+		if err != nil {
+			return nil, err
+		}
+
+		return &virtual.RepositoryBaseParams{
+			PackageType:   virtual.RpmPackageType,
+			Rclass:        rclass,
+			RepoLayoutRef: repoLayout.(string),
+		}, nil
+	}
+
+	rpmSchema := virtual.RpmVirtualSchema
+
+	return &schema.Resource{
+		Schema:      rpmSchema,
+		ReadContext: repository.MkRepoReadDataSource(packer.Default(rpmSchema), constructor),
+		Description: fmt.Sprintf("Provides a data source for a virtual %s repository", virtual.RpmPackageType),
+	}
+}

--- a/pkg/artifactory/datasource/repository/virtual/virtual.go
+++ b/pkg/artifactory/datasource/repository/virtual/virtual.go
@@ -1,0 +1,3 @@
+package virtual
+
+const rclass = "virtual"

--- a/pkg/artifactory/provider/datasources.go
+++ b/pkg/artifactory/provider/datasources.go
@@ -8,12 +8,14 @@ import (
 	datasource_federated "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository/federated"
 	datasource_local "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository/local"
 	datasource_remote "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository/remote"
+	datasource_virtual "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/repository/virtual"
 	datasource_security "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/security"
 	datasource_user "github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/datasource/user"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/federated"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/local"
 	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/remote"
+	"github.com/jfrog/terraform-provider-artifactory/v6/pkg/artifactory/resource/repository/virtual"
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
@@ -48,6 +50,15 @@ func datasourcesMap() map[string]*schema.Resource {
 		"artifactory_remote_pypi_repository":                  datasource_remote.DataSourceArtifactoryRemotePypiRepository(),
 		"artifactory_remote_terraform_repository":             datasource_remote.DataSourceArtifactoryRemoteTerraformRepository(),
 		"artifactory_remote_vcs_repository":                   datasource_remote.DataSourceArtifactoryRemoteVcsRepository(),
+		"artifactory_virtual_alpine_repository":               datasource_virtual.DatasourceArtifactoryVirtualAlpineRepository(),
+		"artifactory_virtual_bower_repository":                datasource_virtual.DatasourceArtifactoryVirtualBowerRepository(),
+		"artifactory_virtual_debian_repository":               datasource_virtual.DatasourceArtifactoryVirtualDebianRepository(),
+		"artifactory_virtual_go_repository":                   datasource_virtual.DatasourceArtifactoryVirtualGoRepository(),
+		"artifactory_virtual_docker_repository":               datasource_virtual.DatasourceArtifactoryVirtualDockerRepository(),
+		"artifactory_virtual_helm_repository":                 datasource_virtual.DatasourceArtifactoryVirtualHelmRepository(),
+		"artifactory_virtual_npm_repository":                  datasource_virtual.DatasourceArtifactoryVirtualNpmRepository(),
+		"artifactory_virtual_nuget_repository":                datasource_virtual.DatasourceArtifactoryVirtualNugetRepository(),
+		"artifactory_virtual_rpm_repository":                  datasource_virtual.DatasourceArtifactoryVirtualRpmRepository(),
 		"artifactory_federated_alpine_repository":             datasource_federated.DataSourceArtifactoryFederatedAlpineRepository(),
 		"artifactory_federated_cargo_repository":              datasource_federated.DataSourceArtifactoryFederatedCargoRepository(),
 		"artifactory_federated_debian_repository":             datasource_federated.DataSourceArtifactoryFederatedDebianRepository(),
@@ -68,6 +79,9 @@ func datasourcesMap() map[string]*schema.Resource {
 		remoteResourceName := fmt.Sprintf("artifactory_remote_%s_repository", packageType)
 		dataSourcesMap[remoteResourceName] = datasource_remote.DataSourceArtifactoryRemoteJavaRepository(packageType, true)
 
+		virtualDataSourceName := fmt.Sprintf("artifactory_virtual_%s_repository", packageType)
+		dataSourcesMap[virtualDataSourceName] = datasource_virtual.DataSourceArtifactoryVirtualJavaRepository(packageType)
+
 		federatedResourceName := fmt.Sprintf("artifactory_federated_%s_repository", packageType)
 		dataSourcesMap[federatedResourceName] = datasource_federated.DataSourceArtifactoryFederatedJavaRepository(packageType, true)
 	}
@@ -80,6 +94,15 @@ func datasourcesMap() map[string]*schema.Resource {
 	for _, packageType := range remote.PackageTypesLikeBasic {
 		remoteDataSourceName := fmt.Sprintf("artifactory_remote_%s_repository", packageType)
 		dataSourcesMap[remoteDataSourceName] = datasource_remote.DataSourceArtifactoryRemoteBasicRepository(packageType)
+	}
+
+	for _, packageType := range virtual.PackageTypesLikeGeneric {
+		virtualDataSourceName := fmt.Sprintf("artifactory_virtual_%s_repository", packageType)
+		dataSourcesMap[virtualDataSourceName] = datasource_virtual.DataSourceArtifactoryVirtualGenericRepository(packageType)
+	}
+	for _, packageType := range virtual.PackageTypesLikeGenericWithRetrievalCachePeriodSecs {
+		virtualDataSourceName := fmt.Sprintf("artifactory_virtual_%s_repository", packageType)
+		dataSourcesMap[virtualDataSourceName] = datasource_virtual.DataSourceArtifactoryVirtualRepositoryWithRetrievalCachePeriodSecs(packageType)
 	}
 
 	for _, packageType := range federated.PackageTypesLikeGeneric {

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_alpine_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_alpine_repository.go
@@ -8,23 +8,22 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-func ResourceArtifactoryVirtualAlpineRepository() *schema.Resource {
+const AlpinePackageType = "alpine"
 
-	const packageType = "alpine"
-
-	var alpineVirtualSchema = util.MergeMaps(
-		BaseVirtualRepoSchema,
-		retrievalCachePeriodSecondsSchema,
-		map[string]*schema.Schema{
-			"primary_keypair_ref": {
-				Type:             schema.TypeString,
-				Optional:         true,
-				ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
-				Description:      "Primary keypair used to sign artifacts. Default value is empty.",
-			},
+var AlpineVirtualSchema = util.MergeMaps(
+	BaseVirtualRepoSchema,
+	RetrievalCachePeriodSecondsSchema,
+	map[string]*schema.Schema{
+		"primary_keypair_ref": {
+			Type:             schema.TypeString,
+			Optional:         true,
+			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+			Description:      "Primary keypair used to sign artifacts. Default value is empty.",
 		},
-		repository.RepoLayoutRefSchema("virtual", packageType))
+	},
+	repository.RepoLayoutRefSchema(Rclass, AlpinePackageType))
 
+func ResourceArtifactoryVirtualAlpineRepository() *schema.Resource {
 	type AlpineVirtualRepositoryParams struct {
 		RepositoryBaseParamsWithRetrievalCachePeriodSecs
 		PrimaryKeyPairRef string `hcl:"primary_keypair_ref" json:"primaryKeyPairRef"`
@@ -34,10 +33,10 @@ func ResourceArtifactoryVirtualAlpineRepository() *schema.Resource {
 		d := &util.ResourceData{ResourceData: s}
 
 		repo := AlpineVirtualRepositoryParams{
-			RepositoryBaseParamsWithRetrievalCachePeriodSecs: UnpackBaseVirtRepoWithRetrievalCachePeriodSecs(s, packageType),
+			RepositoryBaseParamsWithRetrievalCachePeriodSecs: UnpackBaseVirtRepoWithRetrievalCachePeriodSecs(s, AlpinePackageType),
 			PrimaryKeyPairRef: d.GetString("primary_keypair_ref", false),
 		}
-		repo.PackageType = packageType
+		repo.PackageType = AlpinePackageType
 		return &repo, repo.Key, nil
 	}
 
@@ -45,16 +44,16 @@ func ResourceArtifactoryVirtualAlpineRepository() *schema.Resource {
 		return &AlpineVirtualRepositoryParams{
 			RepositoryBaseParamsWithRetrievalCachePeriodSecs: RepositoryBaseParamsWithRetrievalCachePeriodSecs{
 				RepositoryBaseParams: RepositoryBaseParams{
-					Rclass:      "virtual",
-					PackageType: packageType,
+					Rclass:      Rclass,
+					PackageType: AlpinePackageType,
 				},
 			},
 		}, nil
 	}
 
 	return repository.MkResourceSchema(
-		alpineVirtualSchema,
-		packer.Default(alpineVirtualSchema),
+		AlpineVirtualSchema,
+		packer.Default(AlpineVirtualSchema),
 		unpackAlpineVirtualRepository,
 		constructor,
 	)

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_bower_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_bower_repository.go
@@ -7,33 +7,32 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
+const BowerPackageType = "bower"
+
+var BowerVirtualSchema = util.MergeMaps(
+	BaseVirtualRepoSchema,
+	externalDependenciesSchema,
+	repository.RepoLayoutRefSchema(Rclass, BowerPackageType),
+)
+
 func ResourceArtifactoryVirtualBowerRepository() *schema.Resource {
-
-	const packageType = "bower"
-
-	var bowerVirtualSchema = util.MergeMaps(
-		BaseVirtualRepoSchema,
-		externalDependenciesSchema,
-		repository.RepoLayoutRefSchema("virtual", packageType),
-	)
-
 	var unpackBowerVirtualRepository = func(s *schema.ResourceData) (interface{}, string, error) {
-		repo := unpackExternalDependenciesVirtualRepository(s, packageType)
+		repo := unpackExternalDependenciesVirtualRepository(s, BowerPackageType)
 		return repo, repo.Id(), nil
 	}
 
 	constructor := func() (interface{}, error) {
 		return &ExternalDependenciesVirtualRepositoryParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				Rclass:      "virtual",
-				PackageType: packageType,
+				Rclass:      Rclass,
+				PackageType: BowerPackageType,
 			},
 		}, nil
 	}
 
 	return repository.MkResourceSchema(
-		bowerVirtualSchema,
-		packer.Default(bowerVirtualSchema),
+		BowerVirtualSchema,
+		packer.Default(BowerVirtualSchema),
 		unpackBowerVirtualRepository,
 		constructor,
 	)

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_docker_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_docker_repository.go
@@ -7,18 +7,18 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
+const DockerPackageType = "docker"
+
+var DockerVirtualSchema = util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
+	"resolve_docker_tags_by_timestamp": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+		Description: "When enabled, in cases where the same Docker tag exists in two or more of the aggregated repositories, Artifactory will return the tag that has the latest timestamp.",
+	},
+}, repository.RepoLayoutRefSchema(Rclass, DockerPackageType))
+
 func ResourceArtifactoryVirtualDockerRepository() *schema.Resource {
-
-	const packageType = "docker"
-
-	dockerVirtualSchema := util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
-		"resolve_docker_tags_by_timestamp": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "When enabled, in cases where the same Docker tag exists in two or more of the aggregated repositories, Artifactory will return the tag that has the latest timestamp.",
-		},
-	}, repository.RepoLayoutRefSchema("virtual", packageType))
 
 	type DockerVirtualRepositoryParams struct {
 		RepositoryBaseParams
@@ -28,7 +28,7 @@ func ResourceArtifactoryVirtualDockerRepository() *schema.Resource {
 	unpackDockerVirtualRepository := func(data *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: data}
 		repo := DockerVirtualRepositoryParams{
-			RepositoryBaseParams:         UnpackBaseVirtRepo(data, "docker"),
+			RepositoryBaseParams:         UnpackBaseVirtRepo(data, DockerPackageType),
 			ResolveDockerTagsByTimestamp: d.GetBool("resolve_docker_tags_by_timestamp", false),
 		}
 
@@ -38,15 +38,15 @@ func ResourceArtifactoryVirtualDockerRepository() *schema.Resource {
 	constructor := func() (interface{}, error) {
 		return &DockerVirtualRepositoryParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				Rclass:      "virtual",
-				PackageType: packageType,
+				Rclass:      Rclass,
+				PackageType: DockerPackageType,
 			},
 		}, nil
 	}
 
 	return repository.MkResourceSchema(
-		dockerVirtualSchema,
-		packer.Default(dockerVirtualSchema),
+		DockerVirtualSchema,
+		packer.Default(DockerVirtualSchema),
 		unpackDockerVirtualRepository,
 		constructor,
 	)

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_generic_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_generic_repository.go
@@ -11,7 +11,7 @@ func ResourceArtifactoryVirtualGenericRepository(pkt string) *schema.Resource {
 	constructor := func() (interface{}, error) {
 		return &RepositoryBaseParams{
 			PackageType: pkt,
-			Rclass:      "virtual",
+			Rclass:      Rclass,
 		}, nil
 	}
 	unpack := func(data *schema.ResourceData) (interface{}, string, error) {
@@ -19,7 +19,8 @@ func ResourceArtifactoryVirtualGenericRepository(pkt string) *schema.Resource {
 		return repo, repo.Id(), nil
 	}
 
-	genericSchema := util.MergeMaps(BaseVirtualRepoSchema, repository.RepoLayoutRefSchema("virtual", pkt))
+	genericSchema := util.MergeMaps(BaseVirtualRepoSchema,
+		repository.RepoLayoutRefSchema(Rclass, pkt))
 
 	return repository.MkResourceSchema(genericSchema, packer.Default(genericSchema), unpack, constructor)
 }
@@ -27,14 +28,14 @@ func ResourceArtifactoryVirtualGenericRepository(pkt string) *schema.Resource {
 func ResourceArtifactoryVirtualRepositoryWithRetrievalCachePeriodSecs(pkt string) *schema.Resource {
 	var repoWithRetrivalCachePeriodSecsVirtualSchema = util.MergeMaps(
 		BaseVirtualRepoSchema,
-		retrievalCachePeriodSecondsSchema,
-		repository.RepoLayoutRefSchema("virtual", pkt),
+		RetrievalCachePeriodSecondsSchema,
+		repository.RepoLayoutRefSchema(Rclass, pkt),
 	)
 
 	constructor := func() (interface{}, error) {
 		return &RepositoryBaseParamsWithRetrievalCachePeriodSecs{
 			RepositoryBaseParams: RepositoryBaseParams{
-				Rclass:      "virtual",
+				Rclass:      Rclass,
 				PackageType: pkt,
 			},
 		}, nil

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_go_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_go_repository.go
@@ -7,31 +7,30 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
+const GoPackageType = "go"
+
+var GoVirtualSchema = util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
+
+	"external_dependencies_enabled": {
+		Type:        schema.TypeBool,
+		Default:     true,
+		Optional:    true,
+		Description: "When set (default), Artifactory will automatically follow remote VCS roots in 'go-import' meta tags to download remote modules.",
+	},
+	"external_dependencies_patterns": {
+		Type:     schema.TypeList,
+		Optional: true,
+		ForceNew: true,
+		Elem: &schema.Schema{
+			Type: schema.TypeString,
+		},
+		RequiredWith: []string{"external_dependencies_enabled"},
+		Description: "An allow list of Ant-style path patterns that determine which remote VCS roots Artifactory will " +
+			"follow to download remote modules from, when presented with 'go-import' meta tags in the remote repository response.",
+	},
+}, repository.RepoLayoutRefSchema(Rclass, GoPackageType))
+
 func ResourceArtifactoryVirtualGoRepository() *schema.Resource {
-
-	const packageType = "go"
-
-	var goVirtualSchema = util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
-
-		"external_dependencies_enabled": {
-			Type:        schema.TypeBool,
-			Default:     true,
-			Optional:    true,
-			Description: "When set (default), Artifactory will automatically follow remote VCS roots in 'go-import' meta tags to download remote modules.",
-		},
-		"external_dependencies_patterns": {
-			Type:     schema.TypeList,
-			Optional: true,
-			ForceNew: true,
-			Elem: &schema.Schema{
-				Type: schema.TypeString,
-			},
-			RequiredWith: []string{"external_dependencies_enabled"},
-			Description: "An allow list of Ant-style path patterns that determine which remote VCS roots Artifactory will " +
-				"follow to download remote modules from, when presented with 'go-import' meta tags in the remote repository response.",
-		},
-	}, repository.RepoLayoutRefSchema("virtual", packageType))
-
 	type GoVirtualRepositoryParams struct {
 		RepositoryBaseParams
 		ExternalDependenciesEnabled  bool     `hcl:"external_dependencies_enabled" json:"externalDependenciesEnabled,omitempty"`
@@ -42,7 +41,7 @@ func ResourceArtifactoryVirtualGoRepository() *schema.Resource {
 		d := &util.ResourceData{ResourceData: s}
 
 		repo := GoVirtualRepositoryParams{
-			RepositoryBaseParams:         UnpackBaseVirtRepo(s, packageType),
+			RepositoryBaseParams:         UnpackBaseVirtRepo(s, GoPackageType),
 			ExternalDependenciesPatterns: d.GetList("external_dependencies_patterns"),
 			ExternalDependenciesEnabled:  d.GetBool("external_dependencies_enabled", false),
 		}
@@ -53,15 +52,15 @@ func ResourceArtifactoryVirtualGoRepository() *schema.Resource {
 	constructor := func() (interface{}, error) {
 		return &GoVirtualRepositoryParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				Rclass:      "virtual",
-				PackageType: packageType,
+				Rclass:      Rclass,
+				PackageType: GoPackageType,
 			},
 		}, nil
 	}
 
 	return repository.MkResourceSchema(
-		goVirtualSchema,
-		packer.Default(goVirtualSchema),
+		GoVirtualSchema,
+		packer.Default(GoVirtualSchema),
 		unpackGoVirtualRepository,
 		constructor,
 	)

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_helm_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_helm_repository.go
@@ -7,23 +7,22 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
-func ResourceArtifactoryVirtualHelmRepository() *schema.Resource {
+const HelmPackageType = "helm"
 
-	const packageType = "helm"
-
-	helmVirtualSchema := util.MergeMaps(
-		BaseVirtualRepoSchema,
-		retrievalCachePeriodSecondsSchema,
-		map[string]*schema.Schema{
-			"use_namespaces": {
-				Type:        schema.TypeBool,
-				Optional:    true,
-				Default:     false,
-				Description: "From Artifactory 7.24.1 (SaaS Version), you can explicitly state a specific aggregated local or remote repository to fetch from a virtual by assigning namespaces to local and remote repositories\nSee https://www.jfrog.com/confluence/display/JFROG/Kubernetes+Helm+Chart+Repositories#KubernetesHelmChartRepositories-NamespaceSupportforHelmVirtualRepositories. Default to 'false'",
-			},
+var HelmVirtualSchema = util.MergeMaps(
+	BaseVirtualRepoSchema,
+	RetrievalCachePeriodSecondsSchema,
+	map[string]*schema.Schema{
+		"use_namespaces": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "From Artifactory 7.24.1 (SaaS Version), you can explicitly state a specific aggregated local or remote repository to fetch from a virtual by assigning namespaces to local and remote repositories\nSee https://www.jfrog.com/confluence/display/JFROG/Kubernetes+Helm+Chart+Repositories#KubernetesHelmChartRepositories-NamespaceSupportforHelmVirtualRepositories. Default to 'false'",
 		},
-		repository.RepoLayoutRefSchema("virtual", packageType))
+	},
+	repository.RepoLayoutRefSchema(Rclass, HelmPackageType))
 
+func ResourceArtifactoryVirtualHelmRepository() *schema.Resource {
 	type HelmVirtualRepositoryParams struct {
 		RepositoryBaseParamsWithRetrievalCachePeriodSecs
 		UseNamespaces bool `json:"useNamespaces"`
@@ -32,7 +31,7 @@ func ResourceArtifactoryVirtualHelmRepository() *schema.Resource {
 	unpackHelmVirtualRepository := func(data *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: data}
 		repo := HelmVirtualRepositoryParams{
-			RepositoryBaseParamsWithRetrievalCachePeriodSecs: UnpackBaseVirtRepoWithRetrievalCachePeriodSecs(data, "helm"),
+			RepositoryBaseParamsWithRetrievalCachePeriodSecs: UnpackBaseVirtRepoWithRetrievalCachePeriodSecs(data, HelmPackageType),
 			UseNamespaces: d.GetBool("use_namespaces", false),
 		}
 
@@ -43,8 +42,8 @@ func ResourceArtifactoryVirtualHelmRepository() *schema.Resource {
 		return &HelmVirtualRepositoryParams{
 			RepositoryBaseParamsWithRetrievalCachePeriodSecs: RepositoryBaseParamsWithRetrievalCachePeriodSecs{
 				RepositoryBaseParams: RepositoryBaseParams{
-					Rclass:      "virtual",
-					PackageType: packageType,
+					Rclass:      Rclass,
+					PackageType: HelmPackageType,
 				},
 			},
 			UseNamespaces: false,
@@ -52,8 +51,8 @@ func ResourceArtifactoryVirtualHelmRepository() *schema.Resource {
 	}
 
 	return repository.MkResourceSchema(
-		helmVirtualSchema,
-		packer.Default(helmVirtualSchema),
+		HelmVirtualSchema,
+		packer.Default(HelmVirtualSchema),
 		unpackHelmVirtualRepository,
 		constructor,
 	)

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_java_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_java_repository.go
@@ -19,33 +19,37 @@ type JavaVirtualRepositoryParams struct {
 	CommonJavaVirtualRepositoryParams
 }
 
+var JavaVirtualSchema = map[string]*schema.Schema{
+	"force_maven_authentication": {
+		Type:        schema.TypeBool,
+		Computed:    true,
+		Optional:    true,
+		Description: "User authentication is required when accessing the repository. An anonymous request will display an HTTP 401 error. This is also enforced when aggregated repositories support anonymous requests.",
+	},
+	"pom_repository_references_cleanup_policy": {
+		Type:     schema.TypeString,
+		Optional: true,
+		Computed: true,
+		ValidateFunc: validation.StringInSlice(
+			[]string{"discard_active_reference", "discard_any_reference", "nothing"}, false,
+		),
+		Description: "(1: discard_active_reference) Discard Active References - Removes repository elements that are declared directly under project or under a profile in the same POM that is activeByDefault.\n" +
+			"(2: discard_any_reference) Discard Any References - Removes all repository elements regardless of whether they are included in an active profile or not.\n" +
+			"(3: nothing) Nothing - Does not remove any repository elements declared in the POM.",
+	},
+	"key_pair": {
+		Type:        schema.TypeString,
+		Optional:    true,
+		Description: "The keypair used to sign artifacts",
+	},
+}
+
 func ResourceArtifactoryVirtualJavaRepository(repoType string) *schema.Resource {
-
-	var mavenVirtualSchema = util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
-
-		"force_maven_authentication": {
-			Type:        schema.TypeBool,
-			Computed:    true,
-			Optional:    true,
-			Description: "User authentication is required when accessing the repository. An anonymous request will display an HTTP 401 error. This is also enforced when aggregated repositories support anonymous requests.",
-		},
-		"pom_repository_references_cleanup_policy": {
-			Type:     schema.TypeString,
-			Optional: true,
-			Computed: true,
-			ValidateFunc: validation.StringInSlice(
-				[]string{"discard_active_reference", "discard_any_reference", "nothing"}, false,
-			),
-			Description: "(1: discard_active_reference) Discard Active References - Removes repository elements that are declared directly under project or under a profile in the same POM that is activeByDefault.\n" +
-				"(2: discard_any_reference) Discard Any References - Removes all repository elements regardless of whether they are included in an active profile or not.\n" +
-				"(3: nothing) Nothing - Does not remove any repository elements declared in the POM.",
-		},
-		"key_pair": {
-			Type:        schema.TypeString,
-			Optional:    true,
-			Description: "The keypair used to sign artifacts",
-		},
-	}, repository.RepoLayoutRefSchema("virtual", repoType))
+	var mavenVirtualSchema = util.MergeMaps(
+		BaseVirtualRepoSchema,
+		JavaVirtualSchema,
+		repository.RepoLayoutRefSchema(Rclass, repoType),
+	)
 
 	var unpackMavenVirtualRepository = func(s *schema.ResourceData) (interface{}, string, error) {
 		d := &util.ResourceData{ResourceData: s}
@@ -66,7 +70,7 @@ func ResourceArtifactoryVirtualJavaRepository(repoType string) *schema.Resource 
 	constructor := func() (interface{}, error) {
 		return &JavaVirtualRepositoryParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				Rclass:      "virtual",
+				Rclass:      Rclass,
 				PackageType: repoType,
 			},
 		}, nil

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_npm_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_npm_repository.go
@@ -7,16 +7,16 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
+const NpmPackageType = "npm"
+
+var NpmVirtualSchema = util.MergeMaps(
+	BaseVirtualRepoSchema,
+	RetrievalCachePeriodSecondsSchema,
+	externalDependenciesSchema,
+	repository.RepoLayoutRefSchema(Rclass, NpmPackageType),
+)
+
 func ResourceArtifactoryVirtualNpmRepository() *schema.Resource {
-
-	const packageType = "npm"
-
-	var npmVirtualSchema = util.MergeMaps(
-		BaseVirtualRepoSchema,
-		retrievalCachePeriodSecondsSchema,
-		externalDependenciesSchema,
-		repository.RepoLayoutRefSchema("virtual", packageType),
-	)
 
 	type NpmVirtualRepositoryParams struct {
 		ExternalDependenciesVirtualRepositoryParams
@@ -28,7 +28,7 @@ func ResourceArtifactoryVirtualNpmRepository() *schema.Resource {
 
 		repo := NpmVirtualRepositoryParams{
 			VirtualRetrievalCachePeriodSecs:             d.GetInt("retrieval_cache_period_seconds", false),
-			ExternalDependenciesVirtualRepositoryParams: unpackExternalDependenciesVirtualRepository(s, packageType),
+			ExternalDependenciesVirtualRepositoryParams: unpackExternalDependenciesVirtualRepository(s, NpmPackageType),
 		}
 		return &repo, repo.Key, nil
 	}
@@ -37,16 +37,16 @@ func ResourceArtifactoryVirtualNpmRepository() *schema.Resource {
 		return &NpmVirtualRepositoryParams{
 			ExternalDependenciesVirtualRepositoryParams: ExternalDependenciesVirtualRepositoryParams{
 				RepositoryBaseParams: RepositoryBaseParams{
-					Rclass:      "virtual",
-					PackageType: packageType,
+					Rclass:      Rclass,
+					PackageType: NpmPackageType,
 				},
 			},
 		}, nil
 	}
 
 	return repository.MkResourceSchema(
-		npmVirtualSchema,
-		packer.Default(npmVirtualSchema),
+		NpmVirtualSchema,
+		packer.Default(NpmVirtualSchema),
 		unpackNpmVirtualRepository,
 		constructor,
 	)

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_nuget_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_nuget_repository.go
@@ -7,18 +7,18 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
+const NugetPackageType = "nuget"
+
+var NugetVirtualSchema = util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
+	"force_nuget_authentication": {
+		Type:        schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+		Description: "If set, user authentication is required when accessing the repository. An anonymous request will display an HTTP 401 error. This is also enforced when aggregated repositories support anonymous requests.",
+	},
+}, repository.RepoLayoutRefSchema(Rclass, NugetPackageType))
+
 func ResourceArtifactoryVirtualNugetRepository() *schema.Resource {
-
-	const packageType = "nuget"
-
-	var nugetVirtualSchema = util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
-		"force_nuget_authentication": {
-			Type:        schema.TypeBool,
-			Optional:    true,
-			Default:     false,
-			Description: "If set, user authentication is required when accessing the repository. An anonymous request will display an HTTP 401 error. This is also enforced when aggregated repositories support anonymous requests.",
-		},
-	}, repository.RepoLayoutRefSchema("virtual", packageType))
 
 	type NugetVirtualRepositoryParams struct {
 		RepositoryBaseParams
@@ -29,25 +29,25 @@ func ResourceArtifactoryVirtualNugetRepository() *schema.Resource {
 		d := &util.ResourceData{ResourceData: s}
 
 		repo := NugetVirtualRepositoryParams{
-			RepositoryBaseParams:     UnpackBaseVirtRepo(s, packageType),
+			RepositoryBaseParams:     UnpackBaseVirtRepo(s, NugetPackageType),
 			ForceNugetAuthentication: d.GetBool("force_nuget_authentication", false),
 		}
-		repo.PackageType = packageType
+		repo.PackageType = NugetPackageType
 		return &repo, repo.Key, nil
 	}
 
 	constructor := func() (interface{}, error) {
 		return &NugetVirtualRepositoryParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				Rclass:      "virtual",
-				PackageType: packageType,
+				Rclass:      Rclass,
+				PackageType: NugetPackageType,
 			},
 		}, nil
 	}
 
 	return repository.MkResourceSchema(
-		nugetVirtualSchema,
-		packer.Default(nugetVirtualSchema),
+		NugetVirtualSchema,
+		packer.Default(NugetVirtualSchema),
 		unpackNugetVirtualRepository,
 		constructor,
 	)

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
@@ -160,7 +160,10 @@ func TestAccVirtualGoRepository_basic(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "external_dependencies_patterns.0", "**/github.com/**"),
 					resource.TestCheckResourceAttr(fqrn, "external_dependencies_patterns.1", "**/go.googlesource.com/**"),
 					resource.TestCheckResourceAttr(fqrn, "external_dependencies_patterns.#", "2"),
-					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("virtual", packageType)(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef(virtual.Rclass, packageType)()
+						return r.(string)
+					}()), //Check to ensure repository layout is set as per default even when it is not passed.
 				),
 			},
 			{
@@ -239,7 +242,10 @@ func TestAccVirtualGenericRepository_basic(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "key", name),
 					resource.TestCheckResourceAttr(fqrn, "package_type", packageType),
-					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("virtual", packageType)(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef(virtual.Rclass, packageType)()
+						return r.(string)
+					}()), //Check to ensure repository layout is set as per default even when it is not passed.
 				),
 			},
 			{
@@ -287,7 +293,10 @@ func TestAccVirtualMavenRepository_basic(t *testing.T) {
 					// to test key pair, we'd have to be able to create them on the fly and we currently can't.
 					resource.TestCheckResourceAttr(fqrn, "key_pair", ""),
 					resource.TestCheckResourceAttr(fqrn, "pom_repository_references_cleanup_policy", "discard_active_reference"),
-					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("virtual", packageType)(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef(virtual.Rclass, packageType)()
+						return r.(string)
+					}()), //Check to ensure repository layout is set as per default even when it is not passed.
 				),
 			},
 			{
@@ -473,7 +482,10 @@ func TestAccVirtualRpmRepository(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "package_type", packageType),
 					resource.TestCheckResourceAttr(fqrn, "primary_keypair_ref", kpName),
 					resource.TestCheckResourceAttr(fqrn, "secondary_keypair_ref", kpName2),
-					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("virtual", packageType)(); return r.(string) }()), //Check to ensure repository layout is set as per default even when it is not passed.
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef(virtual.Rclass, packageType)()
+						return r.(string)
+					}()), //Check to ensure repository layout is set as per default even when it is not passed.
 				),
 			},
 			{
@@ -905,7 +917,7 @@ func TestAccVirtualNpmExternalDependenciesRepository(t *testing.T) {
 		"name":           name,
 		"remoteRepoName": remoteRepoName,
 	}
-	var virtualBowerRepository = util.ExecuteTemplate("TestAccVirtualNpm", `
+	var virtualNpmRepository = util.ExecuteTemplate("TestAccVirtualNpm", `
 		resource "artifactory_remote_npm_repository" "npm-remote" {
 			key = "{{ .remoteRepoName }}"
 			url = "https://registry.npmjs.org"
@@ -930,7 +942,7 @@ func TestAccVirtualNpmExternalDependenciesRepository(t *testing.T) {
 
 		Steps: []resource.TestStep{
 			{
-				Config: virtualBowerRepository,
+				Config: virtualNpmRepository,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "key", name),
 					resource.TestCheckResourceAttr(fqrn, "package_type", "npm"),

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_rpm_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_rpm_repository.go
@@ -8,25 +8,24 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 )
 
+const RpmPackageType = "rpm"
+
+var RpmVirtualSchema = util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
+	"primary_keypair_ref": {
+		Type:             schema.TypeString,
+		Optional:         true,
+		ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+		Description:      "Primary keypair used to sign artifacts.",
+	},
+	"secondary_keypair_ref": {
+		Type:             schema.TypeString,
+		Optional:         true,
+		ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
+		Description:      "Secondary keypair used to sign artifacts.",
+	},
+}, repository.RepoLayoutRefSchema(Rclass, RpmPackageType))
+
 func ResourceArtifactoryVirtualRpmRepository() *schema.Resource {
-
-	const packageType = "rpm"
-
-	var rpmVirtualSchema = util.MergeMaps(BaseVirtualRepoSchema, map[string]*schema.Schema{
-		"primary_keypair_ref": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
-			Description:      "Primary keypair used to sign artifacts.",
-		},
-		"secondary_keypair_ref": {
-			Type:             schema.TypeString,
-			Optional:         true,
-			ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
-			Description:      "Secondary keypair used to sign artifacts.",
-		},
-	}, repository.RepoLayoutRefSchema("virtual", packageType))
-
 	type CommonRpmDebianVirtualRepositoryParams struct {
 		PrimaryKeyPairRef   string `hcl:"primary_keypair_ref" json:"primaryKeyPairRef"`
 		SecondaryKeyPairRef string `hcl:"secondary_keypair_ref" json:"secondaryKeyPairRef"`
@@ -55,15 +54,15 @@ func ResourceArtifactoryVirtualRpmRepository() *schema.Resource {
 	constructor := func() (interface{}, error) {
 		return &RpmVirtualRepositoryParams{
 			RepositoryBaseParams: RepositoryBaseParams{
-				Rclass:      "virtual",
-				PackageType: packageType,
+				Rclass:      Rclass,
+				PackageType: RpmPackageType,
 			},
 		}, nil
 	}
 
 	return repository.MkResourceSchema(
-		rpmVirtualSchema,
-		packer.Default(rpmVirtualSchema),
+		RpmVirtualSchema,
+		packer.Default(RpmVirtualSchema),
 		unpackRpmVirtualRepository,
 		constructor,
 	)

--- a/pkg/artifactory/resource/repository/virtual/virtual.go
+++ b/pkg/artifactory/resource/repository/virtual/virtual.go
@@ -8,6 +8,8 @@ import (
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
+const Rclass = "virtual"
+
 type RepositoryBaseParams struct {
 	Key                                           string   `hcl:"key" json:"key,omitempty"`
 	ProjectKey                                    string   `json:"projectKey"`
@@ -141,7 +143,7 @@ func UnpackBaseVirtRepo(s *schema.ResourceData, packageType string) RepositoryBa
 
 	return RepositoryBaseParams{
 		Key:                 d.GetString("key", false),
-		Rclass:              "virtual",
+		Rclass:              Rclass,
 		ProjectKey:          d.GetString("project_key", false),
 		ProjectEnvironments: d.GetSet("project_environments"),
 		PackageType:         packageType, // must be set independently
@@ -210,7 +212,7 @@ var unpackExternalDependenciesVirtualRepository = func(s *schema.ResourceData, p
 	}
 }
 
-var retrievalCachePeriodSecondsSchema = map[string]*schema.Schema{
+var RetrievalCachePeriodSecondsSchema = map[string]*schema.Schema{
 	"retrieval_cache_period_seconds": {
 		Type:     schema.TypeInt,
 		Optional: true,


### PR DESCRIPTION
Add documentation and tests.
Refactor virtual repo resources to be able to reuse the schemas in the data sources.