### PR TITLE
Set `cronExp` and `repoKey` fields for each replication when updating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 12.3.1 (October 18, 2024)
+
+BUG FIXES:
+
+* resource/artifactory_local_repository_multi_replication: Fix error when updating resource with new `cron_exp` value. Issue: [#1099](https://github.com/jfrog/terraform-provider-artifactory/issues/1099) PR: [#1100](https://github.com/jfrog/terraform-provider-artifactory/pull/1100)
+
 ## 12.3.0 (October 16, 2024). Tested on Artifactory 7.90.14 with Terraform 1.9.7 and OpenTofu 1.8.3
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 12.3.1 (October 18, 2024)
+## 12.3.1 (October 18, 2024). Tested on Artifactory 7.90.14 with Terraform 1.9.8 and OpenTofu 1.8.3
 
 BUG FIXES:
 

--- a/pkg/artifactory/resource/replication/resource_artifactory_local_repository_multi_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_local_repository_multi_replication.go
@@ -61,6 +61,8 @@ func (m LocalRepositoryMultiReplicationResourceModel) toAPIModel(_ context.Conte
 					SocketTimeoutMillis:             attrs["socket_timeout_millis"].(types.Int64).ValueInt64(),
 					Username:                        attrs["username"].(types.String).ValueString(),
 					Password:                        attrs["password"].(types.String).ValueString(),
+					CronExp:                         m.CronExp.ValueString(),
+					RepoKey:                         m.RepoKey.ValueString(),
 					Enabled:                         attrs["enabled"].(types.Bool).ValueBool(),
 					SyncDeletes:                     attrs["sync_deletes"].(types.Bool).ValueBool(),
 					SyncProperties:                  attrs["sync_properties"].(types.Bool).ValueBool(),

--- a/pkg/artifactory/resource/replication/resource_artifactory_local_repository_multi_replication_test.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_local_repository_multi_replication_test.go
@@ -244,7 +244,7 @@ func TestAccLocalMultiReplication_full(t *testing.T) {
 
 		resource "artifactory_local_repository_multi_replication" "{{ .repo_name }}" {
 			repo_key = artifactory_local_maven_repository.{{ .repo_name }}.key
-			cron_exp = "0 0 * * * ?"
+			cron_exp = "0 0 */2 * * ?"
 			enable_event_replication = true
 
 			replication {
@@ -302,7 +302,7 @@ func TestAccLocalMultiReplication_full(t *testing.T) {
 				Config: updateConfig,
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "repo_key", name),
-					resource.TestCheckResourceAttr(fqrn, "cron_exp", "0 0 * * * ?"),
+					resource.TestCheckResourceAttr(fqrn, "cron_exp", "0 0 */2 * * ?"),
 					resource.TestCheckResourceAttr(fqrn, "enable_event_replication", "true"),
 					resource.TestCheckResourceAttr(fqrn, "replication.#", "2"),
 					resource.TestCheckResourceAttr(fqrn, "replication.0.username", acctest.RtDefaultUser),


### PR DESCRIPTION
Fix #1099 