### PR TITLE
Restore user resource backward compatibility with older Artifactory

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -33,6 +33,9 @@ archives:
 - format: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 signs:
@@ -48,6 +51,9 @@ signs:
       - "--detach-sign"
       - "${artifact}"
 release:
+  extra_files:
+    - glob: 'terraform-registry-manifest.json'
+      name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   # If you want to manually examine the release before its live, uncomment this line:
   # draft: true
 changelog:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 10.4.3 (Apr 1, 2024)
+
+BUG FIXES:
+
+* resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Restore backward compatibility with Artifactory 7.49.2 and earlier. Issue: [#922](https://github.com/jfrog/terraform-provider-artifactory/issues/922) PR: [#923](https://github.com/jfrog/terraform-provider-artifactory/pull/923)
+
 ## 10.4.2 (Mar 27, 2024)
 
 BUG FIXES:
@@ -8,7 +14,7 @@ BUG FIXES:
 
 BUG FIXES:
 
-* resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Fix `groups` handling to keep groups membership from Artifactory sychronized and avoid state drift. Also fix inability to create n user without `password` set with `internal_password_disabled` is set to `true`. Issue: [#915](https://github.com/jfrog/terraform-provider-artifactory/issues/915) PR: [#920](https://github.com/jfrog/terraform-provider-artifactory/pull/920)
+* resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Fix `groups` handling to keep groups membership from Artifactory sychronized and avoid state drift. Also fix inability to create a user without `password` set with `internal_password_disabled` is set to `true`. Issue: [#915](https://github.com/jfrog/terraform-provider-artifactory/issues/915) PR: [#920](https://github.com/jfrog/terraform-provider-artifactory/pull/920)
 
 ## 10.4.0 (Mar 20, 2024)
 

--- a/pkg/acctest/test.go
+++ b/pkg/acctest/test.go
@@ -335,7 +335,7 @@ func DeleteUser(t *testing.T, name string) error {
 	restyClient := GetTestResty(t)
 	_, err := restyClient.R().
 		SetPathParam("name", name).
-		Delete(user.UserEndpointPath)
+		Delete("access/api/v2/users/{name}")
 
 	return err
 }
@@ -355,7 +355,7 @@ func CreateUserUpdatable(t *testing.T, name string, email string) {
 	restyClient := GetTestResty(t)
 	_, err := restyClient.R().
 		SetBody(userObj).
-		Post(user.UsersEndpointPath)
+		Post("access/api/v2/users")
 
 	if err != nil {
 		t.Fatal(err)
@@ -363,7 +363,6 @@ func CreateUserUpdatable(t *testing.T, name string, email string) {
 }
 
 func CompareArtifactoryVersions(t *testing.T, instanceVersions string) (bool, error) {
-
 	fixedVersion, err := version.NewVersion(instanceVersions)
 	if err != nil {
 		return false, err

--- a/pkg/artifactory/datasource/user/datasource_artifactory_user.go
+++ b/pkg/artifactory/datasource/user/datasource_artifactory_user.go
@@ -74,7 +74,7 @@ func DataSourceArtifactoryUser() *schema.Resource {
 		resp, err := m.(util.ProvderMetadata).Client.R().
 			SetPathParam("name", userName).
 			SetResult(&userObj).
-			Get(user.UserEndpointPath)
+			Get(user.GetUsersEndpointPath(m.(util.ProvderMetadata).ArtifactoryVersion))
 
 		if err != nil {
 			return diag.FromErr(err)

--- a/pkg/artifactory/datasource/user/datasource_artifactory_user.go
+++ b/pkg/artifactory/datasource/user/datasource_artifactory_user.go
@@ -9,6 +9,7 @@ import (
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilsdk "github.com/jfrog/terraform-provider-shared/util/sdk"
 
+	"github.com/jfrog/terraform-provider-artifactory/v10/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-artifactory/v10/pkg/artifactory/resource/user"
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
@@ -70,11 +71,14 @@ func DataSourceArtifactoryUser() *schema.Resource {
 		d := &utilsdk.ResourceData{ResourceData: rd}
 
 		userName := d.Get("name").(string)
-		userObj := user.User{}
-		resp, err := m.(util.ProvderMetadata).Client.R().
-			SetPathParam("name", userName).
-			SetResult(&userObj).
-			Get(user.GetUsersEndpointPath(m.(util.ProvderMetadata).ArtifactoryVersion))
+		var userObj user.User
+		var artifactoryError artifactory.ArtifactoryErrorsResponse
+		resp, err := user.ReadUser(
+			m.(util.ProvderMetadata).Client.R(),
+			m.(util.ProvderMetadata).ArtifactoryVersion,
+			userName,
+			&userObj,
+			&artifactoryError)
 
 		if err != nil {
 			return diag.FromErr(err)

--- a/pkg/artifactory/resource/user/resource_artifactory_unmanaged_user.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_unmanaged_user.go
@@ -38,7 +38,6 @@ func ResourceArtifactoryUser() *schema.Resource {
 }
 
 func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
-
 	passwordGenerator := func(user *User) diag.Diagnostics {
 		var diags diag.Diagnostics
 

--- a/pkg/artifactory/resource/user/user.go
+++ b/pkg/artifactory/resource/user/user.go
@@ -222,7 +222,7 @@ func createUser(req *resty.Request, artifactoryVersion string, user User, result
 	return res, err
 }
 
-func readUser(req *resty.Request, artifactoryVersion, name string, result *User, artifactoryError *artifactory.ArtifactoryErrorsResponse) (*resty.Response, error) {
+func ReadUser(req *resty.Request, artifactoryVersion, name string, result *User, artifactoryError *artifactory.ArtifactoryErrorsResponse) (*resty.Response, error) {
 	endpoint := GetUserEndpointPath(artifactoryVersion)
 
 	// 7.49.3 or later, use Access API
@@ -327,7 +327,7 @@ func resourceUserRead(_ context.Context, rd *schema.ResourceData, m interface{})
 
 	var user User
 	var artifactoryError artifactory.ArtifactoryErrorsResponse
-	resp, err := readUser(
+	resp, err := ReadUser(
 		m.(util.ProvderMetadata).Client.R(),
 		m.(util.ProvderMetadata).ArtifactoryVersion,
 		d.Id(),
@@ -412,7 +412,7 @@ func resourceBaseUserCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	retryError := retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		var result User
-		resp, e := readUser(
+		resp, e := ReadUser(
 			m.(util.ProvderMetadata).Client.R(),
 			m.(util.ProvderMetadata).ArtifactoryVersion,
 			d.Id(),

--- a/pkg/artifactory/resource/user/user.go
+++ b/pkg/artifactory/resource/user/user.go
@@ -19,6 +19,8 @@ import (
 	"github.com/samber/lo"
 )
 
+const AccessAPIArtifactoryVersion = "7.49.3"
+
 type User struct {
 	Name                     string   `json:"username"`
 	Email                    string   `json:"email"`
@@ -131,20 +133,206 @@ func PackUser(user User, d *schema.ResourceData) diag.Diagnostics {
 	return nil
 }
 
-const UsersEndpointPath = "access/api/v2/users"
-const UserEndpointPath = "access/api/v2/users/{name}"
 const UserGroupEndpointPath = "access/api/v2/users/{name}/groups"
+
+func GetUsersEndpointPath(artifactoryVersion string) string {
+	if ok, err := util.CheckVersion(artifactoryVersion, AccessAPIArtifactoryVersion); err == nil && ok {
+		return "access/api/v2/users"
+	}
+
+	return "artifactory/api/security/users"
+}
+
+func GetUserEndpointPath(artifactoryVersion string) string {
+	if ok, err := util.CheckVersion(artifactoryVersion, AccessAPIArtifactoryVersion); err == nil && ok {
+		return "access/api/v2/users/{name}"
+	}
+
+	return "artifactory/api/security/users/{name}"
+}
+
+// ArtifactoryUserAPIModel corresponds to old Artifactory user API
+type ArtifactoryUserAPIModel struct {
+	Name                     string    `json:"name"`
+	Email                    string    `json:"email"`
+	Password                 string    `json:"password,omitempty"`
+	Admin                    bool      `json:"admin"`
+	ProfileUpdatable         bool      `json:"profileUpdatable"`
+	DisableUIAccess          bool      `json:"disableUIAccess"`
+	InternalPasswordDisabled bool      `json:"internalPasswordDisabled"`
+	Groups                   *[]string `json:"groups,omitempty"`
+}
+
+func createUser(req *resty.Request, artifactoryVersion string, user User, result *User, artifactoryError *artifactory.ArtifactoryErrorsResponse) (*resty.Response, error) {
+	if ok, err := util.CheckVersion(artifactoryVersion, AccessAPIArtifactoryVersion); err == nil && ok {
+		return req.
+			SetBody(user).
+			SetResult(result).
+			SetError(artifactoryError).
+			Post(GetUsersEndpointPath(artifactoryVersion))
+	}
+
+	// else use old Artifactory API, which has a slightly differect JSON payload!
+	artifactoryUser := ArtifactoryUserAPIModel{
+		Name:                     user.Name,
+		Email:                    user.Email,
+		Password:                 user.Password,
+		Admin:                    user.Admin,
+		ProfileUpdatable:         user.ProfileUpdatable,
+		DisableUIAccess:          user.DisableUIAccess,
+		InternalPasswordDisabled: user.InternalPasswordDisabled,
+		Groups:                   &user.Groups,
+	}
+	endpoint := GetUserEndpointPath(artifactoryVersion)
+	resp, err := req.
+		SetPathParam("name", artifactoryUser.Name).
+		SetBody(artifactoryUser).
+		SetError(artifactoryError).
+		Put(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if resp.IsError() {
+		return resp, nil
+	}
+
+	var artifactoryResult ArtifactoryUserAPIModel
+	res, err := req.
+		SetPathParam("name", artifactoryUser.Name).
+		SetResult(&artifactoryResult).
+		SetError(artifactoryError).
+		Get(endpoint)
+
+	var groups []string
+	if artifactoryResult.Groups != nil {
+		groups = *artifactoryResult.Groups
+	}
+
+	*result = User{
+		Name:                     artifactoryResult.Name,
+		Email:                    artifactoryResult.Email,
+		Password:                 user.Password,
+		Admin:                    artifactoryResult.Admin,
+		ProfileUpdatable:         artifactoryResult.ProfileUpdatable,
+		DisableUIAccess:          artifactoryResult.DisableUIAccess,
+		InternalPasswordDisabled: artifactoryResult.InternalPasswordDisabled,
+		Groups:                   groups,
+	}
+
+	return res, err
+}
+
+func readUser(req *resty.Request, artifactoryVersion, name string, result *User, artifactoryError *artifactory.ArtifactoryErrorsResponse) (*resty.Response, error) {
+	endpoint := GetUserEndpointPath(artifactoryVersion)
+
+	// 7.49.3 or later, use Access API
+	if ok, err := util.CheckVersion(artifactoryVersion, AccessAPIArtifactoryVersion); err == nil && ok {
+		return req.
+			SetPathParam("name", name).
+			SetResult(&result).
+			SetError(&artifactoryError).
+			Get(endpoint)
+	}
+
+	// else use old Artifactory API, which has a slightly differect JSON payload!
+	var artifactoryResult ArtifactoryUserAPIModel
+	res, err := req.
+		SetPathParam("name", name).
+		SetResult(&artifactoryResult).
+		SetError(artifactoryError).
+		Get(endpoint)
+
+	var groups []string
+	if artifactoryResult.Groups != nil {
+		groups = *artifactoryResult.Groups
+	}
+
+	*result = User{
+		Name:                     artifactoryResult.Name,
+		Email:                    artifactoryResult.Email,
+		Admin:                    artifactoryResult.Admin,
+		ProfileUpdatable:         artifactoryResult.ProfileUpdatable,
+		DisableUIAccess:          artifactoryResult.DisableUIAccess,
+		InternalPasswordDisabled: artifactoryResult.InternalPasswordDisabled,
+		Groups:                   groups,
+	}
+
+	return res, err
+}
+
+func updateUser(req *resty.Request, artifactoryVersion string, user User, result *User, artifactoryError *artifactory.ArtifactoryErrorsResponse) (*resty.Response, error) {
+	endpoint := GetUserEndpointPath(artifactoryVersion)
+
+	// 7.49.3 or later, use Access API
+	if ok, err := util.CheckVersion(artifactoryVersion, AccessAPIArtifactoryVersion); err == nil && ok {
+		return req.
+			SetPathParam("name", user.Name).
+			SetBody(user).
+			SetResult(result).
+			SetError(artifactoryError).
+			Patch(endpoint)
+	}
+
+	// else use old Artifactory API, which has a slightly differect JSON payload!
+	artifactoryUser := ArtifactoryUserAPIModel{
+		Name:                     user.Name,
+		Email:                    user.Email,
+		Password:                 user.Password,
+		Admin:                    user.Admin,
+		ProfileUpdatable:         user.ProfileUpdatable,
+		DisableUIAccess:          user.DisableUIAccess,
+		InternalPasswordDisabled: user.InternalPasswordDisabled,
+		Groups:                   &user.Groups,
+	}
+	resp, err := req.
+		SetPathParam("name", artifactoryUser.Name).
+		SetBody(artifactoryUser).
+		SetError(artifactoryError).
+		Post(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	if resp.IsError() {
+		return resp, nil
+	}
+
+	var artifactoryResult ArtifactoryUserAPIModel
+	res, err := req.
+		SetPathParam("name", artifactoryUser.Name).
+		SetResult(&artifactoryResult).
+		SetError(artifactoryError).
+		Get(endpoint)
+
+	var groups []string
+	if artifactoryResult.Groups != nil {
+		groups = *artifactoryResult.Groups
+	}
+
+	*result = User{
+		Name:                     artifactoryResult.Name,
+		Email:                    artifactoryResult.Email,
+		Password:                 user.Password,
+		Admin:                    artifactoryResult.Admin,
+		ProfileUpdatable:         artifactoryResult.ProfileUpdatable,
+		DisableUIAccess:          artifactoryResult.DisableUIAccess,
+		InternalPasswordDisabled: artifactoryResult.InternalPasswordDisabled,
+		Groups:                   groups,
+	}
+
+	return res, err
+}
 
 func resourceUserRead(_ context.Context, rd *schema.ResourceData, m interface{}) diag.Diagnostics {
 	d := &utilsdk.ResourceData{ResourceData: rd}
 
 	var user User
 	var artifactoryError artifactory.ArtifactoryErrorsResponse
-	resp, err := m.(util.ProvderMetadata).Client.R().
-		SetPathParam("name", d.Id()).
-		SetResult(&user).
-		SetError(&artifactoryError).
-		Get(UserEndpointPath)
+	resp, err := readUser(
+		m.(util.ProvderMetadata).Client.R(),
+		m.(util.ProvderMetadata).ArtifactoryVersion,
+		d.Id(),
+		&user,
+		&artifactoryError)
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -156,6 +344,8 @@ func resourceUserRead(_ context.Context, rd *schema.ResourceData, m interface{})
 	if resp.IsError() {
 		return diag.Errorf("%s", artifactoryError.String())
 	}
+
+	d.SetId(user.Name)
 
 	return PackUser(user, rd)
 }
@@ -200,11 +390,12 @@ func resourceBaseUserCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	var result User
 	var artifactoryError artifactory.ArtifactoryErrorsResponse
-	resp, err := m.(util.ProvderMetadata).Client.R().
-		SetBody(user).
-		SetResult(&result).
-		SetError(&artifactoryError).
-		Post(UsersEndpointPath)
+	resp, err := createUser(
+		m.(util.ProvderMetadata).Client.R(),
+		m.(util.ProvderMetadata).ArtifactoryVersion,
+		user,
+		&result,
+		&artifactoryError)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -221,10 +412,12 @@ func resourceBaseUserCreate(ctx context.Context, d *schema.ResourceData, m inter
 
 	retryError := retry.RetryContext(ctx, d.Timeout(schema.TimeoutCreate), func() *retry.RetryError {
 		var result User
-		resp, e := m.(util.ProvderMetadata).Client.R().
-			SetPathParam("name", user.Name).
-			SetResult(&result).
-			Get(UserEndpointPath)
+		resp, e := readUser(
+			m.(util.ProvderMetadata).Client.R(),
+			m.(util.ProvderMetadata).ArtifactoryVersion,
+			d.Id(),
+			&result,
+			&artifactoryError)
 
 		if e != nil {
 			return retry.NonRetryableError(fmt.Errorf("error describing user: %s", err))
@@ -250,12 +443,12 @@ func resourceUserUpdate(ctx context.Context, d *schema.ResourceData, m interface
 
 	var result User
 	var artifactoryError artifactory.ArtifactoryErrorsResponse
-	resp, err := m.(util.ProvderMetadata).Client.R().
-		SetPathParam("name", user.Name).
-		SetBody(&user).
-		SetResult(&result).
-		SetError(&artifactoryError).
-		Patch(UserEndpointPath)
+	resp, err := updateUser(
+		m.(util.ProvderMetadata).Client.R(),
+		m.(util.ProvderMetadata).ArtifactoryVersion,
+		user,
+		&result,
+		&artifactoryError)
 
 	if err != nil {
 		return diag.FromErr(err)
@@ -281,7 +474,7 @@ func resourceUserDelete(_ context.Context, rd *schema.ResourceData, m interface{
 	resp, err := m.(util.ProvderMetadata).Client.R().
 		SetPathParam("name", userName).
 		SetError(&artifactoryError).
-		Delete(UserEndpointPath)
+		Delete(GetUserEndpointPath(m.(util.ProvderMetadata).ArtifactoryVersion))
 	if err != nil {
 		return diag.Errorf("user %s not deleted. %s", userName, err)
 	}


### PR DESCRIPTION
Close #922 

* Restore backward compatibility with Artifactory 7.49.2 and earlier
* Add terraform-registry-manifest.json file to release process
* Tested using Charlies proxy and rewrite the response to request (/artifactory/api/system/version) with Artifactory version 7.49.2.