### PR TITLE
PTRENG-5197 remove `unmanaged_user` from all the tests.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 7.11.1 (May 23, 2023). Tested on Artifactory 7.55.13
+## 7.11.1 (May 23, 2023). Tested on Artifactory 7.55.14
 
 IMPROVEMENTS: 
 

--- a/pkg/artifactory/datasource/security/datasource_artifactory_permission_target_test.go
+++ b/pkg/artifactory/datasource/security/datasource_artifactory_permission_target_test.go
@@ -74,14 +74,14 @@ func TestAccDataSourcePermissionTarget_full(t *testing.T) {
 		"permission_name": name,
 	}
 
-	_, _, userName := testutil.MkNames("test-user", "artifactory_unmanaged_user")
+	_, _, userName := testutil.MkNames("test-user", "artifactory_managed_user")
 
 	resource.Test(t, resource.TestCase{
 		PreCheck: func() {
 			acctest.PreCheck(t)
 			createPermissionTarget(name, userName, t)
 		},
-		ProviderFactories: acctest.ProviderFactories,
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
 		CheckDestroy: func(state *terraform.State) error {
 			err := deletePermissionTarget(t, name)
 			_ = acctest.DeleteUser(t, userName)

--- a/pkg/artifactory/resource/security/resource_artifactory_access_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_access_token_test.go
@@ -16,7 +16,7 @@ import (
 
 func TestAccAccessTokenAudienceBad(t *testing.T) {
 	const audienceBad = `
-		resource "artifactory_unmanaged_user" "existinguser" {
+		resource "artifactory_managed_user" "existinguser" {
 			name  = "existinguser"
 			email = "existinguser@a.com"
 			admin = false
@@ -26,15 +26,15 @@ func TestAccAccessTokenAudienceBad(t *testing.T) {
 
 		resource "artifactory_access_token" "foobar" {
 			end_date_relative = "1s"
-			username = artifactory_unmanaged_user.existinguser.name
+			username = artifactory_managed_user.existinguser.name
 			audience = "bad"
 			refreshable = true
 		}
 	`
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
 		Steps: []resource.TestStep{
 			{
 				Config:      audienceBad,
@@ -47,7 +47,7 @@ func TestAccAccessTokenAudienceBad(t *testing.T) {
 func TestAccAccessTokenAudienceGood(t *testing.T) {
 	fqrn := "artifactory_access_token.foobar"
 	const audienceGood = `
-		resource "artifactory_unmanaged_user" "existinguser" {
+		resource "artifactory_managed_user" "existinguser" {
 			name  = "existinguser"
 			email = "existinguser@a.com"
 			admin = false
@@ -57,15 +57,15 @@ func TestAccAccessTokenAudienceGood(t *testing.T) {
 
 		resource "artifactory_access_token" "foobar" {
 			end_date_relative = "1s"
-			username = artifactory_unmanaged_user.existinguser.name
+			username = artifactory_managed_user.existinguser.name
 			audience = "jfrt@*"
 			refreshable = true
 		}
 	`
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckAccessTokenDestroy(t, fqrn),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testAccCheckAccessTokenDestroy(t, fqrn),
 		Steps: []resource.TestStep{
 			{
 				Config: audienceGood,
@@ -90,7 +90,7 @@ func TestAccAccessTokenAudienceGood(t *testing.T) {
 }
 
 const existingUser = `
-resource "artifactory_unmanaged_user" "existinguser" {
+resource "artifactory_managed_user" "existinguser" {
 	name  = "existinguser"
     email = "existinguser@a.com"
 	admin = false
@@ -100,16 +100,16 @@ resource "artifactory_unmanaged_user" "existinguser" {
 
 resource "artifactory_access_token" "foobar" {
 	end_date_relative = "1s"
-	username = artifactory_unmanaged_user.existinguser.name
+	username = artifactory_managed_user.existinguser.name
 }
 `
 
 func TestAccAccessTokenExistingUser(t *testing.T) {
 	fqrn := "artifactory_access_token.foobar"
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckAccessTokenDestroy(t, "artifactory_access_token.foobar"),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testAccCheckAccessTokenDestroy(t, "artifactory_access_token.foobar"),
 		Steps: []resource.TestStep{
 			{
 				Config: existingUser,
@@ -137,7 +137,7 @@ func fixedDateGood() string {
 
 	date := time.Now().Add(time.Second * time.Duration(10)).Format(time.RFC3339)
 	return fmt.Sprintf(`
-resource "artifactory_unmanaged_user" "existinguser" {
+resource "artifactory_managed_user" "existinguser" {
 	name  = "existinguser"
     email = "existinguser@a.com"
 	admin = false
@@ -147,7 +147,7 @@ resource "artifactory_unmanaged_user" "existinguser" {
 
 resource "artifactory_access_token" "foobar" {
 	end_date = "%s"
-	username = artifactory_unmanaged_user.existinguser.name
+	username = artifactory_managed_user.existinguser.name
 }
 `, date)
 }
@@ -155,9 +155,9 @@ resource "artifactory_access_token" "foobar" {
 func TestAccAccessTokenFixedDateGood(t *testing.T) {
 	fqrn := "artifactory_access_token.foobar"
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckAccessTokenDestroy(t, "artifactory_access_token.foobar"),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testAccCheckAccessTokenDestroy(t, "artifactory_access_token.foobar"),
 		Steps: []resource.TestStep{
 			{
 				Config: fixedDateGood(),
@@ -180,7 +180,7 @@ func TestAccAccessTokenFixedDateGood(t *testing.T) {
 }
 
 var fixedDateBad = `
-resource "artifactory_unmanaged_user" "existinguser" {
+resource "artifactory_managed_user" "existinguser" {
 	name  = "existinguser"
     email = "existinguser@a.com"
 	admin = false
@@ -190,15 +190,15 @@ resource "artifactory_unmanaged_user" "existinguser" {
 
 resource "artifactory_access_token" "foobar" {
 	end_date = "2020-01-01T00:00:00+11:00"
-	username = artifactory_unmanaged_user.existinguser.name
+	username = artifactory_managed_user.existinguser.name
 }
 `
 
 func TestAccAccessTokenFixedDateBad(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
 		Steps: []resource.TestStep{
 			{
 				Config:      fixedDateBad,
@@ -211,7 +211,7 @@ func TestAccAccessTokenFixedDateBad(t *testing.T) {
 // I couldn't find a way to retrieve the instance_id for artifactory via the go library.
 // So, we expect this to fail
 const adminToken = `
-resource "artifactory_unmanaged_user" "existinguser" {
+resource "artifactory_managed_user" "existinguser" {
 	name  = "existinguser"
     email = "existinguser@a.com"
 	admin = false
@@ -221,7 +221,7 @@ resource "artifactory_unmanaged_user" "existinguser" {
 
 resource "artifactory_access_token" "foobar" {
 	end_date_relative = "1s"
-	username = artifactory_unmanaged_user.existinguser.name
+	username = artifactory_managed_user.existinguser.name
 
 	admin_token {
 		instance_id = "blah"
@@ -231,9 +231,9 @@ resource "artifactory_access_token" "foobar" {
 
 func TestAccAccessTokenAdminToken(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
 		Steps: []resource.TestStep{
 			{
 				Config:      adminToken,
@@ -244,7 +244,7 @@ func TestAccAccessTokenAdminToken(t *testing.T) {
 }
 
 const refreshableToken = `
-resource "artifactory_unmanaged_user" "existinguser" {
+resource "artifactory_managed_user" "existinguser" {
 	name  = "existinguser"
     email = "existinguser@a.com"
 	admin = false
@@ -255,16 +255,16 @@ resource "artifactory_unmanaged_user" "existinguser" {
 resource "artifactory_access_token" "foobar" {
 	end_date_relative = "1s"
 	refreshable = true
-	username = artifactory_unmanaged_user.existinguser.name
+	username = artifactory_managed_user.existinguser.name
 }
 `
 
 func TestAccAccessTokenRefreshableToken(t *testing.T) {
 	fqrn := "artifactory_access_token.foobar"
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckAccessTokenDestroy(t, "artifactory_access_token.foobar"),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testAccCheckAccessTokenDestroy(t, "artifactory_access_token.foobar"),
 		Steps: []resource.TestStep{
 			{
 				Config: refreshableToken,
@@ -350,7 +350,7 @@ func TestAccAccessTokenMissingUserGood(t *testing.T) {
 }
 
 const missingGroup = `
-resource "artifactory_unmanaged_user" "existinguser" {
+resource "artifactory_managed_user" "existinguser" {
 	name  = "existinguser"
     email = "existinguser@a.com"
 	admin = false
@@ -360,7 +360,7 @@ resource "artifactory_unmanaged_user" "existinguser" {
 
 resource "artifactory_access_token" "foobar" {
 	end_date_relative = "1s"
-	username = artifactory_unmanaged_user.existinguser.name
+	username = artifactory_managed_user.existinguser.name
 	groups = [
 		"missing-group",
 	]
@@ -369,9 +369,9 @@ resource "artifactory_access_token" "foobar" {
 
 func TestAccAccessTokenMissingGroup(t *testing.T) {
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testAccCheckAccessTokenNotCreated("artifactory_access_token.foobar"),
 		Steps: []resource.TestStep{
 			{
 				Config:      missingGroup,
@@ -382,7 +382,7 @@ func TestAccAccessTokenMissingGroup(t *testing.T) {
 }
 
 const wildcardGroupGood = `
-resource "artifactory_unmanaged_user" "existinguser" {
+resource "artifactory_managed_user" "existinguser" {
 	name  = "existinguser"
   email = "existinguser@a.com"
 	admin = false
@@ -392,7 +392,7 @@ resource "artifactory_unmanaged_user" "existinguser" {
 
 resource "artifactory_access_token" "foobar" {
 	end_date_relative = "1s"
-	username = artifactory_unmanaged_user.existinguser.name
+	username = artifactory_managed_user.existinguser.name
 	groups = [
 		"*",
 	]
@@ -402,9 +402,9 @@ resource "artifactory_access_token" "foobar" {
 func TestAccAccessTokenWildcardGroupGood(t *testing.T) {
 	fqrn := "artifactory_access_token.foobar"
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckAccessTokenDestroy(t, "artifactory_access_token.foobar"),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testAccCheckAccessTokenDestroy(t, "artifactory_access_token.foobar"),
 		Steps: []resource.TestStep{
 			{
 				Config: wildcardGroupGood,
@@ -429,7 +429,7 @@ func TestAccAccessTokenWildcardGroupGood(t *testing.T) {
 }
 
 const nonExpiringToken = `
-resource "artifactory_unmanaged_user" "existinguser" {
+resource "artifactory_managed_user" "existinguser" {
 	name  = "existinguser"
     email = "existinguser@a.com"
 	admin = false
@@ -439,16 +439,16 @@ resource "artifactory_unmanaged_user" "existinguser" {
 
 resource "artifactory_access_token" "foobar" {
 	end_date_relative = "0s"
-	username = artifactory_unmanaged_user.existinguser.name
+	username = artifactory_managed_user.existinguser.name
 }
 `
 
 func TestAccAccessTokenNonExpiringToken(t *testing.T) {
 	fqrn := "artifactory_access_token.foobar"
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testAccCheckAccessTokenDestroy(t, "artifactory_access_token.foobar"),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testAccCheckAccessTokenDestroy(t, "artifactory_access_token.foobar"),
 		Steps: []resource.TestStep{
 			{
 				Config: nonExpiringToken,

--- a/pkg/artifactory/resource/security/resource_artifactory_permission_target_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_permission_target_test.go
@@ -76,7 +76,7 @@ const permissionFull = `
 	//	key 	     = "{{ .repo_name }}"
 	//}
 
-	resource "artifactory_unmanaged_user" "test-user" {
+	resource "artifactory_managed_user" "test-user" {
 		name     = "terraform"
 		email    = "test-user@artifactory-terraform.com"
 		password = "Passsw0rd!"
@@ -92,7 +92,7 @@ const permissionFull = `
 
 		actions {
 			users {
-				name        = artifactory_unmanaged_user.test-user.name
+				name        = artifactory_managed_user.test-user.name
 				permissions = ["read", "write", "annotate", "delete"]
 			}
 
@@ -110,7 +110,7 @@ const permissionFull = `
 
 		actions {
 			users {
-				name        = artifactory_unmanaged_user.test-user.name
+				name        = artifactory_managed_user.test-user.name
 				permissions = ["read", "write", "manage", "annotate", "delete"]
 			}
 
@@ -128,7 +128,7 @@ const permissionFull = `
 
 		actions {
 			users {
-				name        = artifactory_unmanaged_user.test-user.name
+				name        = artifactory_managed_user.test-user.name
 				permissions = ["read", "write", "managedXrayMeta", "distribute"]
 			}
 
@@ -145,14 +145,14 @@ const permissionFull = `
 func TestAccPermissionTarget_GitHubIssue126(t *testing.T) {
 	_, permFqrn, permName := testutil.MkNames("test-perm", "artifactory_permission_target")
 	_, _, repoName := testutil.MkNames("test-perm-repo", "artifactory_local_generic_repository")
-	_, _, username := testutil.MkNames("artifactory_unmanaged_user", "artifactory_unmanaged_user")
+	_, _, username := testutil.MkNames("artifactory_managed_user", "artifactory_managed_user")
 	testConfig := `
 		resource "artifactory_local_generic_repository" "{{ .repo_name }}" {
 		  key             = "{{ .repo_name }}"
 		  repo_layout_ref = "simple-default"
 		}
 
-		resource "artifactory_unmanaged_user" "{{ .username }}" {
+		resource "artifactory_managed_user" "{{ .username }}" {
 		  name                       = "{{ .username }}"
 		  email                      = "example@example.com"
 		  groups                     = ["readers"]
@@ -171,7 +171,7 @@ func TestAccPermissionTarget_GitHubIssue126(t *testing.T) {
 			]
 			actions {
 			  users {
-				name        = artifactory_unmanaged_user.{{ .username }}.name
+				name        = artifactory_managed_user.{{ .username }}.name
 				permissions = ["annotate", "read", "write", "delete"]
 			  }
 			}
@@ -184,9 +184,9 @@ func TestAccPermissionTarget_GitHubIssue126(t *testing.T) {
 	}
 	foo := utilsdk.ExecuteTemplate(permFqrn, testConfig, variables)
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testPermissionTargetCheckDestroy(permFqrn),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testPermissionTargetCheckDestroy(permFqrn),
 		Steps: []resource.TestStep{
 			{
 				Config: foo,
@@ -216,9 +216,9 @@ func TestAccPermissionTarget_full(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testPermissionTargetCheckDestroy(permFqrn),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testPermissionTargetCheckDestroy(permFqrn),
 		Steps: []resource.TestStep{
 			{
 				Config: utilsdk.ExecuteTemplate(permFqrn, permissionFull, tempStruct),
@@ -260,9 +260,9 @@ func TestAccPermissionTarget_user_permissions(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testPermissionTargetCheckDestroy(permFqrn),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testPermissionTargetCheckDestroy(permFqrn),
 		Steps: []resource.TestStep{
 			{
 				Config: utilsdk.ExecuteTemplate(permFqrn, permissionFull, tempStruct),
@@ -311,9 +311,9 @@ func TestAccPermissionTarget_addBuild(t *testing.T) {
 	}
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      testPermissionTargetCheckDestroy(permFqrn),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             testPermissionTargetCheckDestroy(permFqrn),
 		Steps: []resource.TestStep{
 			{
 				Config: utilsdk.ExecuteTemplate(permFqrn, permissionNoIncludes, tempStruct),

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
@@ -17,7 +17,7 @@ func TestAccScopedToken_WithDefaults(t *testing.T) {
 
 	accessTokenConfig := utilsdk.ExecuteTemplate(
 		"TestAccScopedToken",
-		`resource "artifactory_unmanaged_user" "test-user" {
+		`resource "artifactory_managed_user" "test-user" {
 			name              = "testuser"
 		    email             = "testuser@tempurl.org"
 			admin             = true
@@ -27,7 +27,7 @@ func TestAccScopedToken_WithDefaults(t *testing.T) {
 		}
 
 		resource "artifactory_scoped_token" "{{ .name }}" {
-			username    = artifactory_unmanaged_user.test-user.name
+			username    = artifactory_managed_user.test-user.name
 			description = "test description"
 		}`,
 		map[string]interface{}{
@@ -36,9 +36,9 @@ func TestAccScopedToken_WithDefaults(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
-		CheckDestroy:      acctest.VerifyDeleted(fqrn, security.CheckAccessToken),
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(fqrn, security.CheckAccessToken),
 		Steps: []resource.TestStep{
 			{
 				Config: accessTokenConfig,
@@ -73,7 +73,7 @@ func TestAccScopedToken_WithAttributes(t *testing.T) {
 
 	accessTokenConfig := utilsdk.ExecuteTemplate(
 		"TestAccScopedToken",
-		`resource "artifactory_unmanaged_user" "test-user" {
+		`resource "artifactory_managed_user" "test-user" {
 			name              = "testuser"
 		    email             = "testuser@tempurl.org"
 			admin             = true
@@ -83,7 +83,7 @@ func TestAccScopedToken_WithAttributes(t *testing.T) {
 		}
 
 		resource "artifactory_scoped_token" "{{ .name }}" {
-			username    = artifactory_unmanaged_user.test-user.name
+			username    = artifactory_managed_user.test-user.name
 			scopes      = ["applied-permissions/admin", "system:metrics:r"]
 			description = "test description"
 			refreshable = true
@@ -96,8 +96,8 @@ func TestAccScopedToken_WithAttributes(t *testing.T) {
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: accessTokenConfig,
@@ -375,7 +375,7 @@ func TestAccScopedToken_WithExpiresInLessThanPersistencyThreshold(t *testing.T) 
 
 	accessTokenConfig := utilsdk.ExecuteTemplate(
 		"TestAccScopedToken",
-		`resource "artifactory_unmanaged_user" "test-user" {
+		`resource "artifactory_managed_user" "test-user" {
 			name              = "testuser"
 		    email             = "testuser@tempurl.org"
 			admin             = true
@@ -385,7 +385,7 @@ func TestAccScopedToken_WithExpiresInLessThanPersistencyThreshold(t *testing.T) 
 		}
 
 		resource "artifactory_scoped_token" "{{ .name }}" {
-			username    = artifactory_unmanaged_user.test-user.name
+			username    = artifactory_managed_user.test-user.name
 			description = "test description"
 			expires_in  = {{ .expires_in }}
 		}`,
@@ -396,8 +396,8 @@ func TestAccScopedToken_WithExpiresInLessThanPersistencyThreshold(t *testing.T) 
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config:      accessTokenConfig,
@@ -412,7 +412,7 @@ func TestAccScopedToken_WithExpiresInSetToZeroForNonExpiringToken(t *testing.T) 
 
 	accessTokenConfig := utilsdk.ExecuteTemplate(
 		"TestAccScopedToken",
-		`resource "artifactory_unmanaged_user" "test-user" {
+		`resource "artifactory_managed_user" "test-user" {
 			name              = "testuser"
 		    email             = "testuser@tempurl.org"
 			admin             = true
@@ -422,7 +422,7 @@ func TestAccScopedToken_WithExpiresInSetToZeroForNonExpiringToken(t *testing.T) 
 		}
 
 		resource "artifactory_scoped_token" "{{ .name }}" {
-			username    = artifactory_unmanaged_user.test-user.name
+			username    = artifactory_managed_user.test-user.name
 			description = "test description"
 			expires_in  = 0
 		}`,
@@ -432,8 +432,8 @@ func TestAccScopedToken_WithExpiresInSetToZeroForNonExpiringToken(t *testing.T) 
 	)
 
 	resource.Test(t, resource.TestCase{
-		PreCheck:          func() { acctest.PreCheck(t) },
-		ProviderFactories: acctest.ProviderFactories,
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV5ProviderFactories: acctest.ProtoV5MuxProviderFactories,
 		Steps: []resource.TestStep{
 			{
 				Config: accessTokenConfig,


### PR DESCRIPTION
We won't migrate and will keep `unmanaged_user` as an SDKv2 resource to support legacy configurations. 
But it's removed from all the tests to get rid of the dependency. 