### PR TITLE
[DOC] Fix resource name in the Example Usage for the Ansible Remote

### DIFF
--- a/docs/resources/remote_ansible_repository.md
+++ b/docs/resources/remote_ansible_repository.md
@@ -11,7 +11,7 @@ Official documentation can be found [here](https://jfrog.com/help/r/jfrog-artifa
 ## Example Usage
 
 ```terraform
-resource "artifactory_remote_alpine_repository" "my-remote-ansible" {
+resource "artifactory_remote_ansible_repository" "my-remote-ansible" {
   key = "my-remote-ansible"
   url = "https://galaxy.ansible.com"
 }


### PR DESCRIPTION
Fix invalid resource name in the Ansible remote resource example