### PR TITLE
fix: invalid check in remote content sync logic

### DIFF
--- a/pkg/artifactory/resource/repository/remote/remote.go
+++ b/pkg/artifactory/resource/repository/remote/remote.go
@@ -253,8 +253,8 @@ func (r *RemoteResourceModel) FromAPIModel(ctx context.Context, apiModel RemoteA
 	r.ClientTLSCertificate = types.StringValue(apiModel.ClientTLSCertificate)
 
 	contentSynchronisationList := types.ListNull(contentSynchronisationAttrType)
-	if apiModel.ContentSynchronisation.Enabled {
-		if apiModel.ContentSynchronisation != nil {
+	if apiModel.ContentSynchronisation != nil {
+		if apiModel.ContentSynchronisation.Enabled {
 			cs := apiModel.ContentSynchronisation
 			contentSynchronisation, ds := types.ObjectValue(
 				contentSynchronisationAttrTypes,


### PR DESCRIPTION
Fixing a mistake introduced in https://github.com/jfrog/terraform-provider-artifactory/pull/1274

The checks here are the wrong way round.

This causes a fatal error if the repository doesn't have the `contentSynchronisation` attribute.