### PR TITLE
GH-718, artifactory_local_repository_single_replication resource for ProX licenses. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 7.11.1 (May 23, 2023)
+
+IMPROVEMENTS: 
+
+* resource/artifactory_local_repository_single_replication: the resource can deal with different license types (Enterprise and ProX) to create replications. 
+The reason the change introduced, is the API response body is different for different license types.
+
+PR:     [#]()
+Issue:  [#718](https://github.com/jfrog/terraform-provider-artifactory/issues/718)
+
 ## 7.11.0 (May 16, 2023). Tested on Artifactory 7.55.13
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ IMPROVEMENTS:
 * resource/artifactory_local_repository_single_replication: the resource can deal with different license types (Enterprise and ProX) to create replications. 
 The reason the change introduced, is the API response body is different for different license types.
 
-PR:     [#]()
+PR:     [#737](https://github.com/jfrog/terraform-provider-artifactory/pull/737)
 Issue:  [#718](https://github.com/jfrog/terraform-provider-artifactory/issues/718)
 
 ## 7.11.0 (May 16, 2023). Tested on Artifactory 7.55.13

--- a/pkg/acctest/test.go
+++ b/pkg/acctest/test.go
@@ -48,7 +48,7 @@ func init() {
 	Provider = provider.SdkV2()
 
 	ProviderFactories = map[string]func() (*schema.Provider, error){
-		"artifactory": func() (*schema.Provider, error) { return provider.SdkV2(), nil },
+		"artifactory": func() (*schema.Provider, error) { return Provider, nil },
 	}
 
 	ProtoV5MuxProviderFactories = map[string]func() (tfprotov5.ProviderServer, error){
@@ -56,7 +56,7 @@ func init() {
 			ctx := context.Background()
 			providers := []func() tfprotov5.ProviderServer{
 				providerserver.NewProtocol5(provider.Framework()()), // terraform-plugin-framework provider
-				provider.SdkV2().GRPCProvider,                       // terraform-plugin-sdk provider
+				Provider.GRPCProvider,                               // terraform-plugin-sdk provider
 			}
 
 			muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)

--- a/pkg/acctest/test.go
+++ b/pkg/acctest/test.go
@@ -42,23 +42,7 @@ var testAccProviderConfigure sync.Once
 
 // ProtoV5MuxProviderFactories is used to instantiate both SDK v2 and Framework providers
 // during acceptance tests. Use it only if you need to combine resources from SDK v2 and the Framework in the same test.
-var ProtoV5MuxProviderFactories = map[string]func() (tfprotov5.ProviderServer, error){
-	"artifactory": func() (tfprotov5.ProviderServer, error) {
-		ctx := context.Background()
-		providers := []func() tfprotov5.ProviderServer{
-			providerserver.NewProtocol5(provider.Framework()()), // terraform-plugin-framework provider
-			provider.SdkV2().GRPCProvider,                       // terraform-plugin-sdk provider
-		}
-
-		muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
-
-		if err != nil {
-			return nil, err
-		}
-
-		return muxServer.ProviderServer(), nil
-	},
-}
+var ProtoV5MuxProviderFactories map[string]func() (tfprotov5.ProviderServer, error)
 
 func init() {
 	Provider = provider.SdkV2()
@@ -66,6 +50,25 @@ func init() {
 	ProviderFactories = map[string]func() (*schema.Provider, error){
 		"artifactory": func() (*schema.Provider, error) { return provider.SdkV2(), nil },
 	}
+
+	ProtoV5MuxProviderFactories = map[string]func() (tfprotov5.ProviderServer, error){
+		"artifactory": func() (tfprotov5.ProviderServer, error) {
+			ctx := context.Background()
+			providers := []func() tfprotov5.ProviderServer{
+				providerserver.NewProtocol5(provider.Framework()()), // terraform-plugin-framework provider
+				provider.SdkV2().GRPCProvider,                       // terraform-plugin-sdk provider
+			}
+
+			muxServer, err := tf5muxserver.NewMuxServer(ctx, providers...)
+
+			if err != nil {
+				return nil, err
+			}
+
+			return muxServer.ProviderServer(), nil
+		},
+	}
+
 }
 
 // PreCheck This function should be present in every acceptance test.
@@ -224,8 +227,9 @@ func GetValidRandomDefaultRepoLayoutRef() string {
 // updateProxiesConfig is used by acctest.CreateProxy and acctest.DeleteProxy to interact with a proxy on Artifactory
 var updateProxiesConfig = func(t *testing.T, proxyKey string, getProxiesBody func() []byte) {
 	body := getProxiesBody()
-
-	err := configuration.SendConfigurationPatch(body, Provider.Meta())
+	restyClient := GetTestResty(t)
+	metadata := utilsdk.ProvderMetadata{Client: restyClient}
+	err := configuration.SendConfigurationPatch(body, metadata)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/artifactory/resource/replication/resource_artifactory_local_repository_single_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_local_repository_single_replication.go
@@ -243,7 +243,7 @@ func resourceLocalSingleReplicationRead(_ context.Context, d *schema.ResourceDat
 		return packLocalSingleReplication(&replication, d)
 	}
 
-	return nil
+	return diag.Errorf("Error during converting the API call payload.")
 }
 
 func resourceLocalSingleReplicationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {

--- a/pkg/artifactory/resource/replication/resource_artifactory_local_repository_single_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_local_repository_single_replication.go
@@ -2,6 +2,7 @@ package replication
 
 import (
 	"context"
+	"encoding/json"
 	"net/http"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
@@ -38,10 +39,6 @@ type getLocalSingleReplicationBody struct {
 type updateLocalSingleReplicationBody struct {
 	localSingleReplicationBody
 	Proxy string `json:"proxy"`
-}
-
-type GetLocalSingleReplicationBody struct {
-	Replication []getLocalSingleReplicationBody
 }
 
 var localSingleReplicationSchema = map[string]*schema.Schema{
@@ -170,25 +167,25 @@ func unpackLocalSingleReplication(s *schema.ResourceData) updateLocalSingleRepli
 	}
 }
 
-func packLocalSingleReplication(singleLocalReplication *GetLocalSingleReplicationBody, d *schema.ResourceData) diag.Diagnostics {
+func packLocalSingleReplication(singleLocalReplication *getLocalSingleReplicationBody, d *schema.ResourceData) diag.Diagnostics {
 
 	var errors []error
 	setValue := utilsdk.MkLens(d)
-	setValue("url", singleLocalReplication.Replication[0].URL)
-	setValue("socket_timeout_millis", singleLocalReplication.Replication[0].SocketTimeoutMillis)
-	setValue("username", singleLocalReplication.Replication[0].Username)
-	setValue("enable_event_replication", singleLocalReplication.Replication[0].EnableEventReplication)
-	setValue("enabled", singleLocalReplication.Replication[0].Enabled)
-	setValue("cron_exp", singleLocalReplication.Replication[0].CronExp)
-	setValue("sync_deletes", singleLocalReplication.Replication[0].SyncDeletes)
-	setValue("sync_properties", singleLocalReplication.Replication[0].SyncProperties)
-	setValue("sync_statistics", singleLocalReplication.Replication[0].SyncStatistics)
-	setValue("repo_key", singleLocalReplication.Replication[0].RepoKey)
-	setValue("include_path_prefix_pattern", singleLocalReplication.Replication[0].IncludePathPrefixPattern)
-	setValue("exclude_path_prefix_pattern", singleLocalReplication.Replication[0].ExcludePathPrefixPattern)
-	setValue("proxy", singleLocalReplication.Replication[0].ProxyRef)
-	setValue("replication_key", singleLocalReplication.Replication[0].ReplicationKey)
-	errors = setValue("check_binary_existence_in_filestore", singleLocalReplication.Replication[0].CheckBinaryExistenceInFilestore)
+	setValue("url", singleLocalReplication.URL)
+	setValue("socket_timeout_millis", singleLocalReplication.SocketTimeoutMillis)
+	setValue("username", singleLocalReplication.Username)
+	setValue("enable_event_replication", singleLocalReplication.EnableEventReplication)
+	setValue("enabled", singleLocalReplication.Enabled)
+	setValue("cron_exp", singleLocalReplication.CronExp)
+	setValue("sync_deletes", singleLocalReplication.SyncDeletes)
+	setValue("sync_properties", singleLocalReplication.SyncProperties)
+	setValue("sync_statistics", singleLocalReplication.SyncStatistics)
+	setValue("repo_key", singleLocalReplication.RepoKey)
+	setValue("include_path_prefix_pattern", singleLocalReplication.IncludePathPrefixPattern)
+	setValue("exclude_path_prefix_pattern", singleLocalReplication.ExcludePathPrefixPattern)
+	setValue("proxy", singleLocalReplication.ProxyRef)
+	setValue("replication_key", singleLocalReplication.ReplicationKey)
+	errors = setValue("check_binary_existence_in_filestore", singleLocalReplication.CheckBinaryExistenceInFilestore)
 
 	if errors != nil && len(errors) > 0 {
 		return diag.Errorf("failed to pack replication config %q", errors)
@@ -216,10 +213,9 @@ func resourceLocalSingleReplicationCreate(ctx context.Context, d *schema.Resourc
 
 func resourceLocalSingleReplicationRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
 	c := m.(utilsdk.ProvderMetadata).Client
+	var replicationInterface interface{}
 
-	var replication []getLocalSingleReplicationBody
-
-	resp, err := c.R().SetResult(&replication).Get(EndpointPath + d.Id())
+	resp, err := c.R().SetResult(&replicationInterface).Get(EndpointPath + d.Id())
 
 	if err != nil {
 		if resp != nil && (resp.StatusCode() == http.StatusBadRequest || resp.StatusCode() == http.StatusNotFound) {
@@ -228,11 +224,26 @@ func resourceLocalSingleReplicationRead(_ context.Context, d *schema.ResourceDat
 		}
 		return diag.FromErr(err)
 	}
-	repConfig := GetLocalSingleReplicationBody{
-		Replication: replication,
+
+	replicationList, ok := replicationInterface.([]interface{})
+	if ok {
+		jsonData, _ := json.Marshal(replicationList)
+		var replications []getLocalSingleReplicationBody
+		json.Unmarshal(jsonData, &replications)
+
+		return packLocalSingleReplication(&replications[0], d)
 	}
 
-	return packLocalSingleReplication(&repConfig, d)
+	replicationObj, ok := replicationInterface.(interface{})
+	if ok {
+		jsonData, _ := json.Marshal(replicationObj)
+		var replication getLocalSingleReplicationBody
+		json.Unmarshal(jsonData, &replication)
+
+		return packLocalSingleReplication(&replication, d)
+	}
+
+	return nil
 }
 
 func resourceLocalSingleReplicationUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {


### PR DESCRIPTION
Fix the issue when the resource can't deal with the replication call body, if it's a JSON object and not a list.
- Modify test init function to use Mux provider