### PR TITLE
Added disable proxy attribute for single replication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 12.9.7 (July 1, 2025). Tested on Artifactory 7.111.10 with Terraform 1.12.2 and OpenTofu 1.9.1
+### 12.9.7 (July 1, 2025). Tested on Artifactory 7.111.10 with Terraform 1.12.2 and OpenTofu 1.10.1
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 12.9.7 (July 1, 2025). Tested on Artifactory 7.111.10 with Terraform 1.12.2 and OpenTofu 1.9.1
+
+IMPROVEMENTS:
+
+* Introduced a new attribute disable_proxy for single replication. This allows users to explicitly disable the use of a proxy when configuring single replication in the Artifactory Terraform provider. PR: [1284](https://github.com/jfrog/terraform-provider-artifactory/pull/1284)
+
 ## 12.9.6 (June 17, 2025). Tested on Artifactory 7.111.10 with Terraform 1.12.2 and OpenTofu 1.9.1
 
 NOTES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 IMPROVEMENTS:
 
-* Introduced a new attribute disable_proxy for single replication. This allows users to explicitly disable the use of a proxy when configuring single replication in the Artifactory Terraform provider. PR: [1284](https://github.com/jfrog/terraform-provider-artifactory/pull/1284)
+* Introduced a new attribute disable_proxy for single replication. This allows users to explicitly disable the use of a proxy when configuring single replication in the Artifactory Terraform provider. Issue: [#1255](https://github.com/jfrog/terraform-provider-artifactory/issues/1255). PR: [#1284](https://github.com/jfrog/terraform-provider-artifactory/pull/1284)
 
 ## 12.9.6 (June 17, 2025). Tested on Artifactory 7.111.10 with Terraform 1.12.2 and OpenTofu 1.9.1
 
@@ -12,7 +12,7 @@ If you are upgrading from a version earlier than 12.8.3, please upgrade to 12.8.
 
 IMPROVEMENTS:
 
-* GNUmakefile : Enhanced ARM64 Build Process with Dynamic GOARM64 Detection. PR: [1282](https://github.com/jfrog/terraform-provider-artifactory/pull/1282)
+* GNUmakefile : Enhanced ARM64 Build Process with Dynamic GOARM64 Detection. PR: [#1282](https://github.com/jfrog/terraform-provider-artifactory/pull/1282)
 
 BUG FIXES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-### 12.9.7 (July 1, 2025). Tested on Artifactory 7.111.10 with Terraform 1.12.2 and OpenTofu 1.10.1
+### 12.9.7 (July 4, 2025).
 
 IMPROVEMENTS:
 
-* Introduced a new attribute disable_proxy for single replication. This allows users to explicitly disable the use of a proxy when configuring single replication in the Artifactory Terraform provider. Issue: [#1255](https://github.com/jfrog/terraform-provider-artifactory/issues/1255). PR: [#1284](https://github.com/jfrog/terraform-provider-artifactory/pull/1284)
+* resource/artifactory_local_repository_single_replication: Introduced a new attribute disable_proxy for single replication. This allows users to explicitly disable the use of a proxy when configuring single replication in the Artifactory Terraform provider. Issue: [#1255](https://github.com/jfrog/terraform-provider-artifactory/issues/1255). PR: [#1284](https://github.com/jfrog/terraform-provider-artifactory/pull/1284)
 
 ## 12.9.6 (June 17, 2025). Tested on Artifactory 7.111.10 with Terraform 1.12.2 and OpenTofu 1.9.1
 

--- a/docs/resources/local_repository_single_replication.md
+++ b/docs/resources/local_repository_single_replication.md
@@ -73,6 +73,7 @@ The following arguments are supported:
 * `include_path_prefix_pattern` - (Optional) List of artifact patterns to include when evaluating artifact requests in the form of `x/y/**/z/*`. When used, only artifacts matching one of the include patterns are served. By default, all artifacts are included `(**/*)`.
 * `exclude_path_prefix_pattern` - (Optional) List of artifact patterns to exclude when evaluating artifact requests, in the form of `x/y/**/z/*`. By default, no artifacts are excluded.
 * `proxy` - (Optional) Proxy key from Artifactory Proxies settings. The proxy configuration will be used when communicating with the remote instance.
+* `disable_proxy` - (Optional) When set to `true`, the `proxy` attribute will be ignored (from version 7.41.7). The default value is `false`.
 * `replication_key` - (Computed) Replication ID, the value is unknown until the resource is created. Can't be set or updated.
 * `check_binary_existence_in_filestore` - (Optional) Enabling the `check_binary_existence_in_filestore` flag requires an Enterprise Plus license. When true, enables distributed checksum storage. For more information, see [Optimizing Repository Replication with Checksum-Based Storage](https://www.jfrog.com/confluence/display/JFROG/Repository+Replication#RepositoryReplication-OptimizingRepositoryReplicationUsingStorageLevelSynchronizationOptions).
 

--- a/pkg/artifactory/resource/replication/resource_artifactory_local_repository_single_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_local_repository_single_replication.go
@@ -53,6 +53,7 @@ type LocalRepositorySingleReplicationResourceModel struct {
 	SyncStatistics                  types.Bool   `tfsdk:"sync_statistics"`
 	RepoKey                         types.String `tfsdk:"repo_key"`
 	Proxy                           types.String `tfsdk:"proxy"`
+	DisableProxy                    types.Bool   `tfsdk:"disable_proxy"`
 	ReplicationKey                  types.String `tfsdk:"replication_key"`
 	IncludePathPrefixPattern        types.String `tfsdk:"include_path_prefix_pattern"`
 	ExcludePathPrefixPattern        types.String `tfsdk:"exclude_path_prefix_pattern"`
@@ -77,7 +78,8 @@ func (m LocalRepositorySingleReplicationResourceModel) toAPIModel(_ context.Cont
 			ExcludePathPrefixPattern:        m.ExcludePathPrefixPattern.ValueString(),
 			CheckBinaryExistenceInFilestore: m.CheckBinaryExistenceInFilestore.ValueBool(),
 		},
-		Proxy: m.Proxy.ValueString(),
+		Proxy:        m.Proxy.ValueString(),
+		DisableProxy: m.DisableProxy.ValueBool(),
 	}
 
 	return
@@ -104,6 +106,7 @@ func (m *LocalRepositorySingleReplicationResourceModel) fromAPIModel(_ context.C
 	m.ExcludePathPrefixPattern = types.StringValue(apiModel.ExcludePathPrefixPattern)
 	m.CheckBinaryExistenceInFilestore = types.BoolValue(apiModel.CheckBinaryExistenceInFilestore)
 	m.Proxy = types.StringValue(apiModel.ProxyRef)
+	m.DisableProxy = types.BoolValue(apiModel.DisableProxy)
 	m.ReplicationKey = types.StringValue(apiModel.ReplicationKey)
 
 	return
@@ -130,11 +133,13 @@ type LocalSingleReplicationGetAPIModel struct {
 	LocalSingleReplicationAPIModel
 	ProxyRef       string `json:"proxyRef"`
 	ReplicationKey string `json:"replicationKey"`
+	DisableProxy   bool   `json:"disableProxy"`
 }
 
 type LocalSingleReplicationUpdateAPIModel struct {
 	LocalSingleReplicationAPIModel
-	Proxy string `json:"proxy"`
+	Proxy        string `json:"proxy"`
+	DisableProxy bool   `json:"disableProxy"`
 }
 
 func (r *LocalRepositorySingleReplicationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -252,6 +257,12 @@ func (r *LocalRepositorySingleReplicationResource) Schema(ctx context.Context, r
 					stringvalidator.LengthAtLeast(1),
 				},
 				Description: "A proxy configuration to use when communicating with the remote instance.",
+			},
+			"disable_proxy": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "When set to `true`, the `proxy` attribute will be ignored (from version 7.41.7). The default value is `false`.",
 			},
 			"replication_key": schema.StringAttribute{
 				Computed:    true,


### PR DESCRIPTION
## Problem

The `local_repository_single_replication` Terraform resource was missing support for the `disableProxy` setting. This made it impossible to manage or disable the proxy configuration for single replication local repositories via Terraform. As a result, users could not control this setting from their IaC workflow, potentially leaving proxies enabled unintentionally.

### Example Scenario

A user attempts to provision a local repository with single replication in Artifactory but cannot disable the proxy, as the resource's schema does not accept a `disableProxy` field:

```hcl
resource "artifactory_local_repository_single_replication" "example" {
  // ... other settings ...
  // disableProxy = true  # Not supported in previous provider versions
}
```

## Solution

This PR adds support for the `disableProxy` attribute to the `local_repository_single_replication` resource. 

### Example Usage

```hcl
resource "artifactory_local_repository_single_replication" "example" {
  // ... other settings ...
  disableProxy = true
}
```

This addition aligns the Terraform provider's capabilities with the Artifactory API and UI, enabling a more complete and user-friendly experience for managing repository replication settings.

Fixes : https://github.com/jfrog/terraform-provider-artifactory/issues/1255