### PR TITLE
Skip tests when running with tofu

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -139,11 +139,12 @@ jobs:
           cat sample.tf | sed -e "s/version =.*/version = \"${PROVIDER_VERSION}\"/g" > sample.tf.tmp
           cp sample.tf.tmp sample.tf && rm sample.tf.tmp
           TERRAFORM_CLI=${{ matrix.cli }} make install
-      - name: Dump Artifactory logs
-        uses: jwalton/gh-docker-logs@v2
-        if: failure()
-        with:
-          tail: '10000'
+      # uncomment to debug Artifactory docker container failure
+      # - name: Dump Artifactory logs
+      #   uses: jwalton/gh-docker-logs@v2
+      #   if: failure()
+      #   with:
+      #     tail: '10000'
       - name: Clean up Docker container
         if: always()
         run: docker stop artifactory
@@ -171,7 +172,7 @@ jobs:
   update-changelog:
     runs-on: ubuntu-latest
     needs: acceptance-tests-matrix
-    if: ${{ github.event_name == 'pull_request' && needs.acceptance-tests-matrix.result == 'success' }}
+    if: ${{ github.event_name == 'pull_request' }} && ${{ needs.acceptance-tests-matrix.result == 'success' }}
     permissions:
       contents: write
     steps:

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -20,7 +20,7 @@ jobs:
       matrix:
         cli: [terraform, tofu]
     outputs:
-      tf_version: ${{ steps.debug_tf_version.outputs.version }}
+      tf_version: ${{ steps.install_terraform_cli.outputs.version }}
       tofu_version: ${{ steps.install_opentofu_cli.outputs.version }}
       artifactory_version: ${{ steps.run_artifactory_container.outputs.version }}
     steps:

--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -13,7 +13,7 @@ jobs:
   acceptance-tests-matrix:
     name: ${{ matrix.cli }}
     runs-on: ubuntu-latest
-    continue-on-error: true
+    continue-on-error: false
     environment: development
     strategy:
       fail-fast: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 11.0.0 (June 6, 2024)
+## 11.0.0 (June 6, 2024). Tested on Artifactory 7.84.14 with Terraform  and OpenTofu 1.7.2
 
 BREAKING CHANGES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 11.0.0 (June 6, 2024). Tested on Artifactory 7.84.14 with Terraform  and OpenTofu 1.7.2
+## 11.0.0 (June 6, 2024). Tested on Artifactory 7.84.14 with Terraform 1.8.5 and OpenTofu 1.7.2
 
 BREAKING CHANGES:
 

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,7 +22,7 @@ ifeq ($(TERRAFORM_CLI), tofu)
 REGISTRY_HOST=registry.opentofu.org
 endif
 
-BUILD_PATH=terraform.d/plugins/${REGISTRY_HOST}/jfrog/${PRODUCT}/${NEXT_VERSION}/${TARGET_ARCH}
+BUILD_PATH=terraform.d/plugins/${REGISTRY_HOST}/jfrog/${PRODUCT}/${NEXT_PROVIDER_VERSION}/${TARGET_ARCH}
 
 SONAR_SCANNER_VERSION?=4.7.0.2747
 SONAR_SCANNER_HOME?=$HOME/.sonar/sonar-scanner-$SONAR_SCANNER_VERSION-macosx

