### PR TITLE
GH-747 allow usage of plain string in `vcs_git_download_url` attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 BUG FIX:
 * resource/artifactory_remote_vcs_repository: IsURLWithHTTPorHTTPS check was removed from the `vcs_git_download_url` attribute to allow use formatted string with placeholders, like `{0}/{1}/+archive/{2}.{3}` with `CUSTOM` Git provider.
 
-  PR: [#]()
+  PR: [#756](https://github.com/jfrog/terraform-provider-artifactory/pull/756)
   Issue: [#747](https://github.com/jfrog/terraform-provider-artifactory/issues/747)
 
 ## 8.2.1 (June 21, 2023). Tested on Artifactory 7.59.11 with Terraform CLI v1.5.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 8.2.2 (June 22, 2023).
+## 8.2.2 (June 22, 2023). Tested on Artifactory 7.59.11 with Terraform CLI v1.5.1
 
 BUG FIX:
 * resource/artifactory_remote_vcs_repository: IsURLWithHTTPorHTTPS check was removed from the `vcs_git_download_url` attribute to allow use formatted string with placeholders, like `{0}/{1}/+archive/{2}.{3}` with `CUSTOM` Git provider.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 8.2.2 (June 22, 2023).
+
+BUG FIX:
+* resource/artifactory_remote_vcs_repository: IsURLWithHTTPorHTTPS check was removed from the `vcs_git_download_url` attribute to allow use formatted string with placeholders, like `{0}/{1}/+archive/{2}.{3}` with `CUSTOM` Git provider.
+
+  PR: [#]()
+  Issue: [#747](https://github.com/jfrog/terraform-provider-artifactory/issues/747)
+
 ## 8.2.1 (June 21, 2023). Tested on Artifactory 7.59.11 with Terraform CLI v1.5.1
 
 IMPROVEMENTS:

--- a/docs/resources/remote_vcs_repository.md
+++ b/docs/resources/remote_vcs_repository.md
@@ -5,7 +5,7 @@ subcategory: "Remote Repositories"
 
 Creates a remote VCS repository.
 
-Official documentation can be found [here](https://www.jfrog.com/confluence/display/JFROG/VCS+Repositories).
+Official documentation can be found [here](https://jfrog.com/help/r/jfrog-artifactory-documentation/vcs-repositories).
 
 ## Example Usage
 

--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -62,6 +62,10 @@ type RepositoryRemoteBaseParams struct {
 	CdnRedirect                       bool                               `json:"cdnRedirect"`
 }
 
+func (r RepositoryRemoteBaseParams) GetRclass() string {
+	return r.Rclass
+}
+
 type JavaRemoteRepo struct {
 	RepositoryRemoteBaseParams
 	FetchJarsEagerly             bool   `json:"fetchJarsEagerly"`
@@ -394,7 +398,7 @@ var VcsRemoteRepoSchema = map[string]*schema.Schema{
 	"vcs_git_download_url": {
 		Type:             schema.TypeString,
 		Optional:         true,
-		ValidateDiagFunc: validation.ToDiagFunc(validation.All(validation.StringIsNotEmpty, validation.IsURLWithHTTPorHTTPS)),
+		ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 		Description:      `This attribute is used when vcs_git_provider is set to 'CUSTOM'. Provided URL will be used as proxy.`,
 	},
 }
@@ -630,8 +634,4 @@ func verifyRemoteRepoLayoutRef(_ context.Context, diff *schema.ResourceDiff, _ i
 	}
 
 	return nil
-}
-
-func (r RepositoryRemoteBaseParams) GetRclass() string {
-	return r.Rclass
 }

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
@@ -518,7 +518,17 @@ func TestAccRemoteVcsRepository(t *testing.T) {
 		"url":                  "https://github.com/",
 		"vcs_git_provider":     "CUSTOM",
 		"vcs_git_download_url": "https://www.customrepo.com",
-		// "max_unique_snapshots": 5, // commented out due to API bug in 7.49.3
+		"max_unique_snapshots": 5,
+	}))
+}
+
+func TestAccRemoteVcsRepositoryWithFormattedUrl(t *testing.T) {
+	const packageType = "vcs"
+	resource.Test(mkNewRemoteTestCase(packageType, t, map[string]interface{}{
+		"url":                  "https://github.com/",
+		"vcs_git_provider":     "CUSTOM",
+		"vcs_git_download_url": "{0}/{1}/+archive/{2}.{3}",
+		"max_unique_snapshots": 5,
 	}))
 }
 


### PR DESCRIPTION
Also, added a test and some minor refactoring.