### PR TITLE
GH-728, 729 fix provider schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 7.10.0 (May 8, 2023).
+
+BUG FIXES:
+* Fixed a diff between SDK v2 and Plugin Framework providers schemas, which created a problem during the update process from older versions to 7.8.0
+* Removed default functions for the provider schema attributes. Defaults are set in the configuration step now to avoid schemas conflicts.
+
+  PR:     [#730](https://github.com/jfrog/terraform-provider-artifactory/pull/730)
+  Issues: 
+  * [#728](https://github.com/jfrog/terraform-provider-artifactory/issues/728)
+  * [#729](https://github.com/jfrog/terraform-provider-artifactory/issues/729)
+
 ## 7.9.0 (May 8, 2023). Tested on Artifactory 7.55.10
 
 FEATURES:

--- a/pkg/artifactory/provider/framework.go
+++ b/pkg/artifactory/provider/framework.go
@@ -29,6 +29,7 @@ type ArtifactoryProvider struct {
 type ArtifactoryProviderModel struct {
 	Url          types.String `tfsdk:"url"`
 	AccessToken  types.String `tfsdk:"access_token"`
+	ApiKey       types.String `tfsdk:"api_key"`
 	CheckLicense types.Bool   `tfsdk:"check_license"`
 }
 
@@ -43,17 +44,23 @@ func (p *ArtifactoryProvider) Schema(ctx context.Context, req provider.SchemaReq
 	resp.Schema = schema.Schema{
 		Attributes: map[string]schema.Attribute{
 			"url": schema.StringAttribute{
-				MarkdownDescription: "Artifactory URL.",
-				Optional:            true,
+				Description: "Artifactory URL.",
+				Optional:    true,
 			},
 			"access_token": schema.StringAttribute{
-				MarkdownDescription: "This is a access token that can be given to you by your admin under `Identity and Access`. If not set, the 'api_key' attribute value will be used.",
-				Optional:            true,
-				Sensitive:           true,
+				Description: "This is a access token that can be given to you by your admin under `Identity and Access`. If not set, the 'api_key' attribute value will be used.",
+				Optional:    true,
+				Sensitive:   true,
+			},
+			"api_key": schema.StringAttribute{
+				Description:        "API token. Projects functionality will not work with any auth method other than access tokens",
+				DeprecationMessage: "An upcoming version will support the option to block the usage/creation of API Keys (for admins to set on their platform). In September 2022, the option to block the usage/creation of API Keys will be enabled by default, with the option for admins to change it back to enable API Keys. In January 2023, API Keys will be deprecated all together and the option to use them will no longer be available.",
+				Optional:           true,
+				Sensitive:          true,
 			},
 			"check_license": schema.BoolAttribute{
-				MarkdownDescription: "Toggle for pre-flight checking of Artifactory Pro and Enterprise license. Default to `true`.",
-				Optional:            true,
+				Description: "Toggle for pre-flight checking of Artifactory Pro and Enterprise license. Default to `true`.",
+				Optional:    true,
 			},
 		},
 	}

--- a/pkg/artifactory/resource/security/resource_artifactory_distribution_public_key.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_distribution_public_key.go
@@ -9,7 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/jfrog/terraform-provider-shared/packer"
 	"github.com/jfrog/terraform-provider-shared/predicate"
-	"github.com/jfrog/terraform-provider-shared/util"
+	utilsdk "github.com/jfrog/terraform-provider-shared/util/sdk"
 )
 
 const DistributionPublicKeysAPIEndPoint = "artifactory/api/security/keys/trusted"
@@ -84,7 +84,7 @@ func ResourceArtifactoryDistributionPublicKey() *schema.Resource {
 
 		result := distributionPublicKeyPayLoad{}
 
-		resp, err := m.(util.ProvderMetadata).Client.R().SetBody(keyPost{
+		resp, err := m.(utilsdk.ProvderMetadata).Client.R().SetBody(keyPost{
 			d.Get("alias").(string),
 			stripTabs(d.Get("public_key").(string)),
 		}).SetResult(&result).Post(DistributionPublicKeysAPIEndPoint)
@@ -103,7 +103,7 @@ func ResourceArtifactoryDistributionPublicKey() *schema.Resource {
 	var resourceDistributionPublicKeyRead = func(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 
 		data := DistributionPublicKeysList{}
-		resp, err := m.(util.ProvderMetadata).Client.R().SetResult(&data).Get(DistributionPublicKeysAPIEndPoint)
+		resp, err := m.(utilsdk.ProvderMetadata).Client.R().SetResult(&data).Get(DistributionPublicKeysAPIEndPoint)
 		if err != nil {
 			return diag.FromErr(err)
 		}
@@ -123,7 +123,7 @@ func ResourceArtifactoryDistributionPublicKey() *schema.Resource {
 	}
 
 	var resourceDistributionPublictedKeyDelete = func(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-		resp, err := m.(util.ProvderMetadata).Client.R().Delete(fmt.Sprintf("%s/%s", DistributionPublicKeysAPIEndPoint, d.Id()))
+		resp, err := m.(utilsdk.ProvderMetadata).Client.R().Delete(fmt.Sprintf("%s/%s", DistributionPublicKeysAPIEndPoint, d.Id()))
 		if err != nil {
 			return diag.FromErr(err)
 		}

--- a/pkg/artifactory/resource/security/resource_artifactory_distribution_public_key_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_distribution_public_key_test.go
@@ -5,19 +5,19 @@ import (
 	"regexp"
 	"testing"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/security"
-	"github.com/jfrog/terraform-provider-shared/test"
-	"github.com/jfrog/terraform-provider-shared/util"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	utilsdk "github.com/jfrog/terraform-provider-shared/util/sdk"
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
 const resource_name = "artifactory_distribution_public_key"
 
 func TestAccDistributionPublicKeyFormatCheck(t *testing.T) {
-	id, _, name := test.MkNames("mykey", resource_name)
+	id, _, name := testutil.MkNames("mykey", resource_name)
 	keyBasic := fmt.Sprintf(`
 		resource "%s" "%s" {
 			alias = "foo-alias%d"
@@ -37,7 +37,7 @@ func TestAccDistributionPublicKeyFormatCheck(t *testing.T) {
 }
 
 func TestAccDistributionPublicKeyCreate(t *testing.T) {
-	id, fqrn, name := test.MkNames("mykey", resource_name)
+	id, fqrn, name := testutil.MkNames("mykey", resource_name)
 	keyBasic := fmt.Sprintf(`
 		resource "%s" "%s" {
 			alias = "foo-alias%d"
@@ -104,7 +104,7 @@ func TestAccDistributionPublicKeyCreate(t *testing.T) {
 
 func testAccCheckDistributionPublicKeyDestroy(id string) func(*terraform.State) error {
 	return func(s *terraform.State) error {
-		client := acctest.Provider.Meta().(util.ProvderMetadata).Client
+		client := acctest.Provider.Meta().(utilsdk.ProvderMetadata).Client
 
 		rs, ok := s.RootModule().Resources[id]
 		if !ok {

--- a/pkg/artifactory/resource/security/resource_artifactory_distribution_public_key_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_distribution_public_key_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/security"
 	"github.com/jfrog/terraform-provider-shared/testutil"
 	utilsdk "github.com/jfrog/terraform-provider-shared/util/sdk"
-	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
 const resource_name = "artifactory_distribution_public_key"
@@ -96,7 +95,6 @@ func TestAccDistributionPublicKeyCreate(t *testing.T) {
 				ResourceName:      fqrn,
 				ImportState:       true,
 				ImportStateVerify: true,
-				ImportStateCheck:  validator.CheckImportState(name, "public_key"),
 			},
 		},
 	})


### PR DESCRIPTION
GH-728, GH-729 fix the compatibility issue during migration from SDK v2 to Framework. 
Default values are removed now and schemas are the same in both SDK and Framework providers.
The difference in the provider schemas broke the provider, which wasn't detected in our standard tests.