--- a/pkg/artifactory/resource/configuration/resource_artifactory_proxy_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_proxy_test.go
@@ -48,6 +48,11 @@ func TestAccProxy_UpgradeFromSDKv2(t *testing.T) {
 		t.Skipf("env var JFROG_URL '%s' is a cloud instance.", jfrogURL)
 	}
 
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	_, fqrn, resourceName := testutil.MkNames("test-proxy-", "artifactory_proxy")
 
 	temp := `

--- a/pkg/artifactory/resource/configuration/resource_artifactory_saml_settings_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_saml_settings_test.go
@@ -78,8 +78,8 @@ func testAccSamlSettingsDestroy(id string) func(*terraform.State) error {
 		if !ok {
 			return fmt.Errorf("error: resource id [%s] not found", id)
 		}
-		samlSettings := configuration.SamlSettings{}
 
+		var samlSettings configuration.SamlSettings
 		_, err := c.R().SetResult(&samlSettings).Get("artifactory/api/saml/config")
 		if err != nil {
 			return fmt.Errorf("error: failed to retrieve data from <base_url>/artifactory/api/saml/config during Read")

--- a/pkg/artifactory/resource/configuration/resource_artifactory_saml_settings_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_saml_settings_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/hashicorp/terraform-plugin-testing/terraform"
@@ -41,7 +42,6 @@ func TestAccSamlSettings_full(t *testing.T) {
 		PreCheck:          func() { acctest.PreCheck(t) },
 		ProviderFactories: acctest.ProviderFactories,
 		CheckDestroy:      testAccSamlSettingsDestroy("artifactory_saml_settings.saml"),
-
 		Steps: []resource.TestStep{
 			{
 				Config: SamlSettingsTemplateFull,
@@ -79,6 +79,8 @@ func testAccSamlSettingsDestroy(id string) func(*terraform.State) error {
 			return fmt.Errorf("error: resource id [%s] not found", id)
 		}
 
+		// wait 5 sec for Artifactory to catch up before checking?
+		time.Sleep(5 * time.Second)
 		var samlSettings configuration.SamlSettings
 		_, err := c.R().SetResult(&samlSettings).Get("artifactory/api/saml/config")
 		if err != nil {

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_repository_test.go
@@ -23,6 +23,11 @@ import (
 )
 
 func TestAccRemoteUpgradeFromVersionWithNoDisableProxyAttr(t *testing.T) {
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	_, fqrn, name := testutil.MkNames("tf-go-remote-", "artifactory_remote_go_repository")
 
 	params := map[string]string{

--- a/pkg/artifactory/resource/security/resource_artifactory_certificate_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_certificate_test.go
@@ -2,6 +2,7 @@ package security_test
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -15,6 +16,11 @@ import (
 )
 
 func TestAccCertificate_UpgradeFromSDKv2(t *testing.T) {
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	const certificateFull = `
 		resource "artifactory_certificate" "%s" {
 			alias   = "%s"

--- a/pkg/artifactory/resource/security/resource_artifactory_distribution_public_key_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_distribution_public_key_test.go
@@ -2,6 +2,7 @@ package security_test
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -55,6 +56,11 @@ EOF
 }`
 
 func TestAccDistributionPublicKey_UpgradeFromSDKv2(t *testing.T) {
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	_, fqrn, name := testutil.MkNames("mykey", resource_name)
 
 	keyBasic := fmt.Sprintf(template, resource_name, name, name)

--- a/pkg/artifactory/resource/security/resource_artifactory_group_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_group_test.go
@@ -3,6 +3,7 @@ package security_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 	"strings"
 	"testing"
@@ -17,6 +18,11 @@ import (
 )
 
 func TestAccGroup_UpgradeFromSDKv2(t *testing.T) {
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	_, fqrn, groupName := testutil.MkNames("test-group-upgrade-", "artifactory_group")
 	temp := `
 		resource "artifactory_group" "{{ .groupName }}" {

--- a/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_keypair_test.go
@@ -3,6 +3,7 @@ package security_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 	"testing"
 
@@ -15,6 +16,11 @@ import (
 )
 
 func TestAccKeyPair_UpgradeFromSDKv2(t *testing.T) {
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	id, fqrn, name := testutil.MkNames("test", "artifactory_keypair")
 	template := `
 	resource "artifactory_keypair" "{{ .name }}" {

--- a/pkg/artifactory/resource/security/resource_artifactory_permission_target_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_permission_target_test.go
@@ -3,6 +3,7 @@ package security_test
 import (
 	"fmt"
 	"math/rand"
+	"os"
 	"regexp"
 	"testing"
 
@@ -195,6 +196,11 @@ func TestAccPermissionTarget_noActions(t *testing.T) {
 }
 
 func TestAccPermissionTarget_MigrateFromFrameworkBackToSDKv2(t *testing.T) {
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	_, fqrn, name := testutil.MkNames("test-perm", "artifactory_permission_target")
 	repoName := fmt.Sprintf("test-local-docker-%d", rand.Int())
 

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token_test.go
@@ -2,6 +2,7 @@ package security_test
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -13,6 +14,11 @@ import (
 )
 
 func TestAccScopedToken_UpgradeFromSDKv2(t *testing.T) {
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	// Version 7.11.1 is the last version before we migrated the resource from SDKv2 to Plugin Framework
 	version := "7.11.1"
 	title := fmt.Sprintf("from_v%s", version)
@@ -22,6 +28,11 @@ func TestAccScopedToken_UpgradeFromSDKv2(t *testing.T) {
 }
 
 func TestAccScopedToken_UpgradeGH_758(t *testing.T) {
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	// Version 7.2.0 doesn't have `include_reference_token` attribute
 	// This test verifies that there is no state drift on update
 	version := "7.2.0"
@@ -32,6 +43,11 @@ func TestAccScopedToken_UpgradeGH_758(t *testing.T) {
 }
 
 func TestAccScopedToken_UpgradeGH_792(t *testing.T) {
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	_, fqrn, name := testutil.MkNames("test-access-token", "artifactory_scoped_token")
 	config := util.ExecuteTemplate(
 		"TestAccScopedToken",
@@ -91,6 +107,11 @@ func TestAccScopedToken_UpgradeGH_792(t *testing.T) {
 }
 
 func TestAccScopedToken_UpgradeGH_818(t *testing.T) {
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	_, fqrn, name := testutil.MkNames("test-scope-token", "artifactory_scoped_token")
 	config := util.ExecuteTemplate(
 		"TestAccScopedToken",

--- a/pkg/artifactory/resource/user/resource_artifactory_managed_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_managed_user_test.go
@@ -2,6 +2,7 @@ package user_test
 
 import (
 	"fmt"
+	"os"
 	"regexp"
 	"testing"
 
@@ -14,6 +15,11 @@ import (
 )
 
 func TestAccManagedUser_UpgradeFromSDKv2(t *testing.T) {
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	id, fqrn, name := testutil.MkNames("test-user-upgrade-", "artifactory_managed_user")
 	username := fmt.Sprintf("dummy_user%d", id)
 	email := fmt.Sprintf(username + "@test.com")

--- a/pkg/artifactory/resource/user/resource_artifactory_user_test.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_user_test.go
@@ -3,6 +3,7 @@ package user_test
 import (
 	"fmt"
 	"net/http"
+	"os"
 	"regexp"
 	"testing"
 
@@ -18,6 +19,11 @@ import (
 )
 
 func TestAccUser_UpgradeFromSDKv2(t *testing.T) {
+	providerHost := os.Getenv("TF_ACC_PROVIDER_HOST")
+	if providerHost == "registry.opentofu.org" {
+		t.Skipf("provider host is registry.opentofu.org. Previous version of Artifactory provider is unknown to OpenTofu.")
+	}
+
 	id, fqrn, name := testutil.MkNames("test-user-upgrade-", "artifactory_user")
 	username := fmt.Sprintf("dummy_user%d", id)
 	email := fmt.Sprintf(username + "@test.com")

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook_test.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook_test.go
@@ -340,7 +340,7 @@ func webhookTestCase(webhookType string, t *testing.T) (*testing.T, resource.Tes
 				any_local  = {{ .anyLocal }}
 				any_remote = {{ .anyRemote }}
 				any_federated = {{ .anyFederated }}
-				repo_keys  = ["{{ .repoName }}"]
+				repo_keys  = [artifactory_local_{{ .repoType }}_repository.{{ .repoName }}.key]
 				include_patterns = ["foo/**"]
 				exclude_patterns = ["bar/**"]
 			}
@@ -356,8 +356,6 @@ func webhookTestCase(webhookType string, t *testing.T) (*testing.T, resource.Tes
 			handler {
 				url = "https://tempurl.com"
 			}
-
-			depends_on = [artifactory_local_{{ .repoType }}_repository.{{ .repoName }}]
 		}
 	`, params)
 
@@ -374,7 +372,7 @@ func webhookTestCase(webhookType string, t *testing.T) (*testing.T, resource.Tes
 				any_local  = {{ .anyLocal }}
 				any_remote = {{ .anyRemote }}
 				any_federated = {{ .anyFederated }}
-				repo_keys  = ["{{ .repoName }}"]
+				repo_keys  = [artifactory_local_{{ .repoType }}_repository.{{ .repoName }}.key]
 			}
 			handler {
 				url                    = "https://tempurl.org"
@@ -388,8 +386,6 @@ func webhookTestCase(webhookType string, t *testing.T) (*testing.T, resource.Tes
 			handler {
 				url = "https://tempurl.com"
 			}
-
-			depends_on = [artifactory_local_{{ .repoType }}_repository.{{ .repoName }}]
 		}
 	`, params)
 


### PR DESCRIPTION
For tests that load previous version of the provider that doesn't exist in OpenTofu registry