### PR TITLE
Fix user creation and groups membership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Fix `groups` handling to keep groups membership from Artifactory sychronized and avoid state drift. Issue: [#915](https://github.com/jfrog/terraform-provider-artifactory/issues/915) PR: [#920](https://github.com/jfrog/terraform-provider-artifactory/pull/920)
+* resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Fix `groups` handling to keep groups membership from Artifactory sychronized and avoid state drift. Also fix inability to create an user without `password` set with `internal_password_disabled` is set to `true`. Issue: [#915](https://github.com/jfrog/terraform-provider-artifactory/issues/915) PR: [#920](https://github.com/jfrog/terraform-provider-artifactory/pull/920)
 
 ## 10.4.0 (Mar 20, 2024)
 
@@ -23,7 +23,7 @@ Issue: [#909](https://github.com/jfrog/terraform-provider-artifactory/issues/909
 
 BUG FIXES:
 
-* resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Fix `groups` handling so `readers` group from Artifactory no longer cause state drift. Also fix inability to create an user without `password` set with `internal_password_disabled` is set to `true`. Issue: [#900](https://github.com/jfrog/terraform-provider-artifactory/issues/900)
+* resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Fix `groups` handling so `readers` group from Artifactory no longer cause state drift. Issue: [#900](https://github.com/jfrog/terraform-provider-artifactory/issues/900)
 
 PR: [#908](https://github.com/jfrog/terraform-provider-artifactory/pull/908)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,7 @@ Issue: [#909](https://github.com/jfrog/terraform-provider-artifactory/issues/909
 
 BUG FIXES:
 
-* resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Fix `groups` handling so `readers` group from Artifactory no longer cause state drift. Issue: [#900](https://github.com/jfrog/terraform-provider-artifactory/issues/900)
+* resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Fix `groups` handling so `readers` group from Artifactory no longer cause state drift. Also fix inability to create an user without `password` set with `internal_password_disabled` is set to `true`. Issue: [#900](https://github.com/jfrog/terraform-provider-artifactory/issues/900)
 
 PR: [#908](https://github.com/jfrog/terraform-provider-artifactory/pull/908)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-* resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Fix `groups` handling to keep groups membership from Artifactory sychronized and avoid state drift. Also fix inability to create an user without `password` set with `internal_password_disabled` is set to `true`. Issue: [#915](https://github.com/jfrog/terraform-provider-artifactory/issues/915) PR: [#920](https://github.com/jfrog/terraform-provider-artifactory/pull/920)
+* resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Fix `groups` handling to keep groups membership from Artifactory sychronized and avoid state drift. Also fix inability to create n user without `password` set with `internal_password_disabled` is set to `true`. Issue: [#915](https://github.com/jfrog/terraform-provider-artifactory/issues/915) PR: [#920](https://github.com/jfrog/terraform-provider-artifactory/pull/920)
 
 ## 10.4.0 (Mar 20, 2024)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 10.4.1 (Mar 25, 2024)
+
+BUG FIXES:
+
+* resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Fix `groups` handling to keep groups membership from Artifactory sychronized and avoid state drift. Issue: [#915](https://github.com/jfrog/terraform-provider-artifactory/issues/915) PR: [#920](https://github.com/jfrog/terraform-provider-artifactory/pull/920)
+
 ## 10.4.0 (Mar 20, 2024)
 
 IMPROVEMENTS:

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
@@ -453,7 +453,7 @@ func (r *ScopedTokenResource) Read(ctx context.Context, req resource.ReadRequest
 	if response.StatusCode() == http.StatusNotFound {
 		resp.Diagnostics.AddWarning(
 			fmt.Sprintf("Scoped token %s not found or not created", data.Id.ValueString()),
-			"Access Token would not be saved by Artifactory if 'expires_in' is less than the persistence threshold value (default to 10800 seconds) set in Access configuration. See https://www.jfrog.com/confluence/display/JFROG/Access+Tokens#AccessTokens-PersistencyThreshold for details."+err.Error(),
+			"Access Token would not be saved by Artifactory if 'expires_in' is less than the persistence threshold value (default to 10800 seconds) set in Access configuration. See https://www.jfrog.com/confluence/display/JFROG/Access+Tokens#AccessTokens-PersistencyThreshold for details."+response.String(),
 		)
 		resp.State.RemoveResource(ctx)
 		return

--- a/pkg/artifactory/resource/user/resource_artifactory_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_user_test.go
@@ -65,13 +65,10 @@ func TestAccUser_full_groups(t *testing.T) {
 	id, fqrn, name := testutil.MkNames("test-user-", "artifactory_user")
 	_, _, groupName1 := testutil.MkNames("test-group-", "artifactory_group")
 	_, _, groupName2 := testutil.MkNames("test-group-", "artifactory_group")
-	username := fmt.Sprintf("dummy_user%d", id)
-	email := fmt.Sprintf(username + "@test.com")
 
-	params := map[string]interface{}{
-		"name":       fmt.Sprintf("foobar-%d", id),
-		"username":   username,
-		"email":      email,
+	params := map[string]string{
+		"name":       name,
+		"email":      fmt.Sprintf("dummy_user%d@test.com", id),
 		"groupName1": groupName1,
 		"groupName2": groupName2,
 	}
@@ -120,26 +117,26 @@ func TestAccUser_full_groups(t *testing.T) {
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(fqrn, "name", fmt.Sprintf("foobar-%d", id)),
+					resource.TestCheckResourceAttr(fqrn, "name", params["name"]),
 					resource.TestCheckResourceAttr(fqrn, "groups.#", "1"),
-					resource.TestCheckTypeSetElemAttr(fqrn, "groups.*", groupName1),
+					resource.TestCheckTypeSetElemAttr(fqrn, "groups.*", params["groupName1"]),
 				),
 			},
 			{
 				Config: updatedConfig,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(fqrn, "name", fmt.Sprintf("foobar-%d", id)),
+					resource.TestCheckResourceAttr(fqrn, "name", params["name"]),
 					resource.TestCheckResourceAttr(fqrn, "groups.#", "2"),
-					resource.TestCheckTypeSetElemAttr(fqrn, "groups.*", groupName1),
-					resource.TestCheckTypeSetElemAttr(fqrn, "groups.*", groupName2),
+					resource.TestCheckTypeSetElemAttr(fqrn, "groups.*", params["groupName1"]),
+					resource.TestCheckTypeSetElemAttr(fqrn, "groups.*", params["groupName2"]),
 				),
 			},
 			{
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(fqrn, "name", fmt.Sprintf("foobar-%d", id)),
+					resource.TestCheckResourceAttr(fqrn, "name", params["name"]),
 					resource.TestCheckResourceAttr(fqrn, "groups.#", "1"),
-					resource.TestCheckTypeSetElemAttr(fqrn, "groups.*", groupName1),
+					resource.TestCheckTypeSetElemAttr(fqrn, "groups.*", params["groupName1"]),
 				),
 			},
 			{

--- a/pkg/artifactory/resource/user/user.go
+++ b/pkg/artifactory/resource/user/user.go
@@ -175,10 +175,9 @@ func syncReadersGroup(ctx context.Context, client *resty.Client, plan User, actu
 		Add:    toAdd,
 		Remove: toRemove,
 	}
-	// Access PATCH call for updating user will **always** add "readers" to the groups.
-	// This is a bug on Artifactory. Below workaround will fix the issue and has to be removed after the artifactory bug is resolved.
-	// Workaround: We use following PATCH call to remove "readers" from the user's groups.
-	// This action will match the expectation for this resource so "groups" attribute matches what's specified in hcl.
+	// Access API for creating user will add any groups with "auto_join = true" to the user's groups.
+	// We use following PATCH call to sync up user's groups from TF to Artifactory.
+	// This action will match the expectation for this resource so "groups" attribute matches what's on Artifactory.
 	_, err := client.R().
 		SetPathParam("name", plan.Name).
 		SetBody(groupsToAddRemove).

--- a/pkg/artifactory/resource/user/user_fw.go
+++ b/pkg/artifactory/resource/user/user_fw.go
@@ -184,7 +184,7 @@ func (r *ArtifactoryBaseUserResource) syncReadersGroup(ctx context.Context, clie
 		Add:    toAdd,
 		Remove: toRemove,
 	}
-	// Access PATCH call for updating user will add any groups with "auto_join = true" to the user's groups.
+	// Access API for creating user will add any groups with "auto_join = true" to the user's groups.
 	// We use following PATCH call to sync up user's groups from TF to Artifactory.
 	// This action will match the expectation for this resource so "groups" attribute matches what's on Artifactory.
 	resp, err := client.R().


### PR DESCRIPTION
Close #915 

* Fix unable to create `artifactory_user` without `password` when `internal_password_disabled` is set to `true`.
* Update `groups` membership handling so now will keep groups membership in sync according to the `groups` attribute list.