### PR TITLE
Revert password being stored in state for unmanaged user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 10.6.2 (Apr 17, 2024)
 
+BUG FIXES:
+
+resource/artifactory_unmanaged_user, resource/artifactory_user: Revert storing auto-generated `password` attribute value in Terraform state. Issue: [#931](https://github.com/jfrog/terraform-provider-artifactory/issues/931) PR: [#937](https://github.com/jfrog/terraform-provider-artifactory/pull/937)
+
 IMPROVEMENTS:
 
 * resource/artifactory_property_set is migrated to Plugin Framework. PR: [#935](https://github.com/jfrog/terraform-provider-artifactory/pull/935)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 BUG FIXES:
 
-resource/artifactory_unmanaged_user, resource/artifactory_user: Revert storing auto-generated `password` attribute value in Terraform state. Issue: [#931](https://github.com/jfrog/terraform-provider-artifactory/issues/931) PR: [#937](https://github.com/jfrog/terraform-provider-artifactory/pull/937)
+resource/artifactory_unmanaged_user, resource/artifactory_user: Revert storing auto-generated `password` attribute value in Terraform state. Revert back to Artifactory Security API until Artifactory version 7.83.1 due to Access API bug in updating user without password field. Issue: [#931](https://github.com/jfrog/terraform-provider-artifactory/issues/931) PR: [#937](https://github.com/jfrog/terraform-provider-artifactory/pull/937)
 
 IMPROVEMENTS:
 

--- a/docs/resources/unmanaged_user.md
+++ b/docs/resources/unmanaged_user.md
@@ -7,7 +7,7 @@ Provides an Artifactory unmanaged user resource. This can be used to create and 
 The password is a required field by the [Artifactory API](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateorReplaceUser), but we made it optional in this resource to accommodate the scenario where the password is not needed and will be reset by the actual user later.  
 When the optional attribute `password` is omitted, a random password is generated according to current Artifactory password policy.
 
-~> The generated password won't be stored in the TF state and can not be recovered. The user must reset the password to be able to log in. An admin can always generate the access key for the user as well. The password change won't trigger state drift.
+~> The generated password won't be stored in the TF state and can not be recovered. The user must reset the password to be able to log in. An admin can always generate the access key for the user as well. The password change won't trigger state drift. However, attempts at updating this resource without `password` attribute being set will result in error from Artifactory API.
 
 ~> This resource is an alias for `artifactory_user` [resource](https://registry.terraform.io/providers/jfrog/artifactory/latest/docs/resources/user), it is identical and was added for clarity and compatibility purposes. We don't recommend to use this resource unless there is a specific use case for it. Recommended resource is `artifactory_managed_user`.
 

--- a/docs/resources/unmanaged_user.md
+++ b/docs/resources/unmanaged_user.md
@@ -6,7 +6,7 @@ subcategory: "User"
 Provides an Artifactory unmanaged user resource. This can be used to create and manage Artifactory users.
 The password is a required field by the [Artifactory API](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateorReplaceUser), but we made it optional in this resource to accommodate the scenario where the password is not needed and will be reset by the actual user later. When the optional attribute `password` is omitted, a random password is generated according to current Artifactory password policy.
 
-~> The generated password won't be stored in the TF state and can not be recovered. The user must reset the password to be able to log in. An admin can always generate the access key for the user as well. The password change won't trigger state drift. However, attempts at updating this resource without `password` attribute being set will result in error from Artifactory API.
+~> The generated password won't be stored in the TF state and can not be recovered. The user must reset the password to be able to log in. An admin can always generate the access key for the user as well. The password change won't trigger state drift.
 
 ~> This resource is an alias for `artifactory_user` [resource](https://registry.terraform.io/providers/jfrog/artifactory/latest/docs/resources/user), it is identical and was added for clarity and compatibility purposes. We don't recommend to use this resource unless there is a specific use case for it. Recommended resource is `artifactory_managed_user`.
 

--- a/docs/resources/unmanaged_user.md
+++ b/docs/resources/unmanaged_user.md
@@ -4,8 +4,7 @@ subcategory: "User"
 # Artifactory Unmanaged User Resource
 
 Provides an Artifactory unmanaged user resource. This can be used to create and manage Artifactory users.
-The password is a required field by the [Artifactory API](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateorReplaceUser), but we made it optional in this resource to accommodate the scenario where the password is not needed and will be reset by the actual user later.  
-When the optional attribute `password` is omitted, a random password is generated according to current Artifactory password policy.
+The password is a required field by the [Artifactory API](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateorReplaceUser), but we made it optional in this resource to accommodate the scenario where the password is not needed and will be reset by the actual user later. When the optional attribute `password` is omitted, a random password is generated according to current Artifactory password policy.
 
 ~> The generated password won't be stored in the TF state and can not be recovered. The user must reset the password to be able to log in. An admin can always generate the access key for the user as well. The password change won't trigger state drift. However, attempts at updating this resource without `password` attribute being set will result in error from Artifactory API.
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -6,10 +6,9 @@ subcategory: "User"
 # Artifactory User Resource
 
 Provides an Artifactory user resource. This can be used to create and manage Artifactory users.
-The password is a required field by the [Artifactory API](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateorReplaceUser), but we made it optional in this resource to accommodate the scenario where the password is not needed and will be reset by the actual user later.  
-When the optional attribute `password` is omitted, a random password is generated according to current Artifactory password policy.
+The password is a required field by the [Artifactory API](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateorReplaceUser), but we made it optional in this resource to accommodate the scenario where the password is not needed and will be reset by the actual user later. When the optional attribute `password` is omitted, a random password is generated according to current Artifactory password policy.
 
-~> The generated password won't be stored in the TF state and can not be recovered. The user must reset the password to be able to log in. An admin can always generate the access key for the user as well. The password change won't trigger state drift. We don't recommend to use this resource unless there is a specific use case for it. Recommended resource is `artifactory_managed_user`.
+~> The generated password won't be stored in the TF state and can not be recovered. The user must reset the password to be able to log in. An admin can always generate the access key for the user as well. The password change won't trigger state drift. However, attempts at updating this resource without `password` attribute being set will result in error from Artifactory API. We don't recommend to use this resource unless there is a specific use case for it. Recommended resource is `artifactory_managed_user`.
 
 ## Example Usage
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -8,7 +8,7 @@ subcategory: "User"
 Provides an Artifactory user resource. This can be used to create and manage Artifactory users.
 The password is a required field by the [Artifactory API](https://www.jfrog.com/confluence/display/JFROG/Artifactory+REST+API#ArtifactoryRESTAPI-CreateorReplaceUser), but we made it optional in this resource to accommodate the scenario where the password is not needed and will be reset by the actual user later. When the optional attribute `password` is omitted, a random password is generated according to current Artifactory password policy.
 
-~> The generated password won't be stored in the TF state and can not be recovered. The user must reset the password to be able to log in. An admin can always generate the access key for the user as well. The password change won't trigger state drift. However, attempts at updating this resource without `password` attribute being set will result in error from Artifactory API. We don't recommend to use this resource unless there is a specific use case for it. Recommended resource is `artifactory_managed_user`.
+~> The generated password won't be stored in the TF state and can not be recovered. The user must reset the password to be able to log in. An admin can always generate the access key for the user as well. The password change won't trigger state drift. We don't recommend to use this resource unless there is a specific use case for it. Recommended resource is `artifactory_managed_user`.
 
 ## Example Usage
 

--- a/pkg/artifactory/resource/user/resource_artifactory_anonymous_user.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_anonymous_user.go
@@ -75,7 +75,7 @@ func (r *ArtifactoryAnonymousUserResource) Create(ctx context.Context, req resou
 func (r *ArtifactoryAnonymousUserResource) readUser(req *resty.Request, artifactoryVersion, name string, result *ArtifactoryAnonymousUserResourceAPIModel, artifactoryError *artifactory.ArtifactoryErrorsResponse) (*resty.Response, error) {
 	endpoint := GetUserEndpointPath(artifactoryVersion)
 
-	// 7.49.3 or later, use Access API
+	// 7.83.1 or later, use Access API
 	if ok, err := util.CheckVersion(artifactoryVersion, AccessAPIArtifactoryVersion); err == nil && ok {
 		return req.
 			SetPathParam("name", name).

--- a/pkg/artifactory/resource/user/resource_artifactory_unmanaged_user.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_unmanaged_user.go
@@ -57,6 +57,8 @@ func resourceUserCreate(ctx context.Context, d *schema.ResourceData, m interface
 			}
 
 			user.Password = randomPassword
+
+			// DO NOT store the generated password in the TF state
 		}
 
 		return diags

--- a/pkg/artifactory/resource/user/resource_artifactory_unmanaged_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_unmanaged_user_test.go
@@ -6,9 +6,11 @@ import (
 	"regexp"
 	"testing"
 
+	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v10/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v10/pkg/artifactory/resource/user"
 	"github.com/jfrog/terraform-provider-shared/testutil"
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
@@ -117,11 +119,20 @@ func TestAccUnmanagedUser_basic(t *testing.T) {
 	})
 }
 
-func TestAccUnmanagedUser_ShouldCreateWithoutPassword(t *testing.T) {
+func TestAccUnmanagedUser_ShouldCreateUpdateWithoutPassword(t *testing.T) {
 	const config = `
 		resource "artifactory_unmanaged_user" "%s" {
 			name  	= "%s"
 			email 	= "dummy_user%d@a.com"
+			profile_updatable = true
+		}
+	`
+
+	const updatedConfig = `
+		resource "artifactory_unmanaged_user" "%s" {
+			name  	= "%s"
+			email 	= "dummy_user%d@a.com"
+			profile_updatable = false
 		}
 	`
 
@@ -140,6 +151,17 @@ func TestAccUnmanagedUser_ShouldCreateWithoutPassword(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "name", username),
 					resource.TestCheckResourceAttr(fqrn, "email", fmt.Sprintf("dummy_user%d@a.com", id)),
+					resource.TestCheckResourceAttr(fqrn, "profile_updatable", "true"),
+					resource.TestCheckNoResourceAttr(fqrn, "password"),
+					resource.TestCheckNoResourceAttr(fqrn, "groups"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(updatedConfig, name, username, id),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "name", username),
+					resource.TestCheckResourceAttr(fqrn, "email", fmt.Sprintf("dummy_user%d@a.com", id)),
+					resource.TestCheckResourceAttr(fqrn, "profile_updatable", "false"),
 					resource.TestCheckNoResourceAttr(fqrn, "password"),
 					resource.TestCheckNoResourceAttr(fqrn, "groups"),
 				),
@@ -358,7 +380,18 @@ func testAccCheckUserDestroy(id string) func(*terraform.State) error {
 			return fmt.Errorf("resource id[%s] not found", id)
 		}
 
-		resp, err := client.R().Get("access/api/v2/users/" + rs.Primary.ID)
+		var resp *resty.Response
+		var err error
+		// 7.83.1 or later, use Access API
+		if ok, e := util.CheckVersion(acctest.Provider.Meta().(util.ProviderMetadata).ArtifactoryVersion, user.AccessAPIArtifactoryVersion); e == nil && ok {
+			r, er := client.R().Get("access/api/v2/users/" + rs.Primary.ID)
+			resp = r
+			err = er
+		} else {
+			r, er := client.R().Get("artifactory/api/security/users/" + rs.Primary.ID)
+			resp = r
+			err = er
+		}
 
 		if err != nil {
 			return err

--- a/pkg/artifactory/resource/user/resource_artifactory_unmanaged_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_unmanaged_user_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/jfrog/terraform-provider-shared/validator"
 )
 
-func TestAccUnmanagedUserPasswordNotChangeWhenOtherAttributesChangeGH340(t *testing.T) {
+func TestAccUnmanagedUser_PasswordNotChangeWhenOtherAttributesChangeGH340(t *testing.T) {
 	id := testutil.RandomInt()
 	name := fmt.Sprintf("user-%d", id)
 	fqrn := fmt.Sprintf("artifactory_unmanaged_user.%s", name)
@@ -117,24 +117,19 @@ func TestAccUnmanagedUser_basic(t *testing.T) {
 	})
 }
 
-func TestAccUnmanagedUserShouldCreateWithoutPassword(t *testing.T) {
+func TestAccUnmanagedUser_ShouldCreateWithoutPassword(t *testing.T) {
 	const config = `
 		resource "artifactory_unmanaged_user" "%s" {
 			name  	= "%s"
 			email 	= "dummy_user%d@a.com"
 		}
 	`
-	const updatedConfig = `
-		resource "artifactory_unmanaged_user" "%s" {
-			name  	= "%s"
-			email 	= "dummy_user%d@a.com"
-			profile_updatable = false
-		}
-	`
+
 	id := testutil.RandomInt()
 	name := fmt.Sprintf("foobar-%d", id)
 	fqrn := fmt.Sprintf("artifactory_unmanaged_user.%s", name)
 	username := fmt.Sprintf("dummy_user%d", id)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,
@@ -145,13 +140,8 @@ func TestAccUnmanagedUserShouldCreateWithoutPassword(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "name", username),
 					resource.TestCheckResourceAttr(fqrn, "email", fmt.Sprintf("dummy_user%d@a.com", id)),
+					resource.TestCheckNoResourceAttr(fqrn, "password"),
 					resource.TestCheckNoResourceAttr(fqrn, "groups"),
-				),
-			},
-			{
-				Config: fmt.Sprintf(updatedConfig, name, username, id),
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(fqrn, "profile_updatable", "false"),
 				),
 			},
 			{

--- a/pkg/artifactory/resource/user/resource_artifactory_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_user_test.go
@@ -170,6 +170,19 @@ func TestAccUser_no_password(t *testing.T) {
 		}
 	`, params)
 
+	// TODO: bug that require 'password' field even when 'internalPasswordDisabled' is set to false is already fixed
+	// in 7.83.1 in Cloud version. When it's released to Self-Hosted, then we can uncomment this update test
+	//
+	// updatedConfig := util.ExecuteTemplate("TestAccUserBasic", `
+	// 	resource "artifactory_user" "{{ .name }}" {
+	// 		name   = "{{ .name }}"
+	// 		email  = "{{ .email }}"
+	// 		admin  = false
+	// 		profile_updatable = false
+	// 		groups = [ "readers" ]
+	// 	}
+	// `, params)
+
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -182,6 +195,14 @@ func TestAccUser_no_password(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "groups.#", "1"),
 				),
 			},
+			// {
+			// 	Config: updatedConfig,
+			// 	Check: resource.ComposeTestCheckFunc(
+			// 		resource.TestCheckResourceAttr(fqrn, "name", fmt.Sprintf("foobar-%d", id)),
+			// 		resource.TestCheckResourceAttr(fqrn, "profile_updatable", "false"),
+			// 		resource.TestCheckResourceAttr(fqrn, "groups.#", "1"),
+			// 	),
+			// },
 			{
 				ResourceName:            fqrn,
 				ImportState:             true,

--- a/pkg/artifactory/resource/user/resource_artifactory_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_user_test.go
@@ -170,16 +170,6 @@ func TestAccUser_no_password(t *testing.T) {
 		}
 	`, params)
 
-	updatedConfig := util.ExecuteTemplate("TestAccUserBasic", `
-		resource "artifactory_user" "{{ .name }}" {
-			name   = "{{ .name }}"
-			email  = "{{ .email }}"
-			admin  = false
-			profile_updatable = false
-			groups = [ "readers" ]
-		}
-	`, params)
-
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 		PreCheck:                 func() { acctest.PreCheck(t) },
@@ -189,14 +179,6 @@ func TestAccUser_no_password(t *testing.T) {
 				Config: config,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "name", fmt.Sprintf("foobar-%d", id)),
-					resource.TestCheckResourceAttr(fqrn, "groups.#", "1"),
-				),
-			},
-			{
-				Config: updatedConfig,
-				Check: resource.ComposeTestCheckFunc(
-					resource.TestCheckResourceAttr(fqrn, "name", fmt.Sprintf("foobar-%d", id)),
-					resource.TestCheckResourceAttr(fqrn, "profile_updatable", "false"),
 					resource.TestCheckResourceAttr(fqrn, "groups.#", "1"),
 				),
 			},

--- a/pkg/artifactory/resource/user/resource_artifactory_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_user_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
 	"github.com/jfrog/terraform-provider-artifactory/v10/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v10/pkg/artifactory/resource/user"
 	"github.com/jfrog/terraform-provider-shared/testutil"
 	"github.com/jfrog/terraform-provider-shared/util"
 	"github.com/jfrog/terraform-provider-shared/validator"
@@ -173,15 +174,15 @@ func TestAccUser_no_password(t *testing.T) {
 	// TODO: bug that require 'password' field even when 'internalPasswordDisabled' is set to false is already fixed
 	// in 7.83.1 in Cloud version. When it's released to Self-Hosted, then we can uncomment this update test
 	//
-	// updatedConfig := util.ExecuteTemplate("TestAccUserBasic", `
-	// 	resource "artifactory_user" "{{ .name }}" {
-	// 		name   = "{{ .name }}"
-	// 		email  = "{{ .email }}"
-	// 		admin  = false
-	// 		profile_updatable = false
-	// 		groups = [ "readers" ]
-	// 	}
-	// `, params)
+	updatedConfig := util.ExecuteTemplate("TestAccUserBasic", `
+		resource "artifactory_user" "{{ .name }}" {
+			name   = "{{ .name }}"
+			email  = "{{ .email }}"
+			admin  = false
+			profile_updatable = false
+			groups = [ "readers" ]
+		}
+	`, params)
 
 	resource.Test(t, resource.TestCase{
 		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
@@ -195,14 +196,14 @@ func TestAccUser_no_password(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "groups.#", "1"),
 				),
 			},
-			// {
-			// 	Config: updatedConfig,
-			// 	Check: resource.ComposeTestCheckFunc(
-			// 		resource.TestCheckResourceAttr(fqrn, "name", fmt.Sprintf("foobar-%d", id)),
-			// 		resource.TestCheckResourceAttr(fqrn, "profile_updatable", "false"),
-			// 		resource.TestCheckResourceAttr(fqrn, "groups.#", "1"),
-			// 	),
-			// },
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "name", fmt.Sprintf("foobar-%d", id)),
+					resource.TestCheckResourceAttr(fqrn, "profile_updatable", "false"),
+					resource.TestCheckResourceAttr(fqrn, "groups.#", "1"),
+				),
+			},
 			{
 				ResourceName:            fqrn,
 				ImportState:             true,
@@ -484,8 +485,8 @@ func testAccCheckManagedUserDestroy(id string) func(*terraform.State) error {
 
 		var resp *resty.Response
 		var err error
-		// 7.49.3 or later, use Access API
-		if ok, e := util.CheckVersion(acctest.Provider.Meta().(util.ProviderMetadata).ArtifactoryVersion, "7.49.3"); e == nil && ok {
+		// 7.83.1 or later, use Access API
+		if ok, e := util.CheckVersion(acctest.Provider.Meta().(util.ProviderMetadata).ArtifactoryVersion, user.AccessAPIArtifactoryVersion); e == nil && ok {
 			r, er := client.R().Get("access/api/v2/users/" + rs.Primary.ID)
 			resp = r
 			err = er

--- a/pkg/artifactory/resource/user/user.go
+++ b/pkg/artifactory/resource/user/user.go
@@ -390,9 +390,8 @@ func resourceBaseUserCreate(ctx context.Context, d *schema.ResourceData, m inter
 			return diags
 		}
 
-		// explicity set this attribute with password so it gets stored in the state
-		// and allows update to work
-		d.Set("password", user.Password)
+		// generated password should not be saved to state for unmanaged user
+		// as the password is temporary and will be updated out of band
 	}
 
 	var result User

--- a/pkg/artifactory/resource/user/user.go
+++ b/pkg/artifactory/resource/user/user.go
@@ -19,7 +19,7 @@ import (
 	"github.com/samber/lo"
 )
 
-const AccessAPIArtifactoryVersion = "7.49.3"
+const AccessAPIArtifactoryVersion = "7.83.1"
 
 type User struct {
 	Name                     string   `json:"username"`
@@ -225,7 +225,7 @@ func createUser(req *resty.Request, artifactoryVersion string, user User, result
 func ReadUser(req *resty.Request, artifactoryVersion, name string, result *User, artifactoryError *artifactory.ArtifactoryErrorsResponse) (*resty.Response, error) {
 	endpoint := GetUserEndpointPath(artifactoryVersion)
 
-	// 7.49.3 or later, use Access API
+	// 7.83.1 or later, use Access API
 	if ok, err := util.CheckVersion(artifactoryVersion, AccessAPIArtifactoryVersion); err == nil && ok {
 		return req.
 			SetPathParam("name", name).
@@ -263,7 +263,7 @@ func ReadUser(req *resty.Request, artifactoryVersion, name string, result *User,
 func updateUser(req *resty.Request, artifactoryVersion string, user User, result *User, artifactoryError *artifactory.ArtifactoryErrorsResponse) (*resty.Response, error) {
 	endpoint := GetUserEndpointPath(artifactoryVersion)
 
-	// 7.49.3 or later, use Access API
+	// 7.83.1 or later, use Access API
 	if ok, err := util.CheckVersion(artifactoryVersion, AccessAPIArtifactoryVersion); err == nil && ok {
 		return req.
 			SetPathParam("name", user.Name).

--- a/pkg/artifactory/resource/user/user_fw.go
+++ b/pkg/artifactory/resource/user/user_fw.go
@@ -209,16 +209,7 @@ func (r *ArtifactoryBaseUserResource) createUser(_ context.Context, req *resty.R
 	}
 
 	// else use old Artifactory API, which has a slightly differect JSON payload!
-	artifactoryUser := ArtifactoryUserAPIModel{
-		Name:                     user.Name,
-		Email:                    user.Email,
-		Password:                 user.Password,
-		Admin:                    user.Admin,
-		ProfileUpdatable:         user.ProfileUpdatable,
-		DisableUIAccess:          user.DisableUIAccess,
-		InternalPasswordDisabled: user.InternalPasswordDisabled,
-		Groups:                   user.Groups,
-	}
+	artifactoryUser := ArtifactoryUserAPIModel(user)
 	endpoint := GetUserEndpointPath(artifactoryVersion)
 	resp, err := req.
 		SetPathParam("name", artifactoryUser.Name).
@@ -300,16 +291,7 @@ func (r *ArtifactoryBaseUserResource) updateUser(req *resty.Request, artifactory
 	}
 
 	// else use old Artifactory API, which has a slightly differect JSON payload!
-	artifactoryUser := ArtifactoryUserAPIModel{
-		Name:                     user.Name,
-		Email:                    user.Email,
-		Password:                 user.Password,
-		Admin:                    user.Admin,
-		ProfileUpdatable:         user.ProfileUpdatable,
-		DisableUIAccess:          user.DisableUIAccess,
-		InternalPasswordDisabled: user.InternalPasswordDisabled,
-		Groups:                   user.Groups,
-	}
+	artifactoryUser := ArtifactoryUserAPIModel(user)
 	resp, err := req.
 		SetPathParam("name", artifactoryUser.Name).
 		SetBody(artifactoryUser).

--- a/pkg/artifactory/resource/user/user_fw.go
+++ b/pkg/artifactory/resource/user/user_fw.go
@@ -388,9 +388,7 @@ func (r *ArtifactoryBaseUserResource) Create(ctx context.Context, req resource.C
 
 		user.Password = randomPassword
 
-		// explicity set this attribute with password so it gets stored in the state
-		// and allows update to work
-		plan.Password = types.StringValue(randomPassword)
+		// DO NOT store the generated password in the TF state
 	}
 
 	var result ArtifactoryUserResourceAPIModel
@@ -575,6 +573,11 @@ func (u ArtifactoryUserResourceAPIModel) ToState(ctx context.Context, r *Artifac
 	r.Id = types.StringValue(u.Name)
 	r.Name = types.StringValue(u.Name)
 	r.Email = types.StringValue(u.Email)
+
+	if r.Password.IsUnknown() {
+		r.Password = types.StringNull()
+	}
+
 	r.Admin = types.BoolValue(u.Admin)
 	r.ProfileUpdatable = types.BoolValue(u.ProfileUpdatable)
 	r.DisableUIAccess = types.BoolValue(u.DisableUIAccess)

--- a/pkg/artifactory/resource/user/user_fw.go
+++ b/pkg/artifactory/resource/user/user_fw.go
@@ -199,7 +199,7 @@ func (r *ArtifactoryBaseUserResource) syncReadersGroup(ctx context.Context, clie
 }
 
 func (r *ArtifactoryBaseUserResource) createUser(_ context.Context, req *resty.Request, artifactoryVersion string, user ArtifactoryUserResourceAPIModel, result *ArtifactoryUserResourceAPIModel, artifactoryError *artifactory.ArtifactoryErrorsResponse) (*resty.Response, error) {
-	// 7.49.3 or later, use Access API
+	// 7.83.1 or later, use Access API
 	if ok, err := util.CheckVersion(artifactoryVersion, AccessAPIArtifactoryVersion); err == nil && ok {
 		return req.
 			SetBody(user).
@@ -247,7 +247,7 @@ func (r *ArtifactoryBaseUserResource) createUser(_ context.Context, req *resty.R
 func (r *ArtifactoryBaseUserResource) readUser(req *resty.Request, artifactoryVersion, name string, result *ArtifactoryUserResourceAPIModel, artifactoryError *artifactory.ArtifactoryErrorsResponse) (*resty.Response, error) {
 	endpoint := GetUserEndpointPath(artifactoryVersion)
 
-	// 7.49.3 or later, use Access API
+	// 7.83.1 or later, use Access API
 	if ok, err := util.CheckVersion(artifactoryVersion, AccessAPIArtifactoryVersion); err == nil && ok {
 		return req.
 			SetPathParam("name", name).
@@ -280,7 +280,7 @@ func (r *ArtifactoryBaseUserResource) readUser(req *resty.Request, artifactoryVe
 func (r *ArtifactoryBaseUserResource) updateUser(req *resty.Request, artifactoryVersion string, user ArtifactoryUserResourceAPIModel, result *ArtifactoryUserResourceAPIModel, artifactoryError *artifactory.ArtifactoryErrorsResponse) (*resty.Response, error) {
 	endpoint := GetUserEndpointPath(artifactoryVersion)
 
-	// 7.49.3 or later, use Access API
+	// 7.83.1 or later, use Access API
 	if ok, err := util.CheckVersion(artifactoryVersion, AccessAPIArtifactoryVersion); err == nil && ok {
 		return req.
 			SetPathParam("name", user.Name).


### PR DESCRIPTION
Fix #931 

* Update Access API check to 7.83.1 so user resources go back to using Artifactory Security API due to bug in Access API for updating user requiring 'password' field.