### PR TITLE
Add http method parameter to custom webhook

### DIFF
--- a/docs/resources/user_custom_webhook.md
+++ b/docs/resources/user_custom_webhook.md
@@ -14,6 +14,7 @@ resource "artifactory_user_custom_webhook" "user-custom-webhook" {
 
   handler {
     url       = "https://tempurl.org"
+    method    = "POST"
     secrets   = {
       secretName1 = "value1"
       secretName2 = "value2"
@@ -38,12 +39,14 @@ The following arguments are supported:
 * `enabled` - (Optional) Status of webhook. Default to `true`
 * `event_types` - (Required) List of event triggers for the Webhook. Allow values: `locked`
 * `handler` - (Required) At least one is required.
-  * `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.
+  * `url` - (Required) Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send a request to.
+  * `method` - (Required) Specifies the HTTP method for the URL that the Webhook invokes. Allowed values are: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`.
   * `secrets` - (Optional) Defines a set of sensitive values (such as, tokens and passwords) that can be injected in the headers and/or payload.Secrets’ values are encrypted. In the header/payload, the value can be invoked using the `{{.secrets.token}}` format, where token is the name provided for the secret value. Comprise key/value pair. **Note:** if multiple handlers are used, same secret name and different secret value for the same url won't work. Example:
 
 ```hcl
 handler {
   url       = "https://tempurl.org" # same url in both handlers
+  method    = "POST"
   secrets   = {
     secretName1 = "value1"
     secretName2 = "value2"
@@ -56,6 +59,7 @@ handler {
 }
 handler {
   url       = "https://tempurl.org" # same url in both handlers
+  method    = "POST"
   secrets   = {
     secretName1 = "newValue1" # same secret name, but different value
     secretName2 = "newValue2" # same secret name, but different value

--- a/pkg/artifactory/resource/webhook/resource_artifactory_custom_webhook.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_custom_webhook.go
@@ -35,6 +35,13 @@ var customHandlerBlock = schema.SetNestedBlock{
 				},
 				Description: "Specifies the URL that the Webhook invokes. This will be the URL that Artifactory will send an HTTP POST request to.",
 			},
+			"method": schema.StringAttribute{
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf("GET", "POST", "PUT", "PATCH", "DELETE"),
+				},
+				Description: "Specifies the HTTP Method for URL that the Webhook invokes. Allowed values are: `GET`, `POST`, `PUT`, `PATCH`, `DELETE`.",
+			},
 			"secrets": schema.MapAttribute{
 				ElementType: types.StringType,
 				Optional:    true,
@@ -131,6 +138,7 @@ func (m CustomWebhookBaseResourceModel) toAPIModel(ctx context.Context, domain s
 			return CustomHandlerAPIModel{
 				HandlerType: "custom-webhook",
 				Url:         attrs["url"].(types.String).ValueString(),
+				Method:      attrs["method"].(types.String).ValueString(),
 				Secrets:     secrets,
 				Proxy:       attrs["proxy"].(types.String).ValueStringPointer(),
 				HttpHeaders: httpHeaders,
@@ -157,6 +165,7 @@ func (m CustomWebhookBaseResourceModel) toAPIModel(ctx context.Context, domain s
 
 var customHandlerSetResourceModelAttributeTypes = map[string]attr.Type{
 	"url":          types.StringType,
+	"method":       types.StringType,
 	"secrets":      types.MapType{ElemType: types.StringType},
 	"proxy":        types.StringType,
 	"http_headers": types.MapType{ElemType: types.StringType},
@@ -229,6 +238,7 @@ func (m *CustomWebhookBaseResourceModel) fromAPIModel(ctx context.Context, apiMo
 				customHandlerSetResourceModelAttributeTypes,
 				map[string]attr.Value{
 					"url":          types.StringValue(handler.Url),
+					"method":       types.StringValue(handler.Method),
 					"secrets":      secrets,
 					"proxy":        types.StringPointerValue(handler.Proxy),
 					"http_headers": httpHeaders,
@@ -288,6 +298,7 @@ func (w CustomWebhookAPIModel) Id() string {
 type CustomHandlerAPIModel struct {
 	HandlerType string                 `json:"handler_type"`
 	Url         string                 `json:"url"`
+	Method      string                 `json:"method"`
 	Secrets     []KeyValuePairAPIModel `json:"secrets"`
 	Proxy       *string                `json:"proxy"`
 	HttpHeaders []KeyValuePairAPIModel `json:"http_headers"`


### PR DESCRIPTION
Hello.

This pull request introduces a new http method parameter to custom webhooks. 

The method parameter allows users to specify the HTTP method to be used.

Thank you.