### PR TITLE
Fix reading global environments

### DIFF
--- a/pkg/artifactory/resource/security/resource_artifactory_global_environment.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_global_environment.go
@@ -134,6 +134,7 @@ func (r *GlobalEnvironmentResource) Read(ctx context.Context, req resource.ReadR
 	for _, env := range environments {
 		if env.Name == state.Id.ValueString() {
 			matchedEnvName = &env.Name
+			break
 		}
 	}
 


### PR DESCRIPTION
Detailed description
When importing multiple global environments the terraforming does not honor the name of the resource being imported.

Example:
```
resource "artifactory_global_environment" "virtual_env" {
  name = "VIRTUAL"
}

resource "artifactory_global_environment" "shared_env" {
  name = "SHARED"
}
```

The import commands:
```
$ terraform import artifactory_global_environment.virtual_env VIRTUAL

$ terraform import artifactory_global_environment.shared_env SHARED
```

Output:
$terraform plan:

```
  # artifactory_global_environment.shared_env will be updated in-place
  ~ resource "artifactory_global_environment" "shared_env" {
      ~ id   = "VIRTUAL" -> (known after apply)
      ~ name = "VIRTUAL" -> "SHARED"
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```

It seems that it only took the last entry of the environment list.
To try it out i changed the order of the environments in the UI and it wanted to change the Terraform but with the last environment.

