### PR TITLE
Fix to remove the enforcement of artificial requirements on predefined_value. It is now only mandatory when closed_predefined_values or multiple_choice is set to true.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-## 12.9.3 (April 8, 2025). Tested on Artifactory 7.104.14 with Terraform 1.11.3 and OpenTofu 1.9.0
+## 12.9.3 (April 14, 2025).
 
 BUG FIXES:
 
+* resource/artifactory_property_set : Fix to remove the enforcement of artificial requirements on predefined_value. It is now only mandatory when closed_predefined_values or multiple_choice is set to true. Issue: [#1214](https://github.com/jfrog/terraform-provider-artifactory/issues/1214) PR: [#1240](https://github.com/jfrog/terraform-provider-artifactory/pull/1240)
 * resource/resource_artifactory_scoped_token : Fix #Validation of scope when creating tokens doesn't include all valid options. Issue: [#1235](https://github.com/jfrog/terraform-provider-artifactory/issues/1235) PR: [#1241](https://github.com/jfrog/terraform-provider-artifactory/pull/1241)
 
 ## 12.9.2 (April 2, 2025). Tested on Artifactory 7.104.14 with Terraform 1.11.3 and OpenTofu 1.9.0

--- a/docs/resources/property_set.md
+++ b/docs/resources/property_set.md
@@ -49,6 +49,13 @@ resource "artifactory_property_set" "foo" {
     closed_predefined_values 	= false
     multiple_choice 			= false
   }
+
+  property {
+    name = "set1property3"
+
+    closed_predefined_values 	= false
+    multiple_choice 			= false
+  }
 }
 ```
 
@@ -62,7 +69,7 @@ The following arguments are supported:
   * `name` - (Required) The name pf the property.
   * `closed_predefined_values` - (Required) Disables `multiple_choice` if set to `false` at the same time with multiple_choice set to `true`. Default value is `false`
   * `multiple_choice` - (Optional) Defines if user can select multiple values. `closed_predefined_values` should be set to `true`. Default value is `false`.
-    * `predefined_value` - (Required) Properties in the property set.  
+    * `predefined_value` - (Optional) Properties in the property set. predefined_value is (Required) when closed_predefined_values or multiple_choice is set to 'true' 
       * `name` - (Required) Predefined property name.
       * `default_value` - (Required) Whether the value is selected by default in the UI.
 

--- a/pkg/artifactory/resource/configuration/resource_artifactory_property_set.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_property_set.go
@@ -174,7 +174,7 @@ type PredefinedValueAPIModel struct {
 
 type PropertyAPIModel struct {
 	Name                  string                    `xml:"name" yaml:"-"`
-	PredefinedValues      []PredefinedValueAPIModel `xml:"predefinedValues>predefinedValue" yaml:"predefinedValues"`
+	PredefinedValues      []PredefinedValueAPIModel `xml:"predefinedValues>predefinedValue" yaml:"predefinedValues,omitempty"`
 	ClosedPredefinedValue bool                      `xml:"closedPredefinedValues" yaml:"closedPredefinedValues"`
 	MultipleChoice        bool                      `xml:"multipleChoice" yaml:"multipleChoice"`
 }
@@ -258,10 +258,7 @@ func (r *PropertySetResource) Schema(ctx context.Context, req resource.SchemaReq
 									},
 								},
 							},
-							Validators: []validator.Set{
-								setvalidator.IsRequired(),
-							},
-							Description: "Properties in the property set.",
+							Description: "Properties in the property set. Predefined values is mandatory when closed_predefined_values or multiple_choice is set to 'true'",
 						},
 					},
 					Validators: []validator.Object{
@@ -523,4 +520,12 @@ func (v propertyValidator) ValidateObject(ctx context.Context, req validator.Obj
 			"Setting closed_predefined_values to 'false' and multiple_choice to 'true' disables multiple_choice",
 		)
 	}
+	if (closedPredefinedValues || multipleChoice) && len(attrs["predefined_value"].(types.Set).Elements()) == 0 {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("predefined_value"),
+			"Missing Attribute predefined_value",
+			"Predefined values is mandatory when closed_predefined_values or multiple_choice is set to 'true'",
+		)
+	}
+
 }


### PR DESCRIPTION
Fix to remove the enforcement of artificial requirements on predefined_value. It is now only mandatory when closed_predefined_values or multiple_choice is set to true.