### PR TITLE
GH-739 add `disable_proxy` attribute for remote repos, add tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 8.2.0 (June 19, 2023). 
+
+IMPROVEMENTS:
+
+* resource/artifactory_remote_*_repository: new attribute `disable_proxy` was added. When set to `true`, proxy settings are ignored for the remote repository.  
+  
+  PR:    [#]()
+  Issue: [#739](https://github.com/jfrog/terraform-provider-artifactory/issues/739)
+
 ## 8.1.0 (June 15, 2023). Tested on Artifactory 7.59.9
 
 NOTES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ IMPROVEMENTS:
 
 * resource/artifactory_remote_*_repository: new attribute `disable_proxy` was added. When set to `true`, proxy settings are ignored for the remote repository.  
   
-  PR:    [#]()
+  PR:    [#751](https://github.com/jfrog/terraform-provider-artifactory/pull/751)
   Issue: [#739](https://github.com/jfrog/terraform-provider-artifactory/issues/739)
 
 ## 8.1.0 (June 15, 2023). Tested on Artifactory 7.59.9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.2.0 (June 19, 2023). 
+## 8.2.0 (June 19, 2023). Tested on Artifactory 7.59.11
 
 IMPROVEMENTS:
 

--- a/docs/resources/remote.md
+++ b/docs/resources/remote.md
@@ -49,9 +49,10 @@ All generic repo arguments are supported, in addition to:
 * `url` - (Required) The remote repo URL.
 * `username` - (Optional)
 * `password` - (Optional)
-* `proxy` - (Optional) Proxy key from Artifactory Proxies settings. Default is empty field.
-* `includes_pattern` - (Optional, Default: `**/*`) List of comma-separated artifact patterns to include when evaluating artifact requests in the form of x/y/\**/z/*. When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included.
-* `excludes_pattern` - (Optional) List of comma-separated artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*. By default no artifacts are excluded.
+* `proxy` - (Optional) Proxy key from Artifactory Proxies settings. Default is empty field. Can't be set if `disable_proxy = true`.
+* `disable_proxy` - (Optional, Default: `true`) When set to `true`, the proxy is disabled, and not returned in the API response body. If there is a default proxy set for the Artifactory instance, it will be ignored, too. Introduced since Artifactory 7.41.7.
+* `includes_pattern` - (Optional, Default: `**/*`) List of comma-separated artifact patterns to include when evaluating artifact requests in the form of x/y/**/z/*. When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included.
+* `excludes_pattern` - (Optional) List of comma-separated artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*. By default, no artifacts are excluded.
 * `repo_layout_ref` - (Optional) Sets the layout that the repository should use for storing and identifying modules. A recommended layout that corresponds to the package type defined is suggested, and index packages uploaded and calculate metadata accordingly.
 * `remote_repo_layout_ref` - (Optional) Deprecated field. This field has currently no effect, because there is no corresponding field in the API body, and it's not returned by the GET call.
 * `hard_fail` - (Optional, Default: `false`) When set, Artifactory will return an error to the client that causes the build to fail if there is a failure to communicate with this repository.

--- a/docs/resources/remote.md
+++ b/docs/resources/remote.md
@@ -50,7 +50,7 @@ All generic repo arguments are supported, in addition to:
 * `username` - (Optional)
 * `password` - (Optional)
 * `proxy` - (Optional) Proxy key from Artifactory Proxies settings. Default is empty field. Can't be set if `disable_proxy = true`.
-* `disable_proxy` - (Optional, Default: `true`) When set to `true`, the proxy is disabled, and not returned in the API response body. If there is a default proxy set for the Artifactory instance, it will be ignored, too. Introduced since Artifactory 7.41.7.
+* `disable_proxy` - (Optional, Default: `false`) When set to `true`, the proxy is disabled, and not returned in the API response body. If there is a default proxy set for the Artifactory instance, it will be ignored, too. Introduced since Artifactory 7.41.7.
 * `includes_pattern` - (Optional, Default: `**/*`) List of comma-separated artifact patterns to include when evaluating artifact requests in the form of x/y/**/z/*. When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included.
 * `excludes_pattern` - (Optional) List of comma-separated artifact patterns to exclude when evaluating artifact requests, in the form of x/y/**/z/*. By default, no artifacts are excluded.
 * `repo_layout_ref` - (Optional) Sets the layout that the repository should use for storing and identifying modules. A recommended layout that corresponds to the package type defined is suggested, and index packages uploaded and calculate metadata accordingly.

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
-func TestAccRemoteUpgradeFromSDKv2(t *testing.T) {
+func TestAccRemoteUpgradeFromVersionWithNoDisableProxyAttr(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("tf-go-remote-", "artifactory_remote_go_repository")
 
 	params := map[string]string{
@@ -43,7 +43,7 @@ func TestAccRemoteUpgradeFromSDKv2(t *testing.T) {
 			{
 				ExternalProviders: map[string]resource.ExternalProvider{
 					"artifactory": {
-						VersionConstraint: "7.7.0",
+						VersionConstraint: "8.1.0",
 						Source:            "registry.terraform.io/jfrog/artifactory",
 					},
 				},


### PR DESCRIPTION
New attribute for remote repositories, when set, the proxy is disabled for the repo. 
The change was tested on Artifactory 7.41.6 (before the attribute was added) and on the latest. 
Added several tests, including migration test (7.7.0 -> latest)