### PR TITLE
GH-758 `include_reference_token`, default value removed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 8.3.1 (July 5, 2023). Tested on Artifactory 7.59.11 with Terraform CLI v1.5.2
+
+BUG FIX:
+* resource/artifactory_scoped_token: default value `false` is removed from `include_reference_token` attribute to avoid state drift, when the provider updating from version below 7.7.0 to the latest. 
+
+PR: [#]()
+Issues:[#758](https://github.com/jfrog/terraform-provider-artifactory/issues/758), [#761](https://github.com/jfrog/terraform-provider-artifactory/issues/761)
+
 ## 8.3.0 (July 5, 2023). Tested on Artifactory 7.59.11 with Terraform CLI v1.5.2
 
 IMPROVEMENTS:

--- a/docs/resources/scoped_token.md
+++ b/docs/resources/scoped_token.md
@@ -77,7 +77,7 @@ resource "artifactory_scoped_token" "audience" {
 - `description` (String) Free text token description. Useful for filtering and managing tokens. Limited to 1024 characters.
 - `expires_in` (Number) The amount of time, in seconds, it would take for the token to expire. An admin shall be able to set whether expiry is mandatory, what is the default expiry, and what is the maximum expiry allowed. Must be non-negative. Default value is based on configuration in 'access.config.yaml'. See [API documentation](https://jfrog.com/help/r/jfrog-rest-apis/revoke-token-by-id) for details. Access Token would not be saved by Artifactory if this is less than the persistence threshold value (default to 10800 seconds) set in Access configuration. See [official documentation](https://jfrog.com/help/r/jfrog-platform-administration-documentation/using-the-revocable-and-persistency-thresholds) for details.
 - `grant_type` (String) The grant type used to authenticate the request. In this case, the only value supported is `client_credentials` which is also the default value if this parameter is not specified.
-- `include_reference_token` (Boolean) Also create a reference token which can be used like an API key. Default is `false`.
+- `include_reference_token` (Boolean) Also create a reference token which can be used like an API key.
 - `refreshable` (Boolean) Is this token refreshable? Default is `false`.
 - `scopes` (Set of String) The scope of access that the token provides. Access to the REST API is always provided by default. Administrators can set any scope, while non-admin users can only set the scope to a subset of the groups to which they belong.
   The supported scopes include:

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
@@ -207,7 +207,7 @@ func (r *ScopedTokenResource) Schema(ctx context.Context, req resource.SchemaReq
 				MarkdownDescription: "Also create a reference token which can be used like an API key. Default is `false`.",
 				Optional:            true,
 				Computed:            true,
-				Default:             booldefault.StaticBool(false),
+				//Default:             booldefault.StaticBool(false),
 				PlanModifiers: []planmodifier.Bool{
 					boolplanmodifier.RequiresReplaceIfConfigured(),
 					boolplanmodifier.UseStateForUnknown(),
@@ -502,6 +502,7 @@ func (r *ScopedTokenResourceModel) PostResponseToState(ctx context.Context,
 		r.ReferenceToken = types.StringValue(accessTokenResp.ReferenceToken)
 	}
 
+	r.IncludeReferenceToken = types.BoolValue(accessTokenPostBody.IncludeReferenceToken)
 	r.TokenType = types.StringValue(accessTokenResp.TokenType)
 	r.Subject = types.StringValue(getResult.Subject)
 	r.Expiry = types.Int64Value(getResult.Expiry) // could be absent in the get response!

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
@@ -16,9 +16,10 @@ import (
 )
 
 func TestAccScopedToken_UpgradeFromSDKv2(t *testing.T) {
+	// Version 7.11.1 is the last version before we migrated the resource from SDKv2 to Plugin Framework
 	version := "7.11.1"
 	title := fmt.Sprintf(
-		"TestScopedToken_v%s",
+		"TestScopedToken_upgrade_from_v%s",
 		cases.Title(language.AmericanEnglish).String(strings.ToLower(version)),
 	)
 	t.Run(title, func(t *testing.T) {
@@ -27,9 +28,11 @@ func TestAccScopedToken_UpgradeFromSDKv2(t *testing.T) {
 }
 
 func TestAccScopedToken_UpgradeGH_758(t *testing.T) {
+	// Version 7.2.0 doesn't have `include_reference_token` attribute
+	// This test verifies that there is no state drift on update
 	version := "7.2.0"
 	title := fmt.Sprintf(
-		"TestScopedToken_v%s",
+		"TestScopedToken_upgrade_from_v%s",
 		cases.Title(language.AmericanEnglish).String(strings.ToLower(version)),
 	)
 	t.Run(title, func(t *testing.T) {


### PR DESCRIPTION
- Removed default value from the `include_reference_token` attribute
- Added upgrade tests, simulating the situation, described in #758 