### PR TITLE
adding support for oci URLs to pull oci based registries from internet

### DIFF
--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_helm_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_helm_repository.go
@@ -19,7 +19,7 @@ var HelmRemoteSchema = func(isResource bool) map[string]*schema.Schema {
 				Type:             schema.TypeString,
 				Optional:         true,
 				Default:          "",
-				ValidateDiagFunc: validation.ToDiagFunc(validation.Any(validation.IsURLWithHTTPorHTTPS, validation.StringIsEmpty)),
+				ValidateDiagFunc: validation.ToDiagFunc(validation.Any(IsURLWithScheme([]string{"http", "https", "oci"}), validation.StringIsEmpty)),
 				Description: "Base URL for the translation of chart source URLs in the index.yaml of virtual repos. " +
 					"Artifactory will only translate URLs matching the index.yamls hostname or URLs starting with this base url.",
 			},


### PR DESCRIPTION
We wish to pull public charts from the internet that are `OCI` based registries.
An example of URL usage is [oci://public.ecr.aws/karpenter/karpenter](oci://public.ecr.aws/karpenter/karpenter), which is currently being denied due to only `http` and `https` being accepted.
 I updated the validation function to include `oci` as well.