### PR TITLE
Fix provider error when removing 'username' attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 12.3.2 (October 29, 2024)
+
+BUG FIXES:
+
+* resource/artifactory_mail_server: Fix error when unsetting an optional attribute. Issue: [#1103](https://github.com/jfrog/terraform-provider-artifactory/issues/1103) PR: [#1106](https://github.com/jfrog/terraform-provider-artifactory/pull/1106)
+
 ## 12.3.1 (October 18, 2024). Tested on Artifactory 7.90.14 with Terraform 1.9.8 and OpenTofu 1.8.3
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 12.3.2 (October 29, 2024)
+## 12.3.2 (October 29, 2024). Tested on Artifactory 7.90.15 with Terraform 1.9.8 and OpenTofu 1.8.4
 
 BUG FIXES:
 

--- a/pkg/artifactory/resource/configuration/resource_artifactory_mail_server.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_mail_server.go
@@ -21,16 +21,16 @@ import (
 )
 
 type MailServerAPIModel struct {
-	Enabled        bool   `xml:"enabled" yaml:"enabled"`
-	ArtifactoryURL string `xml:"artifactoryUrl" yaml:"artifactoryUrl"`
-	From           string `xml:"from" yaml:"from"`
-	Host           string `xml:"host" yaml:"host"`
-	Username       string `xml:"username" yaml:"username"`
-	Password       string `xml:"password" yaml:"password"`
-	Port           int64  `xml:"port" yaml:"port"`
-	SubjectPrefix  string `xml:"subjectPrefix" yaml:"subjectPrefix"`
-	UseSSL         bool   `xml:"ssl" yaml:"ssl"`
-	UseTLS         bool   `xml:"tls" yaml:"tls"`
+	Enabled        bool    `xml:"enabled" yaml:"enabled"`
+	ArtifactoryURL string  `xml:"artifactoryUrl" yaml:"artifactoryUrl"`
+	Host           string  `xml:"host" yaml:"host"`
+	Port           int64   `xml:"port" yaml:"port"`
+	From           *string `xml:"from" yaml:"from"`
+	Username       *string `xml:"username" yaml:"username"`
+	Password       *string `xml:"password" yaml:"password"`
+	SubjectPrefix  *string `xml:"subjectPrefix" yaml:"subjectPrefix"`
+	UseSSL         bool    `xml:"ssl" yaml:"ssl"`
+	UseTLS         bool    `xml:"tls" yaml:"tls"`
 }
 
 type MailServer struct {
@@ -55,12 +55,12 @@ func (r *MailServerResourceModel) ToAPIModel(ctx context.Context, mailServer *Ma
 	*mailServer = MailServerAPIModel{
 		Enabled:        r.Enabled.ValueBool(),
 		ArtifactoryURL: r.ArtifactoryURL.ValueString(),
-		From:           r.From.ValueString(),
 		Host:           r.Host.ValueString(),
-		Username:       r.Username.ValueString(),
-		Password:       r.Password.ValueString(),
 		Port:           r.Port.ValueInt64(),
-		SubjectPrefix:  r.SubjectPrefix.ValueString(),
+		From:           r.From.ValueStringPointer(),
+		Username:       r.Username.ValueStringPointer(),
+		Password:       r.Password.ValueStringPointer(),
+		SubjectPrefix:  r.SubjectPrefix.ValueStringPointer(),
 		UseSSL:         r.UseSSL.ValueBool(),
 		UseTLS:         r.UseTLS.ValueBool(),
 	}
@@ -71,11 +71,12 @@ func (r *MailServerResourceModel) ToAPIModel(ctx context.Context, mailServer *Ma
 func (r *MailServerResourceModel) FromAPIModel(ctx context.Context, mailServer *MailServerAPIModel) diag.Diagnostics {
 	r.Enabled = types.BoolValue(mailServer.Enabled)
 	r.ArtifactoryURL = types.StringValue(mailServer.ArtifactoryURL)
-	r.From = types.StringValue(mailServer.From)
 	r.Host = types.StringValue(mailServer.Host)
-	r.Username = types.StringValue(mailServer.Username)
 	r.Port = types.Int64Value(mailServer.Port)
-	r.SubjectPrefix = types.StringValue(mailServer.SubjectPrefix)
+
+	r.From = types.StringPointerValue(mailServer.From)
+	r.Username = types.StringPointerValue(mailServer.Username)
+	r.SubjectPrefix = types.StringPointerValue(mailServer.SubjectPrefix)
 	r.UseSSL = types.BoolValue(mailServer.UseSSL)
 	r.UseTLS = types.BoolValue(mailServer.UseTLS)
 

--- a/pkg/artifactory/resource/configuration/resource_artifactory_mail_server_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_mail_server_test.go
@@ -48,8 +48,6 @@ func TestAccMailServer_full(t *testing.T) {
 		artifactory_url = "{{ .artifactory_url }}"
 		from            = "{{ .from }}"
 		host            = "{{ .host }}"
-		username        = "test-user"
-		password        = "test-password"
 		port            = 25
 		subject_prefix  = "[Test]"
 		use_ssl         = true
@@ -84,8 +82,8 @@ func TestAccMailServer_full(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "artifactory_url", testData["artifactory_url"]),
 					resource.TestCheckResourceAttr(fqrn, "from", testData["from"]),
 					resource.TestCheckResourceAttr(fqrn, "host", testData["host"]),
-					resource.TestCheckResourceAttr(fqrn, "username", "test-user"),
-					resource.TestCheckResourceAttr(fqrn, "password", "test-password"),
+					resource.TestCheckNoResourceAttr(fqrn, "username"),
+					resource.TestCheckNoResourceAttr(fqrn, "password"),
 					resource.TestCheckResourceAttr(fqrn, "port", "25"),
 					resource.TestCheckResourceAttr(fqrn, "subject_prefix", "[Test]"),
 					resource.TestCheckResourceAttr(fqrn, "use_ssl", "true"),


### PR DESCRIPTION
Also applies to other optional attributes

Fix #1103 