### PR TITLE
Replace resty multiparts form upload for artifactory_artifact resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ IMPROVEMENTS:
 
 * resource/artifactory_\*\_custom_webhook: Add attribute `method` to support setting HTTP method. PR: [#1160](https://github.com/jfrog/terraform-provider-artifactory/pull/1160) and [#1163](https://github.com/jfrog/terraform-provider-artifactory/pull/1163)
 
+BUG FIXES:
+
+* resource/artifactory_artifact: Fix artifact upload incorrectly (using multipart form vs raw binary data). Issue: [#1083](https://github.com/jfrog/terraform-provider-artifactory/issues/1083) PR: [#1164](https://github.com/jfrog/terraform-provider-artifactory/pull/1164)
+
 ## 12.7.1 (December 18, 2024). Tested on Artifactory 7.98.11 with Terraform 1.10.2 and OpenTofu 1.8.7
 
 BUG FIXES:

--- a/pkg/artifactory/resource/artifact/resource_artifactory_artifact.go
+++ b/pkg/artifactory/resource/artifact/resource_artifactory_artifact.go
@@ -236,9 +236,18 @@ func (r *ArtifactResource) Create(ctx context.Context, req resource.CreateReques
 		defer os.Remove(localFilePath)
 	}
 
+	// open the file as stream
+	f, err := os.Open(localFilePath)
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+	defer f.Close()
+
 	response, err := r.ProviderData.Client.R().
 		SetRawPathParam("repo_target_path", repo_target_path).
-		SetFile(plan.Path.ValueString(), localFilePath).
+		SetHeader("Content-Type", "application/octet-stream").
+		SetBody(f).
 		SetResult(&result).
 		Put("/artifactory/{repo_target_path}")
 
@@ -331,9 +340,18 @@ func (r *ArtifactResource) Update(ctx context.Context, req resource.UpdateReques
 		defer os.Remove(localFilePath)
 	}
 
+	// open the file as stream
+	f, err := os.Open(localFilePath)
+	if err != nil {
+		utilfw.UnableToUpdateResourceError(resp, err.Error())
+		return
+	}
+	defer f.Close()
+
 	response, err := r.ProviderData.Client.R().
 		SetRawPathParam("repo_target_path", repo_target_path).
-		SetFile(plan.Path.ValueString(), localFilePath).
+		SetHeader("Content-Type", "application/octet-stream").
+		SetBody(f).
 		SetResult(&result).
 		Put("/artifactory/{repo_target_path}")
 

--- a/pkg/artifactory/resource/artifact/resource_artifactory_artifact_test.go
+++ b/pkg/artifactory/resource/artifact/resource_artifactory_artifact_test.go
@@ -39,6 +39,14 @@ func TestAccArtifact_filepath(t *testing.T) {
 	}
 	config := util.ExecuteTemplate(name, temp, testData)
 
+	updatedTestData := map[string]string{
+		"name":     name,
+		"repoName": repoName,
+		"path":     "/foo/bar/multi1-3.7-20220310.233748-1.jar",
+		"filePath": "../../../../samples/multi1-3.7-20220310.233859-2.jar",
+	}
+	updatedConfig := util.ExecuteTemplate(name, temp, updatedTestData)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
@@ -56,7 +64,23 @@ func TestAccArtifact_filepath(t *testing.T) {
 					resource.TestCheckResourceAttrSet(fqrn, "created_by"),
 					resource.TestCheckResourceAttrSet(fqrn, "download_uri"),
 					resource.TestCheckResourceAttrSet(fqrn, "mime_type"),
-					resource.TestCheckResourceAttrSet(fqrn, "size"),
+					resource.TestCheckResourceAttr(fqrn, "size", "1034"),
+					resource.TestCheckResourceAttrSet(fqrn, "uri"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "repository", repoName),
+					resource.TestCheckResourceAttr(fqrn, "path", updatedTestData["path"]),
+					resource.TestCheckResourceAttrSet(fqrn, "checksum_md5"),
+					resource.TestCheckResourceAttrSet(fqrn, "checksum_sha1"),
+					resource.TestCheckResourceAttrSet(fqrn, "checksum_sha256"),
+					resource.TestCheckResourceAttrSet(fqrn, "created"),
+					resource.TestCheckResourceAttrSet(fqrn, "created_by"),
+					resource.TestCheckResourceAttrSet(fqrn, "download_uri"),
+					resource.TestCheckResourceAttrSet(fqrn, "mime_type"),
+					resource.TestCheckResourceAttr(fqrn, "size", "1034"),
 					resource.TestCheckResourceAttrSet(fqrn, "uri"),
 				),
 			},
@@ -93,6 +117,20 @@ func TestAccArtifact_content_base64(t *testing.T) {
 	}
 	config := util.ExecuteTemplate(name, temp, testData)
 
+	updatedData, err := os.ReadFile("../../../../samples/multi1-3.7-20220310.233859-2.jar")
+	if err != nil {
+		t.Fatalf("failed to read file. %v", err)
+		return
+	}
+
+	updatedTestData := map[string]string{
+		"name":     name,
+		"repoName": repoName,
+		"path":     "/foo/bar/multi1-3.7-20220310.233748-1.jar",
+		"content":  base64.StdEncoding.EncodeToString(updatedData),
+	}
+	updatedConfig := util.ExecuteTemplate(name, temp, updatedTestData)
+
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { acctest.PreCheck(t) },
 		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
@@ -110,7 +148,23 @@ func TestAccArtifact_content_base64(t *testing.T) {
 					resource.TestCheckResourceAttrSet(fqrn, "created_by"),
 					resource.TestCheckResourceAttrSet(fqrn, "download_uri"),
 					resource.TestCheckResourceAttrSet(fqrn, "mime_type"),
-					resource.TestCheckResourceAttrSet(fqrn, "size"),
+					resource.TestCheckResourceAttr(fqrn, "size", "1034"),
+					resource.TestCheckResourceAttrSet(fqrn, "uri"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "repository", repoName),
+					resource.TestCheckResourceAttr(fqrn, "path", updatedTestData["path"]),
+					resource.TestCheckResourceAttrSet(fqrn, "checksum_md5"),
+					resource.TestCheckResourceAttrSet(fqrn, "checksum_sha1"),
+					resource.TestCheckResourceAttrSet(fqrn, "checksum_sha256"),
+					resource.TestCheckResourceAttrSet(fqrn, "created"),
+					resource.TestCheckResourceAttrSet(fqrn, "created_by"),
+					resource.TestCheckResourceAttrSet(fqrn, "download_uri"),
+					resource.TestCheckResourceAttrSet(fqrn, "mime_type"),
+					resource.TestCheckResourceAttr(fqrn, "size", "1034"),
 					resource.TestCheckResourceAttrSet(fqrn, "uri"),
 				),
 			},


### PR DESCRIPTION
With binary file in Resty's request body with file reader. Also update tests to check for updating resource as well.

Fix #1083 