### PR TITLE
Migrate permission target to framework

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.0.0 (June 1, 2023)
+## 8.0.0 (June 1, 2023). Tested on Artifactory 7.59.9
 
 BREAKING CHANGES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,22 @@
+## 8.0.0 (June 1, 2023)
+
+BREAKING CHANGES:
+
+* resource/artifactory_permission_targets has been removed. It has been marked as deprecated since April 2022.
+
+IMPROVEMENTS: 
+
+* resource/artifactory_permission_target is migrated to Plugin Framework, improved attribute validation.
+
+  PR: [#742](https://github.com/jfrog/terraform-provider-artifactory/pull/42)
+
 ## 7.11.2 (May 30, 2023). Tested on Artifactory 7.59.9
 
 IMPROVEMENTS:
 
 * resource/scoped_token is migrated to Plugin Framework, improved attribute validation.
 
-PR:     [#741](https://github.com/jfrog/terraform-provider-artifactory/pull/741)
+PR: [#741](https://github.com/jfrog/terraform-provider-artifactory/pull/741)
 
 NOTES:
 
@@ -18,8 +30,8 @@ IMPROVEMENTS:
 * resource/artifactory_local_repository_single_replication: the resource can deal with different license types (Enterprise and ProX) to create replications. 
 The reason the change introduced, is the API response body is different for different license types.
 
-PR:     [#737](https://github.com/jfrog/terraform-provider-artifactory/pull/737)
-Issue:  [#718](https://github.com/jfrog/terraform-provider-artifactory/issues/718)
+PR:    [#737](https://github.com/jfrog/terraform-provider-artifactory/pull/737)
+Issue: [#718](https://github.com/jfrog/terraform-provider-artifactory/issues/718)
 
 ## 7.11.0 (May 16, 2023). Tested on Artifactory 7.55.13
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/jfrog/terraform-provider-shared v1.16.2
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.7.2
-	golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4
+	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1
 	golang.org/x/net v0.8.0
 	golang.org/x/text v0.8.0
 	gopkg.in/yaml.v3 v3.0.1
@@ -66,7 +66,7 @@ require (
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/sys v0.6.0 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
-	google.golang.org/genproto v0.0.0-20200711021454-869866162049 // indirect
+	google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d // indirect
 	google.golang.org/grpc v1.51.0 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/asn1-ber.v1 v1.0.0-20181015200546-f715ec2f112d // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/jfrog/terraform-provider-artifactory/v7
 
 // if you need to do local dev, literally just uncomment the line below
-//replace github.com/jfrog/terraform-provider-shared => ../terraform-provider-shared
+// replace github.com/jfrog/terraform-provider-shared => ../terraform-provider-shared
 
 require (
 	github.com/go-resty/resty/v2 v2.7.0
@@ -15,7 +15,7 @@ require (
 	github.com/hashicorp/terraform-plugin-mux v0.9.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.26.1
 	github.com/hashicorp/terraform-plugin-testing v1.2.0
-	github.com/jfrog/terraform-provider-shared v1.16.2
+	github.com/jfrog/terraform-provider-shared v1.17.0
 	github.com/sethvargo/go-password v0.2.0
 	github.com/stretchr/testify v1.7.2
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1

--- a/go.sum
+++ b/go.sum
@@ -140,6 +140,8 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
+github.com/jfrog/terraform-provider-shared v1.17.0 h1:WrzsoilWGn1gvh1c83m4YhSdh7XH2Fkw9Q7P4tcWN20=
+github.com/jfrog/terraform-provider-shared v1.17.0/go.mod h1:JvTKRAXMQyX6gQjESY+YK2lJLeW8uKTVHar5HDTnvp0=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=

--- a/go.sum
+++ b/go.sum
@@ -140,8 +140,6 @@ github.com/imdario/mergo v0.3.13/go.mod h1:4lJ1jqUDcsbIECGy0RUJAXNIhg+6ocWgb1ALK
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOlocH6Fxy8MmwDt+yVQYULKfN0RoTN8A=
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
-github.com/jfrog/terraform-provider-shared v1.16.2 h1:kRh0D7Qq1pYIDIg37QB4TEmGcUgSj0KGZvFNsfia4nQ=
-github.com/jfrog/terraform-provider-shared v1.16.2/go.mod h1:51DBLYR6PdoQUOXNnJs23UymZbex/MKTBk+uWWz43vo=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
@@ -234,8 +232,8 @@ golang.org/x/crypto v0.5.0/go.mod h1:NK/OQwhpMQP3MwtdjgLlYHnH9ebylxKWv3e0fK+mkQU
 golang.org/x/crypto v0.7.0 h1:AvwMYaRytfdeVt3u6mLaxYtErKYjxA2OXjJ1HHq6t3A=
 golang.org/x/crypto v0.7.0/go.mod h1:pYwdfH91IfpZVANVyUOhSIPZaFoJGxTFbZhFTx+dXZU=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4 h1:K3x+yU+fbot38x5bQbU2QqUAVyYLEktdNH2GxZLnM3U=
-golang.org/x/exp v0.0.0-20220407100705-7b9b53b0aca4/go.mod h1:lgLbSvA5ygNOMpwM/9anMpWVlVJ7Z+cHWq/eFuinpGE=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 h1:k/i9J1pBpvlfR+9QsetwPyERsqu1GIbi967PQMq3Ivc=
+golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1/go.mod h1:V1LtkGg67GoY2N1AnLN78QLrzxkLyJw7RJb1gzOOz9w=
 golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3/go.mod h1:UVdnD1Gm6xHRNCYTkRU2/jEulfH38KcIWyp/GAMgvoE=
 golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961/go.mod h1:wehouNa3lNwaWXcvxsM5YxQ5yQlVC4a0KAMCusXpPoU=
 golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3/go.mod h1:6SW0HCj/g11FgYtHlgUYUwCkIfeOF89ocIRzGO/8vkc=
@@ -321,8 +319,8 @@ google.golang.org/appengine v1.6.7/go.mod h1:8WjMMxjGQR8xUklV/ARdw2HLXBOI7O7uCID
 google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8/go.mod h1:JiN7NxoALGmiZfu7CAH4rXhgtRTLTxftemlI0sWmxmc=
 google.golang.org/genproto v0.0.0-20190819201941-24fa4b261c55/go.mod h1:DMBHOl98Agz4BDEuKkezgsaosCRResVns1a3J2ZsMNc=
 google.golang.org/genproto v0.0.0-20200526211855-cb27e3aa2013/go.mod h1:NbSheEEYHJ7i3ixzK3sjbqSGDJWnxyFXZblF3eUsNvo=
-google.golang.org/genproto v0.0.0-20200711021454-869866162049 h1:YFTFpQhgvrLrmxtiIncJxFXeCyq84ixuKWVCaCAi9Oc=
-google.golang.org/genproto v0.0.0-20200711021454-869866162049/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
+google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d h1:92D1fum1bJLKSdr11OJ+54YeCMCGYIygTA7R/YZxH5M=
+google.golang.org/genproto v0.0.0-20200904004341-0bd0a958aa1d/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=

--- a/pkg/acctest/test.go
+++ b/pkg/acctest/test.go
@@ -69,7 +69,6 @@ func init() {
 			return muxServer.ProviderServer(), nil
 		},
 	}
-
 }
 
 // PreCheck This function should be present in every acceptance test.

--- a/pkg/artifactory/datasource/security/datasource_artifactory_permission_target.go
+++ b/pkg/artifactory/datasource/security/datasource_artifactory_permission_target.go
@@ -2,17 +2,135 @@ package security
 
 import (
 	"context"
+	"strings"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	utilsdk "github.com/jfrog/terraform-provider-shared/util/sdk"
-
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/security"
+	utilsdk "github.com/jfrog/terraform-provider-shared/util/sdk"
 )
+
+type PermissionTargetParams struct {
+	Name          string                   `json:"name"`
+	Repo          *PermissionTargetSection `json:"repo,omitempty"`
+	Build         *PermissionTargetSection `json:"build,omitempty"`
+	ReleaseBundle *PermissionTargetSection `json:"releaseBundle,omitempty"`
+}
+
+type PermissionTargetSection struct {
+	IncludePatterns []string `json:"include-patterns,omitempty"`
+	ExcludePatterns []string `json:"exclude-patterns,omitempty"`
+	Repositories    []string `json:"repositories"`
+	Actions         *Actions `json:"actions,omitempty"`
+}
+
+type Actions struct {
+	Users  map[string][]string `json:"users,omitempty"`
+	Groups map[string][]string `json:"groups,omitempty"`
+}
+
+func hashPrincipal(o interface{}) int {
+	p := o.(map[string]interface{})
+	part1 := schema.HashString(p["name"].(string)) + 31
+	permissions := utilsdk.CastToStringArr(p["permissions"].(*schema.Set).List())
+	part3 := schema.HashString(strings.Join(permissions, ""))
+	return part1 * part3
+}
+
+func BuildPermissionTargetSchema() map[string]*schema.Schema {
+	actionSchema := schema.Schema{
+		Type:     schema.TypeSet,
+		Optional: true,
+		Set:      hashPrincipal,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"name": {
+					Type:     schema.TypeString,
+					Required: true,
+				},
+				"permissions": {
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{
+						Type: schema.TypeString,
+						ValidateFunc: validation.StringInSlice([]string{
+							security.PermRead,
+							security.PermAnnotate,
+							security.PermWrite,
+							security.PermDelete,
+							security.PermManage,
+							security.PermManagedXrayMeta,
+							security.PermDistribute,
+						}, false),
+					},
+					Set:      schema.HashString,
+					Required: true,
+				},
+			},
+		},
+	}
+
+	principalSchema := schema.Schema{
+		Type:     schema.TypeList,
+		Optional: true,
+		MaxItems: 1,
+		MinItems: 1,
+		Elem: &schema.Resource{
+			Schema: map[string]*schema.Schema{
+				"includes_pattern": {
+					Type:        schema.TypeSet,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+					Set:         schema.HashString,
+					Optional:    true,
+					Description: `The default value will be [""] if nothing is supplied`,
+				},
+				"excludes_pattern": {
+					Type:        schema.TypeSet,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+					Set:         schema.HashString,
+					Optional:    true,
+					Description: `The default value will be [] if nothing is supplied`,
+				},
+				"repositories": {
+					Type:        schema.TypeSet,
+					Elem:        &schema.Schema{Type: schema.TypeString},
+					Set:         schema.HashString,
+					Description: "You can specify the name `ANY` in the repositories section in order to apply to all repositories, `ANY REMOTE` for all remote repositories and `ANY LOCAL` for all local repositories. The default value will be [] if nothing is specified.",
+					Required:    true,
+				},
+				"actions": {
+					Type:     schema.TypeList,
+					MaxItems: 1,
+					MinItems: 1,
+					Elem: &schema.Resource{
+						Schema: map[string]*schema.Schema{
+							"users":  &actionSchema,
+							"groups": &actionSchema,
+						},
+					},
+					Optional: true,
+				},
+			},
+		},
+	}
+	buildSchema := principalSchema
+	buildSchema.Elem.(*schema.Resource).Schema["repositories"].Description = `This can only be 1 value: "artifactory-build-info", and currently, validation of sets/lists is not allowed. Artifactory will reject the request if you change this`
+
+	return map[string]*schema.Schema{
+		"name": {
+			Type:     schema.TypeString,
+			Required: true,
+			ForceNew: true,
+		},
+		"repo":           &principalSchema,
+		"build":          &buildSchema,
+		"release_bundle": &principalSchema,
+	}
+}
 
 func DataSourceArtifactoryPermissionTarget() *schema.Resource {
 	dataSourcePermissionTargetRead := func(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-		permissionTarget := new(security.PermissionTargetParams)
+		permissionTarget := new(PermissionTargetParams)
 		targetName := d.Get("name").(string)
 		_, err := m.(utilsdk.ProvderMetadata).Client.R().SetResult(permissionTarget).Get(security.PermissionsEndPoint + targetName)
 
@@ -22,11 +140,83 @@ func DataSourceArtifactoryPermissionTarget() *schema.Resource {
 
 		d.SetId(permissionTarget.Name)
 
-		return security.PackPermissionTarget(permissionTarget, d)
+		return PackPermissionTarget(permissionTarget, d)
 	}
 	return &schema.Resource{
 		ReadContext: dataSourcePermissionTargetRead,
-		Schema:      security.BuildPermissionTargetSchema(),
+		Schema:      BuildPermissionTargetSchema(),
 		Description: "Provides the permission target data source. Contains information about a specific permission target.",
 	}
+}
+
+func PackPermissionTarget(permissionTarget *PermissionTargetParams, d *schema.ResourceData) diag.Diagnostics {
+	packPermission := func(p *PermissionTargetSection) []interface{} {
+		packPermMap := func(e map[string][]string) []interface{} {
+			perm := make([]interface{}, len(e))
+
+			count := 0
+			for k, v := range e {
+				perm[count] = map[string]interface{}{
+					"name":        k,
+					"permissions": schema.NewSet(schema.HashString, utilsdk.CastToInterfaceArr(v)),
+				}
+				count++
+			}
+
+			return perm
+		}
+
+		s := map[string]interface{}{}
+
+		if p != nil {
+			if p.IncludePatterns != nil {
+				s["includes_pattern"] = schema.NewSet(schema.HashString, utilsdk.CastToInterfaceArr(p.IncludePatterns))
+			}
+
+			if p.ExcludePatterns != nil {
+				s["excludes_pattern"] = schema.NewSet(schema.HashString, utilsdk.CastToInterfaceArr(p.ExcludePatterns))
+			}
+
+			if p.Repositories != nil {
+				s["repositories"] = schema.NewSet(schema.HashString, utilsdk.CastToInterfaceArr(p.Repositories))
+			}
+
+			if p.Actions != nil {
+				perms := make(map[string]interface{})
+
+				if p.Actions.Users != nil {
+					perms["users"] = schema.NewSet(hashPrincipal, packPermMap(p.Actions.Users))
+				}
+
+				if p.Actions.Groups != nil {
+					perms["groups"] = schema.NewSet(hashPrincipal, packPermMap(p.Actions.Groups))
+				}
+
+				if len(perms) > 0 {
+					s["actions"] = []interface{}{perms}
+				}
+			}
+		}
+
+		return []interface{}{s}
+	}
+
+	setValue := utilsdk.MkLens(d)
+
+	errors := setValue("name", permissionTarget.Name)
+	if permissionTarget.Repo != nil {
+		errors = setValue("repo", packPermission(permissionTarget.Repo))
+	}
+	if permissionTarget.Build != nil {
+		errors = setValue("build", packPermission(permissionTarget.Build))
+	}
+
+	if permissionTarget.ReleaseBundle != nil {
+		errors = setValue("release_bundle", packPermission(permissionTarget.ReleaseBundle))
+	}
+
+	if errors != nil && len(errors) > 0 {
+		return diag.Errorf("failed to marshal permission target %q", errors)
+	}
+	return nil
 }

--- a/pkg/artifactory/datasource/security/datasource_artifactory_permission_target.go
+++ b/pkg/artifactory/datasource/security/datasource_artifactory_permission_target.go
@@ -92,11 +92,12 @@ func BuildPermissionTargetSchema() map[string]*schema.Schema {
 					Description: `The default value will be [] if nothing is supplied`,
 				},
 				"repositories": {
-					Type:        schema.TypeSet,
-					Elem:        &schema.Schema{Type: schema.TypeString},
-					Set:         schema.HashString,
-					Description: "You can specify the name `ANY` in the repositories section in order to apply to all repositories, `ANY REMOTE` for all remote repositories and `ANY LOCAL` for all local repositories. The default value will be [] if nothing is specified.",
-					Required:    true,
+					Type: schema.TypeSet,
+					Elem: &schema.Schema{Type: schema.TypeString},
+					Set:  schema.HashString,
+					Description: "You can specify the name `ANY` in the repositories section in order to apply to all repositories, " +
+						"`ANY REMOTE` for all remote repositories and `ANY LOCAL` for all local repositories. The default value will be [] if nothing is specified.",
+					Required: true,
 				},
 				"actions": {
 					Type:     schema.TypeList,
@@ -114,7 +115,8 @@ func BuildPermissionTargetSchema() map[string]*schema.Schema {
 		},
 	}
 	buildSchema := principalSchema
-	buildSchema.Elem.(*schema.Resource).Schema["repositories"].Description = `This can only be 1 value: "artifactory-build-info", and currently, validation of sets/lists is not allowed. Artifactory will reject the request if you change this`
+	buildSchema.Elem.(*schema.Resource).Schema["repositories"].Description = `This can only be 1 value: "artifactory-build-info", and currently, ` +
+		"validation of sets/lists is not allowed. Artifactory will reject the request if you change this"
 
 	return map[string]*schema.Schema{
 		"name": {

--- a/pkg/artifactory/datasource/security/datasource_artifactory_permission_target_test.go
+++ b/pkg/artifactory/datasource/security/datasource_artifactory_permission_target_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/acctest"
+	datasource "github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/datasource/security"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/security"
 	"github.com/jfrog/terraform-provider-shared/testutil"
@@ -23,30 +24,30 @@ func deletePermissionTarget(t *testing.T, name string) error {
 func createPermissionTarget(targetName string, userName string, t *testing.T) {
 	acctest.CreateUserUpdatable(t, userName, "terraform@email.com")
 
-	actions := security.Actions{
+	actions := datasource.Actions{
 		Users:  map[string][]string{userName: {"read", "write"}},
 		Groups: map[string][]string{"readers": {"read"}},
 	}
-	repoTarget := security.PermissionTargetSection{
+	repoTarget := datasource.PermissionTargetSection{
 		IncludePatterns: []string{"foo/**"},
 		ExcludePatterns: []string{"bar/**"},
 		Repositories:    []string{"example-repo-local"},
 		Actions:         &actions,
 	}
-	buildTarget := security.PermissionTargetSection{
+	buildTarget := datasource.PermissionTargetSection{
 		IncludePatterns: []string{"foo/**"},
 		ExcludePatterns: []string{"bar/**"},
 		Repositories:    []string{"artifactory-build-info"},
 		Actions:         nil,
 	}
-	releaseBundleTarget := security.PermissionTargetSection{
+	releaseBundleTarget := datasource.PermissionTargetSection{
 		IncludePatterns: []string{"foo/**"},
 		ExcludePatterns: []string{"bar/**"},
 		Repositories:    []string{"release-bundles"},
 		Actions:         nil,
 	}
 
-	permissionTarget := security.PermissionTargetParams{
+	permissionTarget := datasource.PermissionTargetParams{
 		Name:          targetName,
 		Repo:          &repoTarget,
 		Build:         &buildTarget,

--- a/pkg/artifactory/provider/framework.go
+++ b/pkg/artifactory/provider/framework.go
@@ -164,11 +164,11 @@ func (p *ArtifactoryProvider) Configure(ctx context.Context, req provider.Config
 // Resources satisfies the provider.Provider interface for ArtifactoryProvider.
 func (p *ArtifactoryProvider) Resources(ctx context.Context) []func() resource.Resource {
 	return []func() resource.Resource{
-		user.NewArtifactoryUserResource,
-		user.NewArtifactoryManagedUserResource,
-		user.NewArtifactoryAnonymousUserResource,
-		security.NewArtifactoryGroupResource,
-		security.NewArtifactoryScopedTokenResource,
+		user.NewUserResource,
+		user.NewManagedUserResource,
+		user.NewAnonymousUserResource,
+		security.NewGroupResource,
+		security.NewScopedTokenResource,
 		security.NewPermissionTargetResource,
 	}
 }

--- a/pkg/artifactory/provider/framework.go
+++ b/pkg/artifactory/provider/framework.go
@@ -169,6 +169,7 @@ func (p *ArtifactoryProvider) Resources(ctx context.Context) []func() resource.R
 		user.NewArtifactoryAnonymousUserResource,
 		security.NewArtifactoryGroupResource,
 		security.NewArtifactoryScopedTokenResource,
+		security.NewPermissionTargetResource,
 	}
 }
 

--- a/pkg/artifactory/provider/resources.go
+++ b/pkg/artifactory/provider/resources.go
@@ -66,7 +66,6 @@ func resourcesMap() map[string]*schema.Resource {
 		"artifactory_virtual_rpm_repository":                  virtual.ResourceArtifactoryVirtualRpmRepository(),
 		"artifactory_virtual_helm_repository":                 virtual.ResourceArtifactoryVirtualHelmRepository(),
 		"artifactory_unmanaged_user":                          user.ResourceArtifactoryUser(), // alias of artifactory_user
-		"artifactory_permission_target":                       security.ResourceArtifactoryPermissionTarget(),
 		"artifactory_pull_replication":                        replication.ResourceArtifactoryPullReplication(),
 		"artifactory_push_replication":                        replication.ResourceArtifactoryPushReplication(),
 		"artifactory_local_repository_single_replication":     replication.ResourceArtifactoryLocalRepositorySingleReplication(),
@@ -79,7 +78,6 @@ func resourcesMap() map[string]*schema.Resource {
 		"artifactory_general_security":                        configuration.ResourceArtifactoryGeneralSecurity(),
 		"artifactory_oauth_settings":                          configuration.ResourceArtifactoryOauthSettings(),
 		"artifactory_saml_settings":                           configuration.ResourceArtifactorySamlSettings(),
-		"artifactory_permission_targets":                      security.ResourceArtifactoryPermissionTargets(), // Deprecated. Remove in V7
 		"artifactory_replication_config":                      replication.ResourceArtifactoryReplicationConfig(),
 		"artifactory_single_replication_config":               replication.ResourceArtifactorySingleReplicationConfig(),
 		"artifactory_ldap_setting":                            configuration.ResourceArtifactoryLdapSetting(),

--- a/pkg/artifactory/resource/security/resource_artifactory_group.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_group.go
@@ -19,7 +19,7 @@ import (
 
 const GroupsEndpoint = "artifactory/api/security/groups/"
 
-func NewArtifactoryGroupResource() resource.Resource {
+func NewGroupResource() resource.Resource {
 
 	return &ArtifactoryGroupResource{}
 }

--- a/pkg/artifactory/resource/security/resource_artifactory_group.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_group.go
@@ -185,13 +185,13 @@ func (r *ArtifactoryGroupResource) Create(ctx context.Context, req resource.Crea
 		Put(GroupsEndpoint + group.Name)
 
 	if err != nil {
-		unableToCreateResourceError(resp, err)
+		utilfw.UnableToCreateResourceError(resp, err.Error())
 		return
 	}
 
 	// Return error if the HTTP status code is not 200 OK
 	if response.StatusCode() != http.StatusCreated {
-		unableToCreateResourceError(resp, err)
+		utilfw.UnableToCreateResourceError(resp, response.String())
 		return
 	}
 
@@ -275,13 +275,13 @@ func (r *ArtifactoryGroupResource) Update(ctx context.Context, req resource.Upda
 			SetBody(group).
 			Put(GroupsEndpoint + group.Name)
 		if err != nil {
-			unableToUpdateResourceError(resp, err)
+			utilfw.UnableToUpdateResourceError(resp, err.Error())
 			return
 		}
 
 		// Return error if the HTTP status code is not 200 OK
 		if response.StatusCode() != http.StatusCreated {
-			unableToUpdateResourceError(resp, err)
+			utilfw.UnableToUpdateResourceError(resp, response.String())
 			return
 		}
 	} else {
@@ -290,13 +290,13 @@ func (r *ArtifactoryGroupResource) Update(ctx context.Context, req resource.Upda
 			SetBody(group).
 			Post(GroupsEndpoint + group.Name)
 		if err != nil {
-			unableToUpdateResourceError(resp, err)
+			utilfw.UnableToUpdateResourceError(resp, err.Error())
 			return
 		}
 
 		// Return error if the HTTP status code is not 200 OK
 		if response.StatusCode() != http.StatusOK {
-			unableToUpdateResourceError(resp, err)
+			utilfw.UnableToUpdateResourceError(resp, response.String())
 			return
 		}
 	}

--- a/pkg/artifactory/resource/security/resource_artifactory_permission_target.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_permission_target.go
@@ -298,12 +298,12 @@ func (r *PermissionTargetResource) getPrincipalBlock(description, repoDescriptio
 			},
 			"repositories": schema.SetAttribute{
 				ElementType:         types.StringType,
-				Optional:            true,
+				Optional:            true, // this attribute can't be set to required as SingleNestedBlock doesn't support it. See https://github.com/hashicorp/terraform-plugin-framework/issues/740
 				MarkdownDescription: repoDescription,
 			},
 		},
 		Validators: []validator.Object{
-			validatorfw.RequireIfDefined(path.Expressions{
+			validatorfw.RequireIfDefined(path.Expressions{ // use customer validator to ensure 'repositories' attribute is set if this block is defined in configuration. See https://github.com/hashicorp/terraform-plugin-framework/issues/740
 				path.MatchRelative().AtName("repositories"),
 			}...),
 		},

--- a/pkg/artifactory/resource/security/resource_artifactory_permission_target.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_permission_target.go
@@ -303,7 +303,7 @@ func (r *PermissionTargetResource) getPrincipalBlock(description, repoDescriptio
 			},
 		},
 		Validators: []validator.Object{
-			validatorfw.RequireIfDefined(path.Expressions{ // use customer validator to ensure 'repositories' attribute is set if this block is defined in configuration. See https://github.com/hashicorp/terraform-plugin-framework/issues/740
+			validatorfw.RequireIfDefined(path.Expressions{ // use custom validator to ensure 'repositories' attribute is set if this block is defined in configuration. See https://github.com/hashicorp/terraform-plugin-framework/issues/740
 				path.MatchRelative().AtName("repositories"),
 			}...),
 		},
@@ -398,13 +398,7 @@ func (r *PermissionTargetResource) Read(ctx context.Context, req resource.ReadRe
 		Get(PermissionsEndPoint + data.Id.ValueString())
 
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Refresh Resource",
-			"An unexpected error occurred while attempting to refresh resource state. "+
-				"Please retry the operation or report this issue to the provider developers.\n\n"+
-				"HTTP Error: "+err.Error(),
-		)
-
+		utilfw.UnableToRefreshResourceError(resp, err.Error())
 		return
 	}
 
@@ -464,25 +458,13 @@ func (r *PermissionTargetResource) Delete(ctx context.Context, req resource.Dele
 		Delete(PermissionsEndPoint + data.Id.ValueString())
 
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Unable to Delete Resource",
-			"An unexpected error occurred while attempting to delete the resource. "+
-				"Please retry the operation or report this issue to the provider developers.\n\n"+
-				"HTTP Error: "+err.Error(),
-		)
-
+		utilfw.UnableToDeleteResourceError(resp, err.Error())
 		return
 	}
 
 	// Return error if the HTTP status code is not 200 OK or 404 Not Found
 	if response.StatusCode() != http.StatusNotFound && response.StatusCode() != http.StatusOK {
-		resp.Diagnostics.AddError(
-			"Unable to Delete Resource",
-			"An unexpected error occurred while attempting to delete the resource. "+
-				"Please retry the operation or report this issue to the provider developers.\n\n"+
-				"HTTP Status: "+response.Status(),
-		)
-
+		utilfw.UnableToDeleteResourceError(resp, response.Status())
 		return
 	}
 

--- a/pkg/artifactory/resource/security/resource_artifactory_permission_target.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_permission_target.go
@@ -3,32 +3,225 @@ package security
 import (
 	"context"
 	"net/http"
-	"strings"
 
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	// "github.com/hashicorp/terraform-plugin-framework-validators/objectvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/setdefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
+	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	utilsdk "github.com/jfrog/terraform-provider-shared/util/sdk"
-
-	"github.com/jfrog/terraform-provider-artifactory/v7/pkg/artifactory/resource/repository"
+	validatorfw "github.com/jfrog/terraform-provider-shared/validator/fw"
 )
 
 const PermissionsEndPoint = "artifactory/api/v2/security/permissions/"
-const (
-	PermRead            = "read"
-	PermWrite           = "write"
-	PermAnnotate        = "annotate"
-	PermDelete          = "delete"
-	PermManage          = "manage"
-	PermManagedXrayMeta = "managedXrayMeta"
-	PermDistribute      = "distribute"
-)
 
-// PermissionTargetParams Copy from https://github.com/jfrog/jfrog-client-go/blob/master/artifactory/services/permissiontarget.go#L116
+func NewPermissionTargetResource() resource.Resource {
+	return &PermissionTargetResource{}
+}
+
+type PermissionTargetResource struct {
+	ProviderData utilsdk.ProvderMetadata
+}
+
+// PermissionTargetResourceModel describes the Terraform resource data model to match the
+// resource schema.
+type PermissionTargetResourceModel struct {
+	Id            types.String `tfsdk:"id"`
+	Name          types.String `tfsdk:"name"`
+	Repo          types.Object `tfsdk:"repo"`
+	Build         types.Object `tfsdk:"build"`
+	ReleaseBundle types.Object `tfsdk:"release_bundle"`
+}
+
+func (r *PermissionTargetResourceModel) toActionsAPIModel(ctx context.Context, resourceActions types.Object) Actions {
+	setToMap := func(sourceSet types.Set, mapToUpdate *map[string][]string) {
+		setElements := sourceSet.Elements()
+		for _, setElement := range setElements {
+			attrs := setElement.(types.Object).Attributes()
+			permissions := utilfw.StringSetToStrings(attrs["permissions"].(types.Set))
+			(*mapToUpdate)[attrs["name"].(types.String).ValueString()] = permissions
+		}
+	}
+
+	actions := Actions{
+		Users:  map[string][]string{},
+		Groups: map[string][]string{},
+	}
+	actionsAttrs := resourceActions.Attributes()
+
+	setToMap(actionsAttrs["users"].(types.Set), &actions.Users)
+	setToMap(actionsAttrs["groups"].(types.Set), &actions.Groups)
+
+	return actions
+}
+
+func (r *PermissionTargetResourceModel) toSectionAPIModel(ctx context.Context, resourceSection types.Object) *PermissionTargetSection {
+	tflog.Debug(ctx, "toSectionAPIModel", map[string]interface{}{
+		"resourceSection": resourceSection,
+	})
+	if resourceSection.IsUnknown() || resourceSection.IsNull() {
+		return nil
+	}
+	sectionAttrs := resourceSection.Attributes()
+	repoActions := r.toActionsAPIModel(ctx, sectionAttrs["actions"].(types.Object))
+
+	return &PermissionTargetSection{
+		IncludePatterns: utilfw.StringSetToStrings(sectionAttrs["includes_pattern"].(types.Set)),
+		ExcludePatterns: utilfw.StringSetToStrings(sectionAttrs["excludes_pattern"].(types.Set)),
+		Repositories:    utilfw.StringSetToStrings(sectionAttrs["repositories"].(types.Set)),
+		Actions:         &repoActions,
+	}
+}
+
+func (r *PermissionTargetResourceModel) toAPIModel(ctx context.Context) PermissionTargetResourceAPIModel {
+	// convert section
+	repo := r.toSectionAPIModel(ctx, r.Repo)
+	build := r.toSectionAPIModel(ctx, r.Build)
+	releaseBundle := r.toSectionAPIModel(ctx, r.ReleaseBundle)
+
+	// Convert from Terraform data model into API data model
+	return PermissionTargetResourceAPIModel{
+		Name:          r.Name.ValueString(),
+		Repo:          repo,
+		Build:         build,
+		ReleaseBundle: releaseBundle,
+	}
+}
+
+func (r *PermissionTargetResourceModel) ToState(ctx context.Context, diags diag.Diagnostics, permissionTarget *PermissionTargetResourceAPIModel) {
+	r.Id = types.StringValue(permissionTarget.Name)
+	r.Name = types.StringValue(permissionTarget.Name)
+
+	var ds diag.Diagnostics
+
+	if permissionTarget.Repo != nil {
+		r.Repo, ds = r.sectionFromAPIModel(ctx, permissionTarget.Repo)
+		if ds != nil {
+			diags.Append(ds...)
+			return
+		}
+	}
+
+	if permissionTarget.Build != nil {
+		r.Build, ds = r.sectionFromAPIModel(ctx, permissionTarget.Build)
+		if ds != nil {
+			diags.Append(ds...)
+			return
+		}
+	}
+
+	if permissionTarget.ReleaseBundle != nil {
+		r.ReleaseBundle, ds = r.sectionFromAPIModel(ctx, permissionTarget.ReleaseBundle)
+		if ds != nil {
+			diags.Append(ds...)
+			return
+		}
+	}
+}
+
+var namePermissionAttrTypes = map[string]attr.Type{
+	"name":        types.StringType,
+	"permissions": types.SetType{types.StringType},
+}
+
+var actionsAttrTypes = map[string]attr.Type{
+	"users": types.SetType{
+		types.ObjectType{
+			AttrTypes: namePermissionAttrTypes,
+		},
+	},
+	"groups": types.SetType{
+		types.ObjectType{
+			AttrTypes: namePermissionAttrTypes,
+		},
+	},
+}
+
+func (r *PermissionTargetResourceModel) sectionFromAPIModel(ctx context.Context, section *PermissionTargetSection) (types.Object, diag.Diagnostics) {
+	includesPatterns, diags := types.SetValueFrom(ctx, types.StringType, section.IncludePatterns)
+	if diags != nil {
+		return types.Object{}, diags
+	}
+
+	excludesPatterns, diags := types.SetValueFrom(ctx, types.StringType, section.ExcludePatterns)
+	if diags != nil {
+		return types.Object{}, diags
+	}
+
+	repos, diags := types.SetValueFrom(ctx, types.StringType, section.Repositories)
+	if diags != nil {
+		return types.Object{}, diags
+	}
+
+	actionFromAPIModel := func(action map[string][]string) (types.Set, diag.Diagnostics) {
+		objectValues := []attr.Value{}
+		for name, permissions := range action {
+			permissionsSet, diags := types.SetValueFrom(ctx, types.StringType, permissions)
+			if diags != nil {
+				return types.Set{}, diags
+			}
+
+			objectValue := types.ObjectValueMust(
+				namePermissionAttrTypes,
+				map[string]attr.Value{
+					"name":        types.StringValue(name),
+					"permissions": permissionsSet,
+				},
+			)
+			objectValues = append(objectValues, objectValue)
+		}
+		return types.SetValueMust(types.ObjectType{
+			AttrTypes: namePermissionAttrTypes,
+		}, objectValues), nil
+	}
+
+	actionsUsers, diags := actionFromAPIModel(section.Actions.Users)
+	if diags != nil {
+		return types.Object{}, diags
+	}
+
+	actionsGroups, diags := actionFromAPIModel(section.Actions.Groups)
+	if diags != nil {
+		return types.Object{}, diags
+	}
+
+	return types.ObjectValueMust(
+		map[string]attr.Type{
+			"includes_pattern": types.SetType{types.StringType},
+			"excludes_pattern": types.SetType{types.StringType},
+			"repositories":     types.SetType{types.StringType},
+			"actions": types.ObjectType{
+				AttrTypes: actionsAttrTypes,
+			},
+		}, map[string]attr.Value{
+			"includes_pattern": includesPatterns,
+			"excludes_pattern": excludesPatterns,
+			"repositories":     repos,
+			"actions": types.ObjectValueMust(
+				actionsAttrTypes,
+				map[string]attr.Value{
+					"users":  actionsUsers,
+					"groups": actionsGroups,
+				},
+			),
+		},
+	), nil
+}
+
+// PermissionTargetResourceAPIModel describes the API data model. Copy from https://github.com/jfrog/jfrog-client-go/blob/master/artifactory/services/permissiontarget.go#L116
 //
 // Using struct pointers to keep the fields null if they are empty.
 // Artifactory evaluates inner struct typed fields if they are not null, which can lead to failures in the request.
-type PermissionTargetParams struct {
+type PermissionTargetResourceAPIModel struct {
 	Name          string                   `json:"name"`
 	Repo          *PermissionTargetSection `json:"repo,omitempty"`
 	Build         *PermissionTargetSection `json:"build,omitempty"`
@@ -47,328 +240,264 @@ type Actions struct {
 	Groups map[string][]string `json:"groups,omitempty"`
 }
 
-func ResourceArtifactoryPermissionTargets() *schema.Resource {
-	target := ResourceArtifactoryPermissionTarget()
-	target.DeprecationMessage = "This resource has been deprecated in favour of artifactory_permission_target resource."
-	return target
+const (
+	PermRead            = "read"
+	PermWrite           = "write"
+	PermAnnotate        = "annotate"
+	PermDelete          = "delete"
+	PermManage          = "manage"
+	PermManagedXrayMeta = "managedXrayMeta"
+	PermDistribute      = "distribute"
+)
+
+func (r *PermissionTargetResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+	resp.TypeName = "artifactory_permission_target"
 }
 
-func BuildPermissionTargetSchema() map[string]*schema.Schema {
-	actionSchema := schema.Schema{
-		Type:     schema.TypeSet,
-		Optional: true,
-		Set:      hashPrincipal,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"name": {
-					Type:     schema.TypeString,
-					Required: true,
-				},
-				"permissions": {
-					Type: schema.TypeSet,
-					Elem: &schema.Schema{
-						Type: schema.TypeString,
-						ValidateFunc: validation.StringInSlice([]string{
-							PermRead,
-							PermAnnotate,
-							PermWrite,
-							PermDelete,
-							PermManage,
-							PermManagedXrayMeta,
-							PermDistribute,
-						}, false),
-					},
-					Set:      schema.HashString,
-					Required: true,
+var actionsAttributeBlock = schema.SetNestedBlock{
+	NestedObject: schema.NestedBlockObject{
+		Attributes: map[string]schema.Attribute{
+			"name": schema.StringAttribute{
+				Required: true,
+			},
+			"permissions": schema.SetAttribute{
+				ElementType: types.StringType,
+				Required:    true,
+				Validators: []validator.Set{
+					validatorfw.StringInSlice([]string{
+						PermRead,
+						PermAnnotate,
+						PermWrite,
+						PermDelete,
+						PermManage,
+						PermManagedXrayMeta,
+						PermDistribute,
+					}),
 				},
 			},
 		},
-	}
+	},
+}
 
-	principalSchema := schema.Schema{
-		Type:     schema.TypeList,
-		Optional: true,
-		MaxItems: 1,
-		MinItems: 1,
-		Elem: &schema.Resource{
-			Schema: map[string]*schema.Schema{
-				"includes_pattern": {
-					Type:        schema.TypeSet,
-					Elem:        &schema.Schema{Type: schema.TypeString},
-					Set:         schema.HashString,
-					Optional:    true,
-					Description: `The default value will be [""] if nothing is supplied`,
+func (r *PermissionTargetResource) getPrincipalBlock(description, repoDescription string) schema.SingleNestedBlock {
+	return schema.SingleNestedBlock{
+		Attributes: map[string]schema.Attribute{
+			"includes_pattern": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Computed:            true,
+				Default:             setdefault.StaticValue(basetypes.NewSetValueMust(types.StringType, []attr.Value{types.StringValue("**")})),
+				MarkdownDescription: `The default value will be [""] if nothing is supplied`,
+			},
+			"excludes_pattern": schema.SetAttribute{
+				ElementType:         types.StringType,
+				Optional:            true,
+				Computed:            true,
+				Default:             setdefault.StaticValue(basetypes.NewSetValueMust(types.StringType, []attr.Value{})),
+				MarkdownDescription: "The default value will be [] if nothing is supplied",
+			},
+			"repositories": schema.SetAttribute{
+				ElementType: types.StringType,
+				Required:    true,
+				// Optional:            true,
+				MarkdownDescription: repoDescription,
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"actions": schema.SingleNestedBlock{
+				Blocks: map[string]schema.Block{
+					"users":  actionsAttributeBlock,
+					"groups": actionsAttributeBlock,
 				},
-				"excludes_pattern": {
-					Type:        schema.TypeSet,
-					Elem:        &schema.Schema{Type: schema.TypeString},
-					Set:         schema.HashString,
-					Optional:    true,
-					Description: `The default value will be [] if nothing is supplied`,
-				},
-				"repositories": {
-					Type:        schema.TypeSet,
-					Elem:        &schema.Schema{Type: schema.TypeString},
-					Set:         schema.HashString,
-					Description: "You can specify the name `ANY` in the repositories section in order to apply to all repositories, `ANY REMOTE` for all remote repositories and `ANY LOCAL` for all local repositories. The default value will be [] if nothing is specified.",
-					Required:    true,
-				},
-				"actions": {
-					Type:     schema.TypeList,
-					MaxItems: 1,
-					MinItems: 1,
-					Elem: &schema.Resource{
-						Schema: map[string]*schema.Schema{
-							"users":  &actionSchema,
-							"groups": &actionSchema,
-						},
-					},
-					Optional: true,
+				// Validators: []validator.Object{
+				// 	objectvalidator.IsRequired(),
+				// },
+			},
+		},
+		MarkdownDescription: description,
+	}
+}
+
+func (r *PermissionTargetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Provides an Artifactory permission target resource. This can be used to create and manage Artifactory permission targets.",
+		Attributes: map[string]schema.Attribute{
+			"id": schema.StringAttribute{
+				Computed: true,
+			},
+			"name": schema.StringAttribute{
+				MarkdownDescription: "Name of permission.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
 				},
 			},
 		},
-	}
-	buildSchema := principalSchema
-	buildSchema.Elem.(*schema.Resource).Schema["repositories"].Description = `This can only be 1 value: "artifactory-build-info", and currently, validation of sets/lists is not allowed. Artifactory will reject the request if you change this`
-
-	return map[string]*schema.Schema{
-		"name": {
-			Type:     schema.TypeString,
-			Required: true,
-			ForceNew: true,
+		Blocks: map[string]schema.Block{
+			"repo":           r.getPrincipalBlock("Repository permission configuration.", "You can specify the name `ANY` in the repositories section in order to apply to all repositories, `ANY REMOTE` for all remote repositories and `ANY LOCAL` for all local repositories. The default value will be [] if nothing is specified."),
+			"build":          r.getPrincipalBlock("As for repo but for artifactory-build-info permissions.", `This can only be 1 value: "artifactory-build-info", and currently, validation of sets/lists is not allowed. Artifactory will reject the request if you change this`),
+			"release_bundle": r.getPrincipalBlock("As for repo for for release-bundles permissions.", "You can specify the name `ANY` in the repositories section in order to apply to all repositories, `ANY REMOTE` for all remote repositories and `ANY LOCAL` for all local repositories. The default value will be [] if nothing is specified."),
 		},
-		"repo":           &principalSchema,
-		"build":          &buildSchema,
-		"release_bundle": &principalSchema,
 	}
 }
 
-func ResourceArtifactoryPermissionTarget() *schema.Resource {
-	return &schema.Resource{
-		CreateContext: resourcePermissionTargetCreate,
-		ReadContext:   resourcePermissionTargetRead,
-		UpdateContext: resourcePermissionTargetUpdate,
-		DeleteContext: resourcePermissionTargetDelete,
-
-		Importer: &schema.ResourceImporter{
-			StateContext: schema.ImportStatePassthroughContext,
-		},
-
-		Schema: BuildPermissionTargetSchema(),
+func (r *PermissionTargetResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+	// Prevent panic if the provider has not been configured.
+	if req.ProviderData == nil {
+		return
 	}
+	r.ProviderData = req.ProviderData.(utilsdk.ProvderMetadata)
 }
 
-func hashPrincipal(o interface{}) int {
-	p := o.(map[string]interface{})
-	part1 := schema.HashString(p["name"].(string)) + 31
-	permissions := utilsdk.CastToStringArr(p["permissions"].(*schema.Set).List())
-	part3 := schema.HashString(strings.Join(permissions, ""))
-	return part1 * part3
-}
+func (r *PermissionTargetResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *PermissionTargetResourceModel
 
-func unpackPermissionTarget(s *schema.ResourceData) *PermissionTargetParams {
-	d := &utilsdk.ResourceData{ResourceData: s}
-
-	unpackPermission := func(rawPermissionData interface{}) *PermissionTargetSection {
-		unpackEntity := func(rawEntityData interface{}) *Actions {
-			unpackPermMap := func(rawPermSet interface{}) map[string][]string {
-				permList := rawPermSet.(*schema.Set).List()
-				if len(permList) == 0 {
-					return nil
-				}
-
-				permissions := make(map[string][]string)
-				for _, v := range permList {
-					id := v.(map[string]interface{})
-
-					permissions[id["name"].(string)] = utilsdk.CastToStringArr(id["permissions"].(*schema.Set).List())
-				}
-				return permissions
-			}
-
-			entityDataList := rawEntityData.([]interface{})
-			if len(entityDataList) == 0 {
-				return nil
-			}
-
-			entityData := entityDataList[0].(map[string]interface{})
-			return &Actions{
-				Users:  unpackPermMap(entityData["users"]),
-				Groups: unpackPermMap(entityData["groups"]),
-			}
-		}
-
-		if rawPermissionData == nil || rawPermissionData.([]interface{})[0] == nil {
-			return nil
-		}
-
-		// It is safe to unpack the zeroth element immediately since permission targets have min size of 1
-		permissionData := rawPermissionData.([]interface{})[0].(map[string]interface{})
-
-		permission := new(PermissionTargetSection)
-
-		// This will always exist
-		{
-			tmp := utilsdk.CastToStringArr(permissionData["repositories"].(*schema.Set).List())
-			permission.Repositories = tmp
-		}
-
-		// Handle optionals
-		if v, ok := permissionData["includes_pattern"]; ok {
-			// It is not possible to set default values for sets. Because the data type between moving from
-			// atlassian to jfrog went from a *[]string to a []string, and both have json attributes of 'on empty omit'
-			// when the * version was used, this would have cause an [] array to be sent, which artifactory would accept
-			// now that the data type is changed, and [] is ommitted and so when artifactory see the key missing entirely
-			// it responds with "[**]" which messes us the testutil. This hack seems to line them up
-			tmp := utilsdk.CastToStringArr(v.(*schema.Set).List())
-			if len(tmp) == 0 {
-				tmp = []string{""}
-			}
-			permission.IncludePatterns = tmp
-		}
-		if v, ok := permissionData["excludes_pattern"]; ok {
-			tmp := utilsdk.CastToStringArr(v.(*schema.Set).List())
-			permission.ExcludePatterns = tmp
-		}
-		if v, ok := permissionData["actions"]; ok {
-			permission.Actions = unpackEntity(v)
-		}
-
-		return permission
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
 	}
 
-	pTarget := new(PermissionTargetParams)
+	permissionTarget := data.toAPIModel(ctx)
 
-	pTarget.Name = d.GetString("name", false)
+	response, err := r.ProviderData.Client.R().
+		SetBody(permissionTarget).
+		Put(PermissionsEndPoint + permissionTarget.Name)
 
-	if v, ok := d.GetOk("repo"); ok {
-		pTarget.Repo = unpackPermission(v)
-	}
-
-	if v, ok := d.GetOk("build"); ok {
-		pTarget.Build = unpackPermission(v)
-	}
-
-	if v, ok := d.GetOk("release_bundle"); ok {
-		pTarget.ReleaseBundle = unpackPermission(v)
-	}
-
-	return pTarget
-}
-
-func PackPermissionTarget(permissionTarget *PermissionTargetParams, d *schema.ResourceData) diag.Diagnostics {
-	packPermission := func(p *PermissionTargetSection) []interface{} {
-		packPermMap := func(e map[string][]string) []interface{} {
-			perm := make([]interface{}, len(e))
-
-			count := 0
-			for k, v := range e {
-				perm[count] = map[string]interface{}{
-					"name":        k,
-					"permissions": schema.NewSet(schema.HashString, utilsdk.CastToInterfaceArr(v)),
-				}
-				count++
-			}
-
-			return perm
-		}
-
-		s := map[string]interface{}{}
-
-		if p != nil {
-			if p.IncludePatterns != nil {
-				s["includes_pattern"] = schema.NewSet(schema.HashString, utilsdk.CastToInterfaceArr(p.IncludePatterns))
-			}
-
-			if p.ExcludePatterns != nil {
-				s["excludes_pattern"] = schema.NewSet(schema.HashString, utilsdk.CastToInterfaceArr(p.ExcludePatterns))
-			}
-
-			if p.Repositories != nil {
-				s["repositories"] = schema.NewSet(schema.HashString, utilsdk.CastToInterfaceArr(p.Repositories))
-			}
-
-			if p.Actions != nil {
-				perms := make(map[string]interface{})
-
-				if p.Actions.Users != nil {
-					perms["users"] = schema.NewSet(hashPrincipal, packPermMap(p.Actions.Users))
-				}
-
-				if p.Actions.Groups != nil {
-					perms["groups"] = schema.NewSet(hashPrincipal, packPermMap(p.Actions.Groups))
-				}
-
-				if len(perms) > 0 {
-					s["actions"] = []interface{}{perms}
-				}
-			}
-		}
-
-		return []interface{}{s}
-	}
-
-	setValue := utilsdk.MkLens(d)
-
-	errors := setValue("name", permissionTarget.Name)
-	if permissionTarget.Repo != nil {
-		errors = setValue("repo", packPermission(permissionTarget.Repo))
-	}
-	if permissionTarget.Build != nil {
-		errors = setValue("build", packPermission(permissionTarget.Build))
-	}
-
-	if permissionTarget.ReleaseBundle != nil {
-		errors = setValue("release_bundle", packPermission(permissionTarget.ReleaseBundle))
-	}
-
-	if errors != nil && len(errors) > 0 {
-		return diag.Errorf("failed to marshal permission target %q", errors)
-	}
-	return nil
-}
-
-func resourcePermissionTargetCreate(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	permissionTarget := unpackPermissionTarget(d)
-
-	if _, err := m.(utilsdk.ProvderMetadata).Client.R().AddRetryCondition(repository.Retry400).SetBody(permissionTarget).Post(PermissionsEndPoint + permissionTarget.Name); err != nil {
-		return diag.FromErr(err)
-	}
-
-	d.SetId(permissionTarget.Name)
-	return nil
-}
-
-func resourcePermissionTargetRead(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	permissionTarget := new(PermissionTargetParams)
-	resp, err := m.(utilsdk.ProvderMetadata).Client.R().SetResult(permissionTarget).Get(PermissionsEndPoint + d.Id())
 	if err != nil {
-		if resp != nil && resp.StatusCode() == http.StatusNotFound {
-			d.SetId("")
-			return nil
-		}
-		return diag.FromErr(err)
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
 	}
 
-	return PackPermissionTarget(permissionTarget, d)
-}
-
-func resourcePermissionTargetUpdate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	permissionTarget := unpackPermissionTarget(d)
-
-	if _, err := m.(utilsdk.ProvderMetadata).Client.R().SetBody(permissionTarget).Put(PermissionsEndPoint + d.Id()); err != nil {
-		return diag.FromErr(err)
+	// Return error if the HTTP status code is not 200 OK
+	if response.StatusCode() != http.StatusOK {
+		utilfw.UnableToCreateResourceError(resp, response.Status())
+		return
 	}
 
-	d.SetId(permissionTarget.Name)
-	return resourcePermissionTargetRead(ctx, d, m)
+	// Assign the resource ID for the resource in the state
+	data.Id = types.StringValue(permissionTarget.Name)
+
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func resourcePermissionTargetDelete(_ context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-	_, err := m.(utilsdk.ProvderMetadata).Client.R().Delete(PermissionsEndPoint + d.Id())
+func (r *PermissionTargetResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *PermissionTargetResourceModel
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
 
-	return diag.FromErr(err)
+	permissionTarget := &PermissionTargetResourceAPIModel{}
+
+	response, err := r.ProviderData.Client.R().
+		SetResult(permissionTarget).
+		Get(PermissionsEndPoint + data.Id.ValueString())
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Refresh Resource",
+			"An unexpected error occurred while attempting to refresh resource state. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Treat HTTP 404 Not Found status as a signal to recreate resource
+	// and return early
+	if response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+
+		return
+	}
+
+	// Convert from the API data model to the Terraform data model
+	// and refresh any attribute values.
+	data.ToState(ctx, resp.Diagnostics, permissionTarget)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
+
+func (r *PermissionTargetResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	var data *PermissionTargetResourceModel
+
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
+
+	// Convert from Terraform data model into API data model
+	permissionTarget := data.toAPIModel(ctx)
+
+	// Update call
+	response, err := r.ProviderData.Client.R().
+		SetBody(permissionTarget).
+		Put(PermissionsEndPoint + permissionTarget.Name)
+	if err != nil {
+		utilfw.UnableToUpdateResourceError(resp, err.Error())
+		return
+	}
+
+	// Return error if the HTTP status code is not 200 OK
+	if response.StatusCode() != http.StatusOK {
+		utilfw.UnableToUpdateResourceError(resp, response.Status())
+		return
+	}
+
+	data.ToState(ctx, resp.Diagnostics, &permissionTarget)
+
+	// Save updated data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (r *PermissionTargetResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data PermissionTargetResourceModel
+
+	// Read Terraform prior state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
+
+	response, err := r.ProviderData.Client.R().
+		Delete(PermissionsEndPoint + data.Id.ValueString())
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Delete Resource",
+			"An unexpected error occurred while attempting to delete the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Error: "+err.Error(),
+		)
+
+		return
+	}
+
+	// Return error if the HTTP status code is not 200 OK or 404 Not Found
+	if response.StatusCode() != http.StatusNotFound && response.StatusCode() != http.StatusOK {
+		resp.Diagnostics.AddError(
+			"Unable to Delete Resource",
+			"An unexpected error occurred while attempting to delete the resource. "+
+				"Please retry the operation or report this issue to the provider developers.\n\n"+
+				"HTTP Status: "+response.Status(),
+		)
+
+		return
+	}
+
+	// If the logic reaches here, it implicitly succeeded and will remove
+	// the resource from state if there are no other errors.
+}
+
+// ImportState imports the resource into the Terraform state.
+func (r *PermissionTargetResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+	resource.ImportStatePassthroughID(ctx, path.Root("id"), req, resp)
+}
+
+// PermissionTargetParams Copy from https://github.com/jfrog/jfrog-client-go/blob/master/artifactory/services/permissiontarget.go#L116
+//
+// Using struct pointers to keep the fields null if they are empty.
+// Artifactory evaluates inner struct typed fields if they are not null, which can lead to failures in the request.
 
 func PermTargetExists(id string, m interface{}) (bool, error) {
 	resp, err := m.(utilsdk.ProvderMetadata).Client.R().Head(PermissionsEndPoint + id)

--- a/pkg/artifactory/resource/security/resource_artifactory_permission_target.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_permission_target.go
@@ -297,11 +297,15 @@ func (r *PermissionTargetResource) getPrincipalBlock(description, repoDescriptio
 				MarkdownDescription: "The default value will be [] if nothing is supplied",
 			},
 			"repositories": schema.SetAttribute{
-				ElementType: types.StringType,
-				Required:    true,
-				// Optional:            true,
+				ElementType:         types.StringType,
+				Optional:            true,
 				MarkdownDescription: repoDescription,
 			},
+		},
+		Validators: []validator.Object{
+			validatorfw.RequireIfDefined(path.Expressions{
+				path.MatchRelative().AtName("repositories"),
+			}...),
 		},
 		Blocks: map[string]schema.Block{
 			"actions": schema.SingleNestedBlock{
@@ -309,9 +313,6 @@ func (r *PermissionTargetResource) getPrincipalBlock(description, repoDescriptio
 					"users":  actionsAttributeBlock,
 					"groups": actionsAttributeBlock,
 				},
-				// Validators: []validator.Object{
-				// 	objectvalidator.IsRequired(),
-				// },
 			},
 		},
 		MarkdownDescription: description,

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
@@ -26,18 +26,18 @@ import (
 	utilsdk "github.com/jfrog/terraform-provider-shared/util/sdk"
 )
 
-func NewArtifactoryScopedTokenResource() resource.Resource {
+func NewScopedTokenResource() resource.Resource {
 
-	return &ArtifactoryScopedTokenResource{}
+	return &ScopedTokenResource{}
 }
 
-type ArtifactoryScopedTokenResource struct {
+type ScopedTokenResource struct {
 	ProviderData utilsdk.ProvderMetadata
 }
 
-// ArtifactoryScopedTokenResourceModel describes the Terraform resource data model to match the
+// ScopedTokenResourceModel describes the Terraform resource data model to match the
 // resource schema.
-type ArtifactoryScopedTokenResourceModel struct {
+type ScopedTokenResourceModel struct {
 	Id                    types.String `tfsdk:"id"`
 	GrantType             types.String `tfsdk:"grant_type"`
 	Username              types.String `tfsdk:"username"`
@@ -94,11 +94,11 @@ type AccessTokenGetAPIModel struct {
 	Refreshable bool   `json:"refreshable"`
 }
 
-func (r *ArtifactoryScopedTokenResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
+func (r *ScopedTokenResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
 	resp.TypeName = "artifactory_scoped_token"
 }
 
-func (r *ArtifactoryScopedTokenResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+func (r *ScopedTokenResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
 		MarkdownDescription: "Create scoped tokens for any of the services in your JFrog Platform and to " +
 			"manage user access to these services. If left at the default setting, the token will " +
@@ -261,7 +261,7 @@ func (r *ArtifactoryScopedTokenResource) Schema(ctx context.Context, req resourc
 
 var serviceTypesScopedToken = []string{"jfrt", "jfxr", "jfpip", "jfds", "jfmc", "jfac", "jfevt", "jfmd", "jfcon"}
 
-func (r *ArtifactoryScopedTokenResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
+func (r *ScopedTokenResource) Configure(ctx context.Context, req resource.ConfigureRequest, resp *resource.ConfigureResponse) {
 	// Prevent panic if the provider has not been configured.
 	if req.ProviderData == nil {
 		return
@@ -269,8 +269,8 @@ func (r *ArtifactoryScopedTokenResource) Configure(ctx context.Context, req reso
 	r.ProviderData = req.ProviderData.(utilsdk.ProvderMetadata)
 }
 
-func (r *ArtifactoryScopedTokenResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
-	var data *ArtifactoryScopedTokenResourceModel
+func (r *ScopedTokenResource) Create(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	var data *ScopedTokenResourceModel
 	// Read Terraform plan data into the model
 	resp.Diagnostics.Append(req.Plan.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -348,8 +348,8 @@ func (r *ArtifactoryScopedTokenResource) Create(ctx context.Context, req resourc
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...) // All attributes are assigned in data
 }
 
-func (r *ArtifactoryScopedTokenResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
-	var data *ArtifactoryScopedTokenResourceModel
+func (r *ScopedTokenResource) Read(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	var data *ScopedTokenResourceModel
 	// Read Terraform prior state data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 	if resp.Diagnostics.HasError() {
@@ -389,13 +389,13 @@ func (r *ArtifactoryScopedTokenResource) Read(ctx context.Context, req resource.
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
-func (r *ArtifactoryScopedTokenResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+func (r *ScopedTokenResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
 	// Scoped tokens are not updatable
 	return
 }
 
-func (r *ArtifactoryScopedTokenResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data ArtifactoryScopedTokenResourceModel
+func (r *ScopedTokenResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
+	var data ScopedTokenResourceModel
 	respError := AccessTokenErrorResponseAPIModel{}
 
 	// Read Terraform prior state data into the model
@@ -422,14 +422,14 @@ func (r *ArtifactoryScopedTokenResource) Delete(ctx context.Context, req resourc
 }
 
 // ImportState imports the resource into the Terraform state.
-func (r *ArtifactoryScopedTokenResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
+func (r *ScopedTokenResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
 	resp.Diagnostics.AddError(
 		"Import is not supported",
 		"resource artifactory_scoped_token doesn't support import.",
 	)
 }
 
-func (r *ArtifactoryScopedTokenResourceModel) PostResponseToState(ctx context.Context,
+func (r *ScopedTokenResourceModel) PostResponseToState(ctx context.Context,
 	accessTokenResp *AccessTokenPostResponseAPIModel, accessTokenPostBody *AccessTokenPostRequestAPIModel, getResult *AccessTokenGetAPIModel) {
 
 	r.Id = types.StringValue(accessTokenResp.TokenId)
@@ -466,7 +466,7 @@ func (r *ArtifactoryScopedTokenResourceModel) PostResponseToState(ctx context.Co
 	r.Issuer = types.StringValue(getResult.Issuer)
 }
 
-func (r *ArtifactoryScopedTokenResourceModel) GetResponseToState(accessToken *AccessTokenGetAPIModel) {
+func (r *ScopedTokenResourceModel) GetResponseToState(accessToken *AccessTokenGetAPIModel) {
 	r.Id = types.StringValue(accessToken.TokenId)
 	r.Subject = types.StringValue(accessToken.Subject)
 	r.Expiry = types.Int64Value(accessToken.Expiry)

--- a/pkg/artifactory/resource/user/resource_artifactory_anonymous_user.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_anonymous_user.go
@@ -11,7 +11,7 @@ import (
 	"golang.org/x/net/context"
 )
 
-func NewArtifactoryAnonymousUserResource() resource.Resource {
+func NewAnonymousUserResource() resource.Resource {
 
 	return &ArtifactoryAnonymousUserResource{}
 }

--- a/pkg/artifactory/resource/user/resource_artifactory_managed_user.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_managed_user.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-func NewArtifactoryManagedUserResource() resource.Resource {
+func NewManagedUserResource() resource.Resource {
 
 	return &ArtifactoryManagedUserResource{}
 }

--- a/pkg/artifactory/resource/user/resource_artifactory_user.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_user.go
@@ -8,7 +8,7 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-func NewArtifactoryUserResource() resource.Resource {
+func NewUserResource() resource.Resource {
 
 	return &ArtifactoryUserResource{}
 }

--- a/scripts/run-artifactory.sh
+++ b/scripts/run-artifactory.sh
@@ -3,7 +3,7 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" > /dev/null && pwd )"
 source "${SCRIPT_DIR}/get-access-key.sh"
 source "${SCRIPT_DIR}/wait-for-rt.sh"
-export ARTIFACTORY_VERSION=${ARTIFACTORY_VERSION:-7.55.8}
+export ARTIFACTORY_VERSION=${ARTIFACTORY_VERSION:-7.59.9}
 echo "ARTIFACTORY_VERSION=${ARTIFACTORY_VERSION}"
 
 set -euf


### PR DESCRIPTION
* Migrate artifactory_permission_target to plugin framework
* Remove deprecated `artifactory_permission_targets` resource from SDKv2 provider
* DRY the error handling function and move to shared module