### PR TITLE
Update remote cargo repository documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 12.7.1 (December 18, 2024)
+
+BUG FIXES:
+
+* resource/artifactory_remote_cargo_repository: Fix `git_registry_url` attribute to be incorrectly set to required. Issue: [#1153](https://github.com/jfrog/terraform-provider-artifactory/issues/1153) PR: [#1154](https://github.com/jfrog/terraform-provider-artifactory/pull/1154) and [#1155](https://github.com/jfrog/terraform-provider-artifactory/pull/1155)
+
 ## 12.7.0 (December 17, 2024). Tested on Artifactory 7.98.11 with Terraform 1.10.2 and OpenTofu 1.8.7
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 12.7.1 (December 18, 2024)
+## 12.7.1 (December 18, 2024). Tested on Artifactory 7.98.11 with Terraform 1.10.2 and OpenTofu 1.8.7
 
 BUG FIXES:
 

--- a/docs/resources/remote_cargo_repository.md
+++ b/docs/resources/remote_cargo_repository.md
@@ -4,8 +4,8 @@ subcategory: "Remote Repositories"
 # Artifactory Remote Cargo Repository Resource
 
 Creates a remote Cargo repository.
-Official documentation can be found [here](https://www.jfrog.com/confluence/display/JFROG/Cargo+Registry).
 
+Official documentation can be found [here](https://www.jfrog.com/confluence/display/JFROG/Cargo+Registry).
 
 ## Example Usage
 
@@ -14,8 +14,8 @@ resource "artifactory_remote_cargo_repository" "my-remote-cargo" {
   key                 = "my-remote-cargo"
   anonymous_access    = true
   enable_sparse_index = true
-  url                 = "https://github.com/rust-lang/crates.io-index"
-  git_registry_url    = "https://github.com/rust-lang/foo.index"
+  url                 = "https://index.crates.io/"
+  git_registry_url    = "https://index.crates.io/"
 }
 ```
 ## Note
@@ -34,7 +34,7 @@ The following arguments are supported, along with the [common list of arguments 
 * `url` - (Required) The remote repo URL.
 * `anonymous_access` - (Required) Cargo client does not send credentials when performing download and search for crates. Enable this to allow anonymous access to these resources (only), note that this will override the security anonymous access option. Default value is `false`.
 * `enable_sparse_index` - (Optional) Enable internal index support based on Cargo sparse index specifications, instead of the default git index. Default value is `false`.
-* `git_registry_url` - (Optional) This is the index url, expected to be a git repository. Default value is `https://github.com/rust-lang/crates.io-index`.
+* `git_registry_url` - (Optional) This is the index url, expected to be a git repository. Default value is `https://index.crates.io/`.
 
 
 ## Import

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_cargo_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_cargo_repository.go
@@ -21,9 +21,9 @@ var cargoSchema = lo.Assign(
 	map[string]*schema.Schema{
 		"git_registry_url": {
 			Type:         schema.TypeString,
-			Required:     false,
+			Optional:     true,
 			ValidateFunc: validation.IsURLWithHTTPorHTTPS,
-			Description:  `This is the index url, expected to be a git repository. Default value in UI is "https://github.com/rust-lang/crates.io-index"`,
+			Description:  `This is the index url, expected to be a git repository. Default value in UI is "https://index.crates.io/"`,
 		},
 		"anonymous_access": {
 			Type:     schema.TypeBool,


### PR DESCRIPTION
Set attribute git_registry_url to be optional

For issue #1153 and PR #1154 