### PR TITLE
Upgrade golang for CVE 2024-34156

### DIFF
--- a/.github/workflows/acceptance-tests.yml
+++ b/.github/workflows/acceptance-tests.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: '1.22.7'
       - name: Install Helm
         uses: azure/setup-helm@v4.2.0
       - name: Install Terraform CLI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.22
+          go-version: '1.22.7'
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@v6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 11.9.2 (September 12, 2024)
+
+IMPROVEMENTS:
+
+* provider: Upgrade Golang version to 1.22.7 due to CVE-2024-34156. Security Advisory: [GHSA-wcq6-89h8-g366](https://github.com/jfrog/terraform-provider-artifactory/security/advisories/GHSA-wcq6-89h8-g366)
+* resource/artifactory_package_cleanup_policy: Remove version limitation note from documentation.
+
+PR: [#1071](https://github.com/jfrog/terraform-provider-artifactory/pull/1071)
+
 ## 11.9.1 (September 9, 2024). Tested on Artifactory 7.90.9 with Terraform 1.9.5 and OpenTofu 1.8.2
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 11.9.2 (September 12, 2024)
+## 11.9.2 (September 12, 2024). Tested on Artifactory 7.90.10 with Terraform 1.9.5 and OpenTofu 1.8.2
 
 IMPROVEMENTS:
 

--- a/docs/resources/package_cleanup_policy.md
+++ b/docs/resources/package_cleanup_policy.md
@@ -4,15 +4,12 @@ page_title: "artifactory_package_cleanup_policy Resource - terraform-provider-ar
 subcategory: "Configuration"
 description: |-
   Provides an Artifactory Package Cleanup Policy resource. This resource enable system administrators to define and customize policies based on specific criteria for removing unused binaries from across their JFrog platform. See Rentation Policies https://jfrog.com/help/r/jfrog-platform-administration-documentation/retention-policies for more details.
-  ->Only available for Artifactory 7.90.1 or later.
   ~>Currently in beta and not yet globally available. A full rollout is scheduled for early October 2024.
 ---
 
 # artifactory_package_cleanup_policy (Resource)
 
-Provides an Artifactory Package Cleanup Policy resource. This resource enable system administrators to define and customize policies based on specific criteria for removing unused binaries from across their JFrog platform. See [Retention Policies](https://jfrog.com/help/r/jfrog-platform-administration-documentation/retention-policies) for more details.
-
-->Only available for Artifactory 7.90.1 or later.
+Provides an Artifactory Package Cleanup Policy resource. This resource enable system administrators to define and customize policies based on specific criteria for removing unused binaries from across their JFrog platform. See [Rentation Policies](https://jfrog.com/help/r/jfrog-platform-administration-documentation/retention-policies) for more details.
 
 ~>Currently in beta and not yet globally available. A full rollout is scheduled for early October 2024.
 

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/jfrog/terraform-provider-artifactory/v11
 // if you need to do local dev, literally just uncomment the line below
 // replace github.com/jfrog/terraform-provider-shared => ../terraform-provider-shared
 
-go 1.22.5
+go 1.22.7
 
 require (
 	github.com/go-resty/resty/v2 v2.14.0

--- a/pkg/artifactory/resource/configuration/resource_artifactory_package_cleanup_policy.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_package_cleanup_policy.go
@@ -493,7 +493,6 @@ func (r *PackageCleanupPolicyResource) Schema(ctx context.Context, req resource.
 		Version:    1,
 		Description: "Provides an Artifactory Package Cleanup Policy resource. This resource enable system administrators to define and customize policies based on specific criteria for removing unused binaries from across their JFrog platform. " +
 			"See [Rentation Policies](https://jfrog.com/help/r/jfrog-platform-administration-documentation/retention-policies) for more details.\n\n" +
-			"->Only available for Artifactory 7.90.1 or later.\n\n" +
 			"~>Currently in beta and not yet globally available. A full rollout is scheduled for early October 2024.",
 	}
 }


### PR DESCRIPTION
https://github.com/jfrog/terraform-provider-artifactory/security/advisories/GHSA-wcq6-89h8-g366

Also update doc for `artifactory_package_cleanup_policy` resource.