### PR TITLE
GH-732 Fixing bug where `check_license` is always true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 BUG FIX: 
 * Fixed bug where `check_license` attribute was always `true` in the SDK v2 provider configuration.
 
-  PR:     [#]()
+  PR:     [#733](https://github.com/jfrog/terraform-provider-artifactory/pull/733)
   Issues: [#732](https://github.com/jfrog/terraform-provider-artifactory/issues/732)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 7.10.1 (May 10, 2023).
+
+BUG FIX: 
+* Fixed bug where `check_license` attribute was always `true` in the SDK v2 provider configuration.
+
+  PR:     [#]()
+  Issues: [#732](https://github.com/jfrog/terraform-provider-artifactory/issues/732)
+
+
 ## 7.10.0 (May 8, 2023).
 
 BUG FIXES:

--- a/pkg/artifactory/provider/sdkv2.go
+++ b/pkg/artifactory/provider/sdkv2.go
@@ -96,10 +96,12 @@ func providerConfigure(ctx context.Context, d *schema.ResourceData, terraformVer
 	}
 	// Due to migration from SDK v2 to plugin framework, we have to remove defaults from the provider configuration.
 	// https://discuss.hashicorp.com/t/muxing-upgraded-tfsdk-and-framework-provider-with-default-provider-configuration/43945
-	// License check will happen if `check_license` is true or if it's not set.
-	checkLicense := d.Get("check_license").(bool)
-	_, checkLicenseBoolSet := d.GetOk("check_license")
-	if checkLicense || !checkLicenseBoolSet {
+	checkLicense := true
+	v, checkLicenseBoolSet := d.GetOkExists("check_license")
+	if checkLicenseBoolSet {
+		checkLicense = v.(bool)
+	}
+	if checkLicense {
 		licenseErr := utilsdk.CheckArtifactoryLicense(restyBase, "Enterprise", "Commercial", "Edge")
 		if licenseErr != nil {
 			return nil, licenseErr

--- a/sample.tf
+++ b/sample.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     artifactory = {
       source  = "registry.terraform.io/jfrog/artifactory"
-      version = "7.0.2"
+      version = "7.10.1"
     }
   }
 }
@@ -370,7 +370,7 @@ resource "artifactory_remote_maven_repository" "maven-remote" {
   fetch_sources_eagerly              = false
   suppress_pom_consistency_checks    = false
   reject_invalid_jars                = true
-  metadata_retrieval_timeout_seconds = 120
+  metadata_retrieval_timeout_secs = 120
 }
 
 resource "artifactory_remote_npm_repository" "thing" {


### PR DESCRIPTION
In the SDK v2 provider configuration `check_license` was always true because of `GetOk` was returning `false` even if the attribute was set.
Fixing the attribute name in the .tf example.