### PR TITLE
Relax validations for search_criteria attributes for cleanup policy resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 12.4.1 (November 12, 2024)
+## 12.4.1 (November 12, 2024). Tested on Artifactory 7.98.8 with Terraform 1.9.8 and OpenTofu 1.8.5
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-## 12.4.1 (November 11, 2024). Tested on Artifactory 7.98.8 with Terraform 1.9.8 and OpenTofu 1.8.5
+## 12.4.1 (November 12, 2024)
 
 BUG FIXES:
 
 * resource/artifactory_build_webhook, resource/artifactory_release_bundle_webhook, resource/artifactory_release_bundle_v2_webhook, resource/artifactory_artifact_webhook, resource/artifactory_artifact_property_webhook, resource/artifactory_docker_webhook, resource/artifactory_build_custom_webhook, resource/artifactory_release_bundle_custom_webhook, resource/artifactory_release_bundle_v2_custom_webhook, resource/artifactory_artifact_custom_webhook, resource/artifactory_artifact_property_custom_webhook, resource/artifactory_docker_custom_webhook, resource/artifactory_ldap_group_setting_v2, resource/artifactory_repository_layout, resource/artifactory_release_bundle_v2, resource/artifactory_vault_configuration, resource/artifactory_user, resource/artifactory_managed_user, resource/artifactory_unmanaged_user: Fix attribute validation not working for unknown value (e.g. when resource is used in a module). Issue: [#1120](https://github.com/jfrog/terraform-provider-artifactory/issues/1120) PR: [#1123](https://github.com/jfrog/terraform-provider-artifactory/pull/1123)
+* resource/artifactory_package_cleanup_policy: Relax validations to allow 0 for `created_before_in_months` and `last_downloaded_before_in_months` attributes. Add validation run to ensure both can't be 0 at the same time. Issue: [#1122](https://github.com/jfrog/terraform-provider-artifactory/issues/1122) PR: [#1126](https://github.com/jfrog/terraform-provider-artifactory/pull/1126)
 
 ## 12.4.0 (November 4, 2024). Tested on Artifactory 7.98.7 with Terraform 1.9.8 and OpenTofu 1.8.5
 


### PR DESCRIPTION
To allow 0 for `created_before_in_months` and `last_downloaded_before_in_months` attributes

Add validation run to ensure both can't be 0 at the same time.

Fixes #1122 