### PR TITLE
Make provider attributes match between SDKv2 and framework providers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 9.7.2 (Oct 19, 2023).
+## 9.7.2 (Oct 19, 2023). Tested on Artifactory 7.68.14 with Terraform CLI v1.6.2
 
 BUG FIX:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 9.7.2 (Oct 19, 2023).
+
+BUG FIX:
+
+* provider: Fix schema differences between SDKv2 and Framework providers. PR: [#834](https://github.com/jfrog/terraform-provider-artifactory/pull/834) Issue: [#833](https://github.com/jfrog/terraform-provider-artifactory/issues/833)
+
 ## 9.7.1 (Oct 19, 2023). Tested on Artifactory 7.68.14 with Terraform CLI v1.6.2
 
 IMPROVEMENTS:

--- a/pkg/artifactory/provider/framework.go
+++ b/pkg/artifactory/provider/framework.go
@@ -51,7 +51,7 @@ func (p *ArtifactoryProvider) Schema(ctx context.Context, req provider.SchemaReq
 				},
 			},
 			"access_token": schema.StringAttribute{
-				Description: "This is a access token that can be given to you by your admin under `User Management -> Access Tokens`.",
+				Description: "This is a access token that can be given to you by your admin under `User Management -> Access Tokens`. If not set, the 'api_key' attribute value will be used.",
 				Optional:    true,
 				Sensitive:   true,
 				Validators: []validator.String{
@@ -59,7 +59,7 @@ func (p *ArtifactoryProvider) Schema(ctx context.Context, req provider.SchemaReq
 				},
 			},
 			"api_key": schema.StringAttribute{
-				Description:        "API token. Projects functionality will not work with any auth method other than access tokens",
+				Description:        "API key. If `access_token` attribute, `JFROG_ACCESS_TOKEN` or `ARTIFACTORY_ACCESS_TOKEN` environment variable is set, the provider will ignore this attribute.",
 				DeprecationMessage: "An upcoming version will support the option to block the usage/creation of API Keys (for admins to set on their platform). In a future version (scheduled for end of Q3, 2023), the option to disable the usage/creation of API Keys will be available and set to disabled by default. Admins will be able to enable the usage/creation of API Keys. By end of Q1 2024, API Keys will be deprecated all together and the option to use them will no longer be available.",
 				Optional:           true,
 				Sensitive:          true,
@@ -123,7 +123,7 @@ func (p *ArtifactoryProvider) Configure(ctx context.Context, req provider.Config
 		)
 	}
 
-	restyBase, err = client.AddAuth(restyBase, "", accessToken)
+	restyBase, err = client.AddAuth(restyBase, config.ApiKey.ValueString(), accessToken)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error adding Auth to Resty client",

--- a/pkg/artifactory/provider/sdkv2.go
+++ b/pkg/artifactory/provider/sdkv2.go
@@ -37,7 +37,7 @@ func SdkV2() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
-				Description: "This is a access token that can be given to you by your admin under `Identity and Access`. If not set, the 'api_key' attribute value will be used.",
+				Description: "This is a access token that can be given to you by your admin under `User Management -> Access Tokens`. If not set, the 'api_key' attribute value will be used.",
 			},
 			"check_license": {
 				Type:        schema.TypeBool,

--- a/sample.tf
+++ b/sample.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     artifactory = {
       source  = "registry.terraform.io/jfrog/artifactory"
-      version = "7.10.1"
+      version = "9.7.2"
     }
   }
 }


### PR DESCRIPTION
Fix #833 

Terraform cli doesn't like the descriptions between SDKv2 and Framework providers are different. 🤷🏼 