### PR TITLE
Fix plan change func in acceptance tests

### DIFF
--- a/pkg/artifactory/resource/configuration/resource_artifactory_general_security_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_general_security_test.go
@@ -44,13 +44,13 @@ func TestAccGeneralSecurity_UpgradeFromSDKv2(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "enable_anonymous_access", "true"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Config:                   generalSecurityTemplateFull,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_v2_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_v2_test.go
@@ -69,7 +69,7 @@ func TestAccLdapGroupSettingV2_full(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "description_attribute", "description"),
 					resource.TestCheckResourceAttr(fqrn, "strategy", "STATIC"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				Config: LdapSettingTemplateFullUpdate,
@@ -85,7 +85,7 @@ func TestAccLdapGroupSettingV2_full(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "description_attribute", "description"),
 					resource.TestCheckResourceAttr(fqrn, "strategy", "DYNAMIC"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ResourceName:      fqrn,

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting_v2_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting_v2_test.go
@@ -48,7 +48,7 @@ func TestAccLdapSettingV2_full_no_search(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "user_dn_pattern", params["user_dn_pattern"].(string)),
 					resource.TestCheckResourceAttr(fqrn, "email_attribute", "mail_attr"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ResourceName:            fqrn,
@@ -102,7 +102,7 @@ func TestAccLdapSettingV2_full_with_search(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "search_filter", "(uid={0})"),
 					resource.TestCheckResourceAttr(fqrn, "search_base", params["search_base"].(string)),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ResourceName:            fqrn,

--- a/pkg/artifactory/resource/configuration/resource_artifactory_property_set_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_property_set_test.go
@@ -43,13 +43,13 @@ func TestAccPropertySet_UpgradeFromSDKv2(t *testing.T) {
 				},
 				Config:           config,
 				Check:            resource.ComposeTestCheckFunc(verifyPropertySet(fqrn, testData)),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Config:                   config,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/configuration/resource_artifactory_proxy_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_proxy_test.go
@@ -87,13 +87,13 @@ func TestAccProxy_UpgradeFromSDKv2(t *testing.T) {
 					resource.TestCheckNoResourceAttr(fqrn, "redirect_to_hosts"),
 					resource.TestCheckNoResourceAttr(fqrn, "services"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Config:                   config,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout_test.go
@@ -53,13 +53,13 @@ func TestAccRepositoryLayout_UpgradeFromSDKv2(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "folder_integration_revision_regexp", "SNAPSHOT"),
 					resource.TestCheckResourceAttr(fqrn, "file_integration_revision_regexp", "SNAPSHOT|(?:(?:[0-9]{8}.[0-9]{6})-(?:[0-9]+))"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Config:                   config,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/configuration/resource_artifactory_saml_settings.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_saml_settings.go
@@ -176,7 +176,8 @@ func resourceSamlSettingsUpdate(ctx context.Context, d *schema.ResourceData, m i
 func resourceSamlSettingsDelete(_ context.Context, _ *schema.ResourceData, m interface{}) diag.Diagnostics {
 	var content = `
 security:
-  samlSettings: ~
+  samlSettings: 
+    enableIntegration: false
 `
 
 	err := SendConfigurationPatch([]byte(content), m)

--- a/pkg/artifactory/resource/configuration/resource_artifactory_saml_settings_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_saml_settings_test.go
@@ -85,16 +85,7 @@ func testAccSamlSettingsDestroy(id string) func(*terraform.State) error {
 			return fmt.Errorf("error: failed to retrieve data from <base_url>/artifactory/api/saml/config during Read")
 		}
 
-		if samlSettings.AllowUserToAccessProfile != false {
-			return fmt.Errorf("error: SAML SSO setting, allow user to access profile, is still enabled")
-		}
-		if samlSettings.SyncGroups != false {
-			return fmt.Errorf("error: SAML SSO setting, sync groups, is still enabled")
-		}
-		if samlSettings.NoAutoUserCreation != false {
-			return fmt.Errorf("error: SAML SSO setting, no auto user creation, is still enabled")
-		}
-		if samlSettings.EnableIntegration != false {
+		if samlSettings.EnableIntegration {
 			return fmt.Errorf("error: SAML SSO integration is still enabled")
 		}
 

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
@@ -59,7 +59,7 @@ func TestAccRemoteUpgradeFromVersionWithNoDisableProxyAttr(t *testing.T) {
 				ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
 				Config:                   config,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/security/resource_artifactory_certificate_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_certificate_test.go
@@ -77,13 +77,13 @@ func TestAccCertificate_UpgradeFromSDKv2(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "issued_to", "Unknown"),
 					resource.TestCheckResourceAttr(fqrn, "valid_until", "2029-05-14T10:03:26.000Z"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
 				Config:                   config,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/security/resource_artifactory_distribution_public_key_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_distribution_public_key_test.go
@@ -75,13 +75,13 @@ func TestAccDistributionPublicKey_UpgradeFromSDKv2(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "fingerprint", "10:16:2c:c5:1c:db:d0:59:ad:86:d3:66:dc:d1:d9:02:65:03:a8:25"),
 					resource.TestCheckResourceAttr(fqrn, "issued_by", "alan <alann@jfrog.com>"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Config:                   keyBasic,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/security/resource_artifactory_group_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_group_test.go
@@ -49,13 +49,13 @@ func TestAccGroup_UpgradeFromSDKv2(t *testing.T) {
 					resource.TestCheckNoResourceAttr(fqrn, "users_names"),
 					resource.TestCheckResourceAttr(fqrn, "watch_manager", "false"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Config:                   config,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
@@ -93,13 +93,13 @@ EOF
 					resource.TestCheckResourceAttr(fqrn, "passphrase", "password"),
 					resource.TestCheckResourceAttr(fqrn, "unavailable", "false"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
 				Config:                   keyPairConfig,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/security/resource_artifactory_permission_target_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_permission_target_test.go
@@ -221,13 +221,13 @@ func TestAccPermissionTarget_MigrateFromFrameworkBackToSDKv2(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "build.#", "1"),
 					resource.TestCheckResourceAttr(fqrn, "release_bundle.#", "1"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
 				Config:                   config,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
@@ -78,13 +78,13 @@ func TestAccScopedToken_UpgradeGH_792(t *testing.T) {
 					resource.TestCheckResourceAttrSet(fqrn, "issued_at"),
 					resource.TestCheckResourceAttrSet(fqrn, "issuer"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
 				Config:                   config,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})
@@ -136,13 +136,13 @@ func TestAccScopedToken_UpgradeGH_818(t *testing.T) {
 					resource.TestCheckResourceAttrSet(fqrn, "issued_at"),
 					resource.TestCheckResourceAttrSet(fqrn, "issuer"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
 				Config:                   config,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})
@@ -196,13 +196,13 @@ func scopedTokenUpgradeTestCase(version string, t *testing.T) (*testing.T, resou
 					resource.TestCheckResourceAttrSet(fqrn, "issued_at"),
 					resource.TestCheckResourceAttrSet(fqrn, "issuer"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Config:                   config,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	}

--- a/pkg/artifactory/resource/user/resource_artifactory_managed_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_managed_user_test.go
@@ -48,13 +48,13 @@ func TestAccManagedUser_UpgradeFromSDKv2(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "internal_password_disabled", "false"),
 					resource.TestCheckNoResourceAttr(fqrn, "groups"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Config:                   userNoGroups,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/user/resource_artifactory_unmanaged_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_unmanaged_user_test.go
@@ -53,13 +53,13 @@ func TestAccUnmanagedUser_UpgradeFromSDKv2(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "internal_password_disabled", "false"),
 					resource.TestCheckNoResourceAttr(fqrn, "groups"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Config:                   config,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/user/resource_artifactory_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_user_test.go
@@ -52,13 +52,13 @@ func TestAccUser_UpgradeFromSDKv2(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "internal_password_disabled", "false"),
 					resource.TestCheckNoResourceAttr(fqrn, "groups"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Config:                   userNoGroups,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})
@@ -99,13 +99,13 @@ func TestAccUser_UpgradeFrom10_7_0(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "internal_password_disabled", "false"),
 					resource.TestCheckNoResourceAttr(fqrn, "groups"),
 				),
-				ConfigPlanChecks: testutil.ConfigPlanChecks,
+				ConfigPlanChecks: testutil.ConfigPlanChecks(""),
 			},
 			{
 				ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
 				Config:                   userNoGroups,
 				PlanOnly:                 true,
-				ConfigPlanChecks:         testutil.ConfigPlanChecks,
+				ConfigPlanChecks:         testutil.ConfigPlanChecks(""),
 			},
 		},
 	})


### PR DESCRIPTION
Also change how SAML settings is deleted. No longer allowed to delete the entire YAML object so now we disable the settings instead.