### PR TITLE
Fix various webhook resource crashes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 10.8.1 (May 24, 2024)
+
+BUG FIXES:
+
+* resource/artifactory_\*\_webhook, resource/artifactory_\*\_custom_webhook: Fix various crashes when importing the resource with optional attributes not set in the configuration. PR: [#973](https://github.com/jfrog/terraform-provider-artifactory/pull/973)
+
 ## 10.8.0 (May 20, 2024)
 
 IMPROVEMENTS:

--- a/docs/index.md
+++ b/docs/index.md
@@ -128,7 +128,7 @@ terraform {
   }
 }
 
-provider "platform" {
+provider "artifactory" {
   url = "https://myinstance.jfrog.io"
   oidc_provider_name = "terraform-cloud"
 }

--- a/pkg/artifactory/resource/webhook/resource_artifactory_custom_webhook.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_custom_webhook.go
@@ -174,11 +174,24 @@ func ResourceArtifactoryCustomWebhook(webhookType string) *schema.Resource {
 						webhookHandler := CustomHandler{
 							HandlerType: "custom-webhook",
 							Url:         h["url"].(string),
-							Secrets:     unpackKeyValuePair(h["secrets"].(map[string]interface{})),
-							Proxy:       h["proxy"].(string),
-							HttpHeaders: unpackKeyValuePair(h["http_headers"].(map[string]interface{})),
-							Payload:     h["payload"].(string),
 						}
+
+						if v, ok := h["secrets"]; ok {
+							webhookHandler.Secrets = unpackKeyValuePair(v.(map[string]interface{}))
+						}
+
+						if v, ok := h["proxy"]; ok {
+							webhookHandler.Proxy = v.(string)
+						}
+
+						if v, ok := h["http_headers"]; ok {
+							webhookHandler.HttpHeaders = unpackKeyValuePair(v.(map[string]interface{}))
+						}
+
+						if v, ok := h["payload"]; ok {
+							webhookHandler.Payload = v.(string)
+						}
+
 						webhookHandlers = append(webhookHandlers, webhookHandler)
 					}
 				}
@@ -208,12 +221,19 @@ func ResourceArtifactoryCustomWebhook(webhookType string) *schema.Resource {
 		packedHandlers := make([]interface{}, len(handlers))
 		for _, handler := range handlers {
 			packedHandler := map[string]interface{}{
-				"url":          handler.Url,
-				"secrets":      packSecretsCustom(handler.Secrets, d, handler.Url),
-				"proxy":        handler.Proxy,
-				"http_headers": packKeyValuePair(handler.HttpHeaders),
-				"payload":      handler.Payload,
+				"url":     handler.Url,
+				"proxy":   handler.Proxy,
+				"payload": handler.Payload,
 			}
+
+			if handler.Secrets != nil {
+				packedHandler["secrets"] = packSecretsCustom(handler.Secrets, d, handler.Url)
+			}
+
+			if handler.HttpHeaders != nil {
+				packedHandler["http_headers"] = packKeyValuePair(handler.HttpHeaders)
+			}
+
 			packedHandlers = append(packedHandlers, packedHandler)
 		}
 

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook_repo.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook_repo.go
@@ -54,12 +54,18 @@ var repoWebhookSchema = func(webhookType string, version int, isCustom bool) map
 }
 
 var packRepoCriteria = func(artifactoryCriteria map[string]interface{}) map[string]interface{} {
-	return map[string]interface{}{
+	criteria := map[string]interface{}{
 		"any_local":     artifactoryCriteria["anyLocal"].(bool),
 		"any_remote":    artifactoryCriteria["anyRemote"].(bool),
-		"any_federated": artifactoryCriteria["anyFederated"].(bool),
+		"any_federated": false,
 		"repo_keys":     schema.NewSet(schema.HashString, artifactoryCriteria["repoKeys"].([]interface{})),
 	}
+
+	if v, ok := artifactoryCriteria["anyFederated"]; ok {
+		criteria["any_federated"] = v.(bool)
+	}
+
+	return criteria
 }
 
 var unpackRepoCriteria = func(terraformCriteria map[string]interface{}, baseCriteria BaseWebhookCriteria) interface{} {


### PR DESCRIPTION
Happens when importing the resource with optional attributes not set in the configuration.