### PR TITLE
Enhanced ARM64 Build Process with Dynamic GOARM64 Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 12.9.6 (June 13, 2025). Tested on Artifactory 7.111.8 with Terraform 1.12.0 and OpenTofu 1.9.1
+
+IMPROVEMENTS:
+
+* GNUmakefile : Enhanced ARM64 Build Process with Dynamic GOARM64 Detection. PR: [1282](https://github.com/jfrog/terraform-provider-artifactory/pull/1282)
+
 ## 12.9.5 (June 3, 2025). Tested on Artifactory 7.111.8 with Terraform 1.12.0 and OpenTofu 1.9.1
 
 BUG FIXES:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -10,6 +10,11 @@ GORELEASER_ARCH=${TARGET_ARCH}_$(shell go env GOAMD64)
 LINUX_GORELEASER_ARCH:=${LINUX_GORELEASER_ARCH}_$(shell go env GOAMD64)
 endif
 
+ifeq ($(GO_ARCH), arm64)
+GORELEASER_ARCH=${TARGET_ARCH}_$(shell go env GOARM64)
+LINUX_GORELEASER_ARCH:=${LINUX_GORELEASER_ARCH}_$(shell go env GOARM64)
+endif
+
 PKG_NAME=pkg/artifactory
 # if this path ever changes, you need to also update the 'ldflags' value in .goreleaser.yml
 PROVIDER_VERSION?=$(shell git describe --tags --abbrev=0 | sed  -n 's/v\([0-9]*\).\([0-9]*\).\([0-9]*\)/\1.\2.\3/p')


### PR DESCRIPTION
**Problem:**
Previously, building the `terraform-provider-artifactory` locally on `darwin_arm64` failed due to a path regex mismatch during the `make install` step. The `goreleaser` build output was not consistently tagged with the precise ARM64 variant, leading to incorrect binary paths and subsequent `mv` errors.

**Exact Error Encountered:**
```
make install
rm -fR dist terraform.d/ .terraform terraform.tfstate* .terraform.lock.hcl
==> Fixing source code with gofmt...
GORELEASER_CURRENT_TAG=12.9.6 goreleaser build --clean --snapshot --single-target
  • skipping validate...
  • cleaning distribution directory
  • loading environment variables
  • getting and validating git state
    • couldn't find any tags before "12.9.6"
    • git state                                      commit=87e71e6250409e006098be7b71c97a7328f5d200 branch=Support-for-Hex-repositories-in-the-Artifactory-Terraform-provider current_tag=12.9.6 previous_tag=<unknown> dirty=true
    • pipe skipped or partially skipped              reason=disabled during snapshot mode
  • parsing tag
  • setting defaults
  • partial
  • snapshotting
    • building snapshot...                           version=12.9.6-SNAPSHOT-87e71e62
  • running before hooks
    • running                                        hook=go mod tidy
  • ensuring distribution directory
  • setting up metadata
  • writing release metadata
  • loading go mod information
  • build prerequisites
  • building binaries
    • partial build                                  match=target=darwin_arm64_v8.0
    • building                                       binary=dist/terraform-provider-artifactory_darwin_arm64_v8.0/terraform-provider-artifactory_v12.9.6-SNAPSHOT-87e71e62
  • writing artifacts metadata
  • build succeeded after 1s
  • thanks for using GoReleaser!
mkdir -p terraform.d/plugins/registry.terraform.io/jfrog/artifactory/12.9.6/darwin_arm64 && \
	mkdir -p terraform.d/plugins/registry.terraform.io/jfrog/artifactory/12.9.6/linux_amd64 && \
		mv -v dist/terraform-provider-artifactory_darwin_arm64/terraform-provider-artifactory_v12.9.6* terraform.d/plugins/registry.terraform.io/jfrog/artifactory/12.9.6/darwin_arm64 && \
		sed -i.bak 's/version = ".*"/version = "12.9.6"/' sample.tf && rm sample.tf.bak && \
		terraform init
mv: rename dist/terraform-provider-artifactory_darwin_arm64/terraform-provider-artifactory_v12.9.6* to terraform.d/plugins/registry.terraform.io/jfrog/artifactory/12.9.6/darwin_arm64/terraform-provider-artifactory_v12.9.6*: No such file or directory
make: *** [install] Error 1
```

**Solution:**
This PR enhances the `GNUmakefile` to dynamically determine the exact ARM64 variant by leveraging `go env GOARM64`. This ensures that `goreleaser` builds are accurately tagged and optimized for different ARM64 environments, resolving the path mismatch issue.