### PR TITLE
Fix: update remote repos document with missing attribute, fix broken …

### DIFF
--- a/docs/resources/package_cleanup_policy.md
+++ b/docs/resources/package_cleanup_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 # artifactory_package_cleanup_policy (Resource)
 
-Provides an Artifactory Package Cleanup Policy resource. This resource enable system administrators to define and customize policies based on specific criteria for removing unused binaries from across their JFrog platform. See [Retention Policies](https://jfrog.com/help/r/jfrog-platform-administration-documentation/create-a-package-retention-policy) for more details.
+Provides an Artifactory Package Cleanup Policy resource. This resource enable system administrators to define and customize policies based on specific criteria for removing unused binaries from across their JFrog platform. See [Retention Policies](https://jfrog.com/help/r/jfrog-platform-administration-documentation/retention-policies) for more details.
 
 ->Only available for Artifactory 7.90.1 or later.
 

--- a/docs/resources/package_cleanup_policy.md
+++ b/docs/resources/package_cleanup_policy.md
@@ -9,7 +9,7 @@ description: |-
 
 # artifactory_package_cleanup_policy (Resource)
 
-Provides an Artifactory Package Cleanup Policy resource. This resource enable system administrators to define and customize policies based on specific criteria for removing unused binaries from across their JFrog platform. See [Rentation Policies](https://jfrog.com/help/r/jfrog-platform-administration-documentation/retention-policies) for more details.
+Provides an Artifactory Package Cleanup Policy resource. This resource enable system administrators to define and customize policies based on specific criteria for removing unused binaries from across their JFrog platform. See [Retention Policies](https://jfrog.com/help/r/jfrog-platform-administration-documentation/create-a-package-retention-policy) for more details.
 
 ->Only available for Artifactory 7.90.1 or later.
 

--- a/docs/resources/remote.md
+++ b/docs/resources/remote.md
@@ -83,3 +83,4 @@ the artifact directly from the cloud storage provider. Available in Enterprise+ 
 * `cdn_redirect` - (Optional) When set, download requests to this repository will redirect the client to download
 the artifact directly from AWS CloudFront. Available in Enterprise+ and Edge licenses only.
 * `disable_url_normalization` - (Optional) Whether to disable URL normalization, default is `false`.
+* `archive_browsing_enabled` - (Optional) When set, you may view content such as HTML or Javadoc files directly from Artifactory. This may not be safe and therefore requires strict content moderation to prevent malicious users from uploading content that may compromise security (e.g., cross-site scripting attacks).


### PR DESCRIPTION
- added attribute _archive_browsing_enabled_ in remote repos document. Feature was added in 11.1.0
- Fix broken link for creating pkg retention policies