### PR TITLE
Adding new Hex repository Resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 12.11.1 (Nov 17, 2025). Tested on Artifactory 7.125.6 with Terraform 1.13.5 and OpenTofu 1.10.7
+
+FEATURES:
+
+**New Resource:** `artifactory_*_hex_repository` to support local, remote, virtual Hex repository. Issue: [#1230](https://github.com/jfrog/terraform-provider-artifactory/issues/1230) PR: [#1336](https://github.com/jfrog/terraform-provider-artifactory/pull/1336)
+
+**New Data Source** `datasource_artifactory_*_hex_repository` : Adds new data sources for all hex repository types. Issue: [#1230](https://github.com/jfrog/terraform-provider-artifactory/issues/1230) PR: [#1336](https://github.com/jfrog/terraform-provider-artifactory/pull/1336)
+
 ### 12.11.0 (Nov 14 2025). Tested on Artifactory 7.125.6 with Terraform 1.13.5 and OpenTofu 1.10.7
 
 BUG FIXES: 

--- a/docs/data-sources/local_hex_repository.md
+++ b/docs/data-sources/local_hex_repository.md
@@ -1,0 +1,30 @@
+---
+subcategory: "Local Repositories"
+---
+
+# Artifactory Local Hex Repository Data Source
+
+Retrieves a local Hex repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_local_hex_repository" "local-test-hex-repo" {
+  key = "local-test-hex-repo"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported along with the [common list of attributes for the local repositories](local.md):
+
+* `hex_primary_keypair_ref` - Select the RSA key pair to sign and encrypt content for secure communication between Artifactory and the Mix client.
+* `description`
+* `notes`
+

--- a/docs/data-sources/remote_hex_repository.md
+++ b/docs/data-sources/remote_hex_repository.md
@@ -1,0 +1,29 @@
+---
+subcategory: "Remote Repositories"
+---
+# Artifactory Remote Hex Repository Data Source
+
+Retrieves a remote Hex repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_remote_hex_repository" "remote-hex" {
+  key = "remote-hex"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of attributes for the remote repositories](../resources/remote.md):
+
+* `hex_primary_keypair_ref` - Select the RSA key pair to sign and encrypt content for secure communication between Artifactory and the Mix client.
+* `public_key` - Contains the public key used when downloading packages from the Hex remote registry (public, private, or self-hosted Hex server).
+* `url` - The remote repo URL. For the official Hex registry, use `https://repo.hex.pm`.
+

--- a/docs/data-sources/virtual_hex_repository.md
+++ b/docs/data-sources/virtual_hex_repository.md
@@ -1,0 +1,28 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Hex Repository Data Source
+
+Retrieves a virtual Hex repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_hex_repository" "virtual-hex" {
+  key = "virtual-hex"
+}
+```
+
+## Argument Reference
+
+The following argument is supported:
+
+* `key` - (Required) the identity key of the repo.
+
+## Attribute Reference
+
+The following attributes are supported, along with the [common list of arguments for the virtual repositories](../resources/virtual.md):
+
+* `hex_primary_keypair_ref` - Select the RSA key pair to sign and encrypt content for secure communication between Artifactory and the Mix client.
+* `repositories` - The effective list of actual repositories included in this virtual repository.
+

--- a/docs/resources/local_hex_repository.md
+++ b/docs/resources/local_hex_repository.md
@@ -1,0 +1,54 @@
+---
+subcategory: "Local Repositories"
+---
+# Artifactory Local Hex Repository Resource
+
+Creates a local Hex repository for storing Elixir/Erlang packages.
+
+## Example Usage
+
+```hcl
+resource "artifactory_keypair" "some-keypairRSA" {
+  pair_name   = "some-keypair${random_id.randid.id}"
+  pair_type   = "RSA"
+  alias       = "foo-alias"
+  private_key = file("samples/rsa.priv")
+  public_key  = file("samples/rsa.pub")
+  lifecycle {
+    ignore_changes = [
+      private_key,
+      passphrase,
+    ]
+  }
+}
+
+resource "artifactory_local_hex_repository" "my-hex-repo" {
+  key                     = "my-hex-repo"
+  hex_primary_keypair_ref = artifactory_keypair.some-keypairRSA.pair_name
+  description             = "Local Hex repository for Elixir packages"
+  notes                   = "Internal repository"
+  depends_on              = [artifactory_keypair.some-keypairRSA]
+}
+```
+
+## Argument Reference
+
+Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/confluence/display/RTF/Repository+Configuration+JSON).
+The following arguments are supported, along with the [common list of arguments for the local repositories](local.md):
+
+* `key` - (Required) the identity key of the repo.
+* `hex_primary_keypair_ref` - (Required) Select the RSA key pair to sign and encrypt content for secure communication between Artifactory and the Mix client.
+* `description` - (Optional)
+* `notes` - (Optional)
+
+Artifactory REST API call Get Key Pair doesn't return keys `private_key` and `passphrase`, but consumes these keys in the POST call.
+
+The meta-argument `lifecycle` used here to make Provider ignore the changes for these two keys in the Terraform state.
+
+## Import
+
+Local repositories can be imported using their name, e.g.
+```
+$ terraform import artifactory_local_hex_repository.my-hex-repo my-hex-repo
+```
+

--- a/docs/resources/remote_hex_repository.md
+++ b/docs/resources/remote_hex_repository.md
@@ -1,0 +1,60 @@
+---
+subcategory: "Remote Repositories"
+---
+# Artifactory Remote Hex Repository Resource
+
+Creates a remote Hex repository for proxying Elixir/Erlang packages from a remote Hex registry.
+
+Official documentation can be found [here](https://www.jfrog.com/confluence/display/JFROG/Hex+Registry).
+
+## Example Usage
+
+```hcl
+resource "artifactory_keypair" "some-keypairRSA" {
+  pair_name   = "some-keypair${random_id.randid.id}"
+  pair_type   = "RSA"
+  alias       = "foo-alias"
+  private_key = file("samples/rsa.priv")
+  public_key  = file("samples/rsa.pub")
+  lifecycle {
+    ignore_changes = [
+      private_key,
+      passphrase,
+    ]
+  }
+}
+
+resource "artifactory_remote_hex_repository" "my-remote-hex" {
+  key                     = "my-remote-hex"
+  url                     = "https://repo.hex.pm"
+  hex_primary_keypair_ref = artifactory_keypair.some-keypairRSA.pair_name
+  public_key              = file("samples/rsa.pub")
+  description             = "Remote Hex repository for Elixir packages"
+  notes                   = "Internal repository"
+  depends_on              = [artifactory_keypair.some-keypairRSA]
+}
+```
+
+## Argument Reference
+
+Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/confluence/display/RTF/Repository+Configuration+JSON).
+The following arguments are supported, along with the [common list of arguments for the remote repositories](remote.md):
+
+* `key` - (Required) A mandatory identifier for the repository that must be unique. It cannot begin with a number or contain spaces or special characters.
+* `url` - (Required) The remote repo URL. For the official Hex registry, use `https://repo.hex.pm`.
+* `hex_primary_keypair_ref` - (Required) Select the RSA key pair to sign and encrypt content for secure communication between Artifactory and the Mix client.
+* `public_key` - (Required) Contains the public key used when downloading packages from the Hex remote registry (public, private, or self-hosted Hex server).
+* `description` - (Optional)
+* `notes` - (Optional)
+
+Artifactory REST API call Get Key Pair doesn't return keys `private_key` and `passphrase`, but consumes these keys in the POST call.
+
+The meta-argument `lifecycle` used here to make Provider ignore the changes for these two keys in the Terraform state.
+
+## Import
+
+Remote repositories can be imported using their name, e.g.
+```
+$ terraform import artifactory_remote_hex_repository.my-remote-hex my-remote-hex
+```
+

--- a/docs/resources/virtual_hex_repository.md
+++ b/docs/resources/virtual_hex_repository.md
@@ -1,0 +1,77 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Hex Repository Resource
+
+Creates a virtual Hex repository that aggregates local and remote Hex repositories.
+
+Official documentation can be found [here](https://www.jfrog.com/confluence/display/JFROG/Hex+Registry#HexRegistry-VirtualRepositories).
+
+## Example Usage
+
+```hcl
+resource "artifactory_keypair" "some-keypairRSA" {
+  pair_name   = "some-keypair${random_id.randid.id}"
+  pair_type   = "RSA"
+  alias       = "foo-alias"
+  private_key = file("samples/rsa.priv")
+  public_key  = file("samples/rsa.pub")
+  lifecycle {
+    ignore_changes = [
+      private_key,
+      passphrase,
+    ]
+  }
+}
+
+resource "artifactory_local_hex_repository" "local-hex" {
+  key                     = "local-hex"
+  hex_primary_keypair_ref = artifactory_keypair.some-keypairRSA.pair_name
+}
+
+resource "artifactory_remote_hex_repository" "remote-hex" {
+  key                     = "remote-hex"
+  url                     = "https://repo.hex.pm"
+  hex_primary_keypair_ref = artifactory_keypair.some-keypairRSA.pair_name
+  public_key              = file("samples/rsa.pub")
+}
+
+resource "artifactory_virtual_hex_repository" "my-virtual-hex" {
+  key                     = "my-virtual-hex"
+  hex_primary_keypair_ref = artifactory_keypair.some-keypairRSA.pair_name
+  repositories           = [
+    artifactory_local_hex_repository.local-hex.key,
+    artifactory_remote_hex_repository.remote-hex.key
+  ]
+  description             = "Virtual Hex repository aggregating local and remote"
+  notes                   = "Internal repository"
+  depends_on              = [
+    artifactory_keypair.some-keypairRSA,
+    artifactory_local_hex_repository.local-hex,
+    artifactory_remote_hex_repository.remote-hex
+  ]
+}
+```
+
+## Argument Reference
+
+Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/confluence/display/RTF/Repository+Configuration+JSON).
+The following arguments are supported, along with the [common list of arguments for the virtual repositories](virtual.md):
+
+* `key` - (Required) A mandatory identifier for the repository that must be unique. It cannot begin with a number or contain spaces or special characters.
+* `hex_primary_keypair_ref` - (Required) Select the RSA key pair to sign and encrypt content for secure communication between Artifactory and the Mix client.
+* `repositories` - (Optional) The effective list of actual repositories included in this virtual repository.
+* `description` - (Optional)
+* `notes` - (Optional)
+
+Artifactory REST API call Get Key Pair doesn't return keys `private_key` and `passphrase`, but consumes these keys in the POST call.
+
+The meta-argument `lifecycle` used here to make Provider ignore the changes for these two keys in the Terraform state.
+
+## Import
+
+Virtual repositories can be imported using their name, e.g.
+```
+$ terraform import artifactory_virtual_hex_repository.my-virtual-hex my-virtual-hex
+```
+

--- a/examples/resources/artifactory_local_hex_repository/import.sh
+++ b/examples/resources/artifactory_local_hex_repository/import.sh
@@ -1,0 +1,2 @@
+terraform import artifactory_local_hex_repository.my-hex-local my-hex-local
+

--- a/examples/resources/artifactory_local_hex_repository/resource.tf
+++ b/examples/resources/artifactory_local_hex_repository/resource.tf
@@ -1,0 +1,22 @@
+resource "artifactory_keypair" "hex-keypair" {
+  pair_name   = "hex-keypair"
+  pair_type   = "RSA"
+  alias       = "hex-alias"
+  private_key = file("samples/rsa.priv")
+  public_key  = file("samples/rsa.pub")
+  lifecycle {
+    ignore_changes = [
+      private_key,
+      passphrase,
+    ]
+  }
+}
+
+resource "artifactory_local_hex_repository" "my-hex-local" {
+  key                     = "my-hex-local"
+  hex_primary_keypair_ref = artifactory_keypair.hex-keypair.pair_name
+  description             = "Local Hex repository for Elixir packages"
+  notes                   = "Internal repository"
+  depends_on              = [artifactory_keypair.hex-keypair]
+}
+

--- a/examples/resources/artifactory_remote_hex_repository/import.sh
+++ b/examples/resources/artifactory_remote_hex_repository/import.sh
@@ -1,0 +1,2 @@
+terraform import artifactory_remote_hex_repository.my-hex-remote my-hex-remote
+

--- a/examples/resources/artifactory_remote_hex_repository/resource.tf
+++ b/examples/resources/artifactory_remote_hex_repository/resource.tf
@@ -1,0 +1,24 @@
+resource "artifactory_keypair" "hex-keypair" {
+  pair_name   = "hex-keypair"
+  pair_type   = "RSA"
+  alias       = "hex-alias"
+  private_key = file("samples/rsa.priv")
+  public_key  = file("samples/rsa.pub")
+  lifecycle {
+    ignore_changes = [
+      private_key,
+      passphrase,
+    ]
+  }
+}
+
+resource "artifactory_remote_hex_repository" "my-hex-remote" {
+  key                     = "my-hex-remote"
+  url                     = "https://repo.hex.pm"
+  hex_primary_keypair_ref = artifactory_keypair.hex-keypair.pair_name
+  public_key              = file("samples/rsa.pub")
+  description             = "Remote Hex repository for Elixir packages"
+  notes                   = "Internal repository"
+  depends_on              = [artifactory_keypair.hex-keypair]
+}
+

--- a/examples/resources/artifactory_virtual_hex_repository/import.sh
+++ b/examples/resources/artifactory_virtual_hex_repository/import.sh
@@ -1,0 +1,2 @@
+terraform import artifactory_virtual_hex_repository.my-hex-virtual my-hex-virtual
+

--- a/examples/resources/artifactory_virtual_hex_repository/resource.tf
+++ b/examples/resources/artifactory_virtual_hex_repository/resource.tf
@@ -1,0 +1,44 @@
+resource "artifactory_keypair" "hex-keypair" {
+  pair_name   = "hex-keypair"
+  pair_type   = "RSA"
+  alias       = "hex-alias"
+  private_key = file("samples/rsa.priv")
+  public_key  = file("samples/rsa.pub")
+  lifecycle {
+    ignore_changes = [
+      private_key,
+      passphrase,
+    ]
+  }
+}
+
+resource "artifactory_local_hex_repository" "local-hex" {
+  key                     = "local-hex"
+  hex_primary_keypair_ref = artifactory_keypair.hex-keypair.pair_name
+  depends_on              = [artifactory_keypair.hex-keypair]
+}
+
+resource "artifactory_remote_hex_repository" "remote-hex" {
+  key                     = "remote-hex"
+  url                     = "https://repo.hex.pm"
+  hex_primary_keypair_ref = artifactory_keypair.hex-keypair.pair_name
+  public_key              = file("samples/rsa.pub")
+  depends_on              = [artifactory_keypair.hex-keypair]
+}
+
+resource "artifactory_virtual_hex_repository" "my-hex-virtual" {
+  key                     = "my-hex-virtual"
+  hex_primary_keypair_ref = artifactory_keypair.hex-keypair.pair_name
+  repositories           = [
+    artifactory_local_hex_repository.local-hex.key,
+    artifactory_remote_hex_repository.remote-hex.key
+  ]
+  description             = "Virtual Hex repository aggregating local and remote"
+  notes                   = "Internal repository"
+  depends_on              = [
+    artifactory_keypair.hex-keypair,
+    artifactory_local_hex_repository.local-hex,
+    artifactory_remote_hex_repository.remote-hex
+  ]
+}
+

--- a/pkg/artifactory/datasource/repository/local/datasource_artifactory_local_hex_repository.go
+++ b/pkg/artifactory/datasource/repository/local/datasource_artifactory_local_hex_repository.go
@@ -1,0 +1,185 @@
+package local
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	datasource_repository "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/datasource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/local"
+	"github.com/jfrog/terraform-provider-shared/util"
+	"github.com/samber/lo"
+)
+
+var _ datasource.DataSource = &LocalHexRepositoryDataSource{}
+
+func NewLocalHexRepositoryDataSource() datasource.DataSource {
+	return &LocalHexRepositoryDataSource{}
+}
+
+type LocalHexRepositoryDataSource struct {
+	ProviderData util.ProviderMetadata
+}
+
+type LocalHexRepositoryDataSourceModel struct {
+	Key                    types.String `tfsdk:"key"`
+	ProjectKey             types.String `tfsdk:"project_key"`
+	ProjectEnvironments    types.Set    `tfsdk:"project_environments"`
+	Description            types.String `tfsdk:"description"`
+	Notes                  types.String `tfsdk:"notes"`
+	IncludesPattern        types.String `tfsdk:"includes_pattern"`
+	ExcludesPattern        types.String `tfsdk:"excludes_pattern"`
+	RepoLayoutRef          types.String `tfsdk:"repo_layout_ref"`
+	BlackedOut             types.Bool   `tfsdk:"blacked_out"`
+	XrayIndex              types.Bool   `tfsdk:"xray_index"`
+	PropertySets           types.Set    `tfsdk:"property_sets"`
+	ArchiveBrowsingEnabled types.Bool   `tfsdk:"archive_browsing_enabled"`
+	DownloadDirect         types.Bool   `tfsdk:"download_direct"`
+	PriorityResolution     types.Bool   `tfsdk:"priority_resolution"`
+	CDNRedirect            types.Bool   `tfsdk:"cdn_redirect"`
+	PackageType            types.String `tfsdk:"package_type"`
+	HexPrimaryKeyPairRef   types.String `tfsdk:"hex_primary_keypair_ref"`
+}
+
+type LocalHexRepositoryAPIModel struct {
+	repository.BaseAPIModel
+	local.LocalAPIModel
+	HexPrimaryKeyPairRef string `json:"primaryKeyPairRef"`
+}
+
+func (d *LocalHexRepositoryDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "artifactory_local_hex_repository"
+}
+
+func (d *LocalHexRepositoryDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attributes := lo.Assign(
+		LocalDataSourceAttributes,
+		datasource_repository.HexDataSourceAttributes,
+	)
+
+	resp.Schema = schema.Schema{
+		Attributes:  attributes,
+		Description: "Provides a data source for a local Hex repository",
+	}
+}
+
+func (d *LocalHexRepositoryDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	d.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+func (d *LocalHexRepositoryDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data LocalHexRepositoryDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var apiModel LocalHexRepositoryAPIModel
+	var jfrogErrors util.JFrogErrors
+
+	response, err := d.ProviderData.Client.R().
+		SetPathParam("key", data.Key.ValueString()).
+		SetResult(&apiModel).
+		SetError(&jfrogErrors).
+		Get(repository.RepositoriesEndpoint)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while fetching the data source. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+err.Error(),
+		)
+		return
+	}
+
+	if response.StatusCode() == http.StatusBadRequest || response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while fetching the data source. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+jfrogErrors.String(),
+		)
+		return
+	}
+
+	// Convert from API model to Terraform model
+	data.FromAPIModel(ctx, &apiModel)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (m *LocalHexRepositoryDataSourceModel) FromAPIModel(ctx context.Context, apiModel *LocalHexRepositoryAPIModel) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	// Base fields
+	m.Key = types.StringValue(apiModel.Key)
+	m.ProjectKey = types.StringValue(apiModel.ProjectKey)
+	m.Description = types.StringValue(apiModel.Description)
+	m.Notes = types.StringValue(apiModel.Notes)
+	m.IncludesPattern = types.StringValue(apiModel.IncludesPattern)
+	m.ExcludesPattern = types.StringValue(apiModel.ExcludesPattern)
+	m.PackageType = types.StringValue(repository.HexPackageType)
+
+	// Local-specific fields
+	m.RepoLayoutRef = types.StringValue(apiModel.RepoLayoutRef)
+	m.BlackedOut = types.BoolValue(apiModel.LocalAPIModel.BlackedOut)
+	m.XrayIndex = types.BoolValue(apiModel.LocalAPIModel.XrayIndex)
+	m.ArchiveBrowsingEnabled = types.BoolValue(apiModel.LocalAPIModel.ArchiveBrowsingEnabled)
+	m.DownloadDirect = types.BoolValue(apiModel.LocalAPIModel.DownloadRedirect)
+	m.PriorityResolution = types.BoolValue(apiModel.LocalAPIModel.PriorityResolution)
+	m.CDNRedirect = types.BoolValue(apiModel.LocalAPIModel.CDNRedirect)
+
+	// Hex-specific field
+	m.HexPrimaryKeyPairRef = types.StringValue(apiModel.HexPrimaryKeyPairRef)
+
+	// Property sets
+	var propertySets []types.String
+	for _, ps := range apiModel.LocalAPIModel.PropertySets {
+		propertySets = append(propertySets, types.StringValue(ps))
+	}
+	if len(propertySets) > 0 {
+		psSet, d := types.SetValueFrom(ctx, types.StringType, propertySets)
+		if d.HasError() {
+			diags.Append(d...)
+			return diags
+		}
+		m.PropertySets = psSet
+	} else {
+		m.PropertySets = types.SetNull(types.StringType)
+	}
+
+	// Project environments
+	var projectEnvironments []types.String
+	for _, env := range apiModel.ProjectEnvironments {
+		projectEnvironments = append(projectEnvironments, types.StringValue(env))
+	}
+	if len(projectEnvironments) > 0 {
+		envSet, d := types.SetValueFrom(ctx, types.StringType, projectEnvironments)
+		if d.HasError() {
+			diags.Append(d...)
+			return diags
+		}
+		m.ProjectEnvironments = envSet
+	} else {
+		m.ProjectEnvironments = types.SetNull(types.StringType)
+	}
+
+	return diags
+}

--- a/pkg/artifactory/datasource/repository/local/datasource_artifactory_local_hex_repository_test.go
+++ b/pkg/artifactory/datasource/repository/local/datasource_artifactory_local_hex_repository_test.go
@@ -1,0 +1,68 @@
+package local_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccDataSourceLocalHexRepository(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-local-test-repo-basic", "data.artifactory_local_hex_repository")
+	kpId, _, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+	localRepositoryBasic := util.ExecuteTemplate("keypair", `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+			lifecycle {
+				ignore_changes = [
+					private_key,
+					passphrase,
+				]
+			}
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .repo_name }}" {
+			key 	     = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			depends_on = [artifactory_keypair.{{ .kp_name }}]
+		}
+
+		data "artifactory_local_hex_repository" "{{ .repo_name }}" {
+			key = artifactory_local_hex_repository.{{ .repo_name }}.key
+		}
+	`, map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: localRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "hex"),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("local", "hex"); return r }()),
+				),
+			},
+		},
+	})
+}

--- a/pkg/artifactory/datasource/repository/local/local.go
+++ b/pkg/artifactory/datasource/repository/local/local.go
@@ -1,0 +1,44 @@
+package local
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	datasource_repository "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/datasource/repository"
+	"github.com/samber/lo"
+)
+
+// LocalDataSourceAttributes defines the attributes for local repository datasources
+var LocalDataSourceAttributes = lo.Assign(
+	datasource_repository.BaseDataSourceAttributes,
+	map[string]schema.Attribute{
+		"blacked_out": schema.BoolAttribute{
+			Computed:            true,
+			MarkdownDescription: "When set, the repository does not participate in artifact resolution and new artifacts cannot be deployed.",
+		},
+		"xray_index": schema.BoolAttribute{
+			Computed:            true,
+			MarkdownDescription: "Enable Indexing In Xray. Repository will be indexed with the default retention period.",
+		},
+		"property_sets": schema.SetAttribute{
+			ElementType:         types.StringType,
+			Computed:            true,
+			MarkdownDescription: "List of property set name",
+		},
+		"archive_browsing_enabled": schema.BoolAttribute{
+			Computed:            true,
+			MarkdownDescription: "When set, you may view content such as HTML or Javadoc files directly from Artifactory.",
+		},
+		"download_direct": schema.BoolAttribute{
+			Computed:            true,
+			MarkdownDescription: "When set, download requests to this repository will redirect the client to download the artifact directly from the cloud storage provider.",
+		},
+		"priority_resolution": schema.BoolAttribute{
+			Computed:            true,
+			MarkdownDescription: "Setting repositories with priority will cause metadata to be merged only from repositories set with this field",
+		},
+		"cdn_redirect": schema.BoolAttribute{
+			Computed:            true,
+			MarkdownDescription: "When set, download requests to this repository will redirect the client to download the artifact directly from AWS CloudFront.",
+		},
+	},
+)

--- a/pkg/artifactory/datasource/repository/remote/datasource_artifactory_remote_hex_repository.go
+++ b/pkg/artifactory/datasource/repository/remote/datasource_artifactory_remote_hex_repository.go
@@ -1,0 +1,149 @@
+package remote
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	datasource_repository "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/datasource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/remote"
+	"github.com/jfrog/terraform-provider-shared/util"
+	"github.com/samber/lo"
+)
+
+var _ datasource.DataSource = &RemoteHexRepositoryDataSource{}
+
+func NewRemoteHexRepositoryDataSource() datasource.DataSource {
+	return &RemoteHexRepositoryDataSource{}
+}
+
+type RemoteHexRepositoryDataSource struct {
+	ProviderData util.ProviderMetadata
+}
+
+type RemoteHexRepositoryDataSourceModel struct {
+	BaseRemoteRepositoryDataSourceModel
+	HexPrimaryKeyPairRef types.String `tfsdk:"hex_primary_keypair_ref"`
+	PublicKey            types.String `tfsdk:"public_key"`
+}
+
+type RemoteHexRepositoryAPIModel struct {
+	remote.RemoteAPIModel
+	HexPrimaryKeyPairRef string `json:"primaryKeyPairRef"`
+	PublicKey            string `json:"hexPublicKey"`
+}
+
+func (d *RemoteHexRepositoryDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "artifactory_remote_hex_repository"
+}
+
+func (d *RemoteHexRepositoryDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attributes := lo.Assign(
+		BaseRemoteSchemaAttributes(),
+		datasource_repository.HexRemoteDataSourceAttributes,
+	)
+
+	resp.Schema = schema.Schema{
+		Attributes:  attributes,
+		Description: "Provides a data source for a remote Hex repository",
+	}
+}
+
+func (d *RemoteHexRepositoryDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	d.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+func (d *RemoteHexRepositoryDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data RemoteHexRepositoryDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var apiModel RemoteHexRepositoryAPIModel
+	var jfrogErrors util.JFrogErrors
+
+	response, err := d.ProviderData.Client.R().
+		SetPathParam("key", data.Key.ValueString()).
+		SetResult(&apiModel).
+		SetError(&jfrogErrors).
+		Get(repository.RepositoriesEndpoint)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while fetching the data source. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+err.Error(),
+		)
+		return
+	}
+
+	if response.StatusCode() == http.StatusBadRequest || response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while fetching the data source. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+jfrogErrors.String(),
+		)
+		return
+	}
+
+	// Convert from API model to Terraform model
+	data.FromAPIModel(ctx, &apiModel)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (m *RemoteHexRepositoryDataSourceModel) FromAPIModel(ctx context.Context, apiModel *RemoteHexRepositoryAPIModel) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	// Convert base repository fields
+	baseAPIModel := datasource_repository.BaseRepositoryAPIModel{
+		Key:                 apiModel.RemoteAPIModel.Key,
+		ProjectKey:          apiModel.RemoteAPIModel.ProjectKey,
+		ProjectEnvironments: apiModel.RemoteAPIModel.ProjectEnvironments,
+		Description:         apiModel.RemoteAPIModel.Description,
+		Notes:               apiModel.RemoteAPIModel.Notes,
+		IncludesPattern:     apiModel.RemoteAPIModel.IncludesPattern,
+		ExcludesPattern:     apiModel.RemoteAPIModel.ExcludesPattern,
+		RepoLayoutRef:       apiModel.RemoteAPIModel.RepoLayoutRef,
+		PackageType:         repository.HexPackageType,
+	}
+	diags.Append(datasource_repository.CommonFromAPIModel(ctx, &m.BaseRepositoryDataSourceModel, baseAPIModel)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	// Convert remote-specific fields
+	remoteAPIModel := BaseRemoteRepositoryAPIModel{
+		BaseRepositoryAPIModel: baseAPIModel,
+		RemoteAPIModel:         apiModel.RemoteAPIModel,
+	}
+	diags.Append(CommonRemoteFromAPIModel(ctx, &m.BaseRemoteRepositoryDataSourceModel, remoteAPIModel)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	// Hex-specific fields
+	m.HexPrimaryKeyPairRef = types.StringValue(apiModel.HexPrimaryKeyPairRef)
+	m.PublicKey = types.StringValue(apiModel.PublicKey)
+
+	return diags
+}

--- a/pkg/artifactory/datasource/repository/remote/datasource_artifactory_remote_hex_repository_test.go
+++ b/pkg/artifactory/datasource/repository/remote/datasource_artifactory_remote_hex_repository_test.go
@@ -1,0 +1,73 @@
+package remote_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccDataSourceRemoteHexRepository(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-remote-test-repo-basic", "data.artifactory_remote_hex_repository")
+	kpId, _, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+	remoteRepositoryBasic := util.ExecuteTemplate("keypair", `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+			lifecycle {
+				ignore_changes = [
+					private_key,
+					passphrase,
+				]
+			}
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key 	     = "{{ .repo_name }}"
+			url          = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key   = <<EOF
+{{ .public_key }}
+EOF
+			depends_on = [artifactory_keypair.{{ .kp_name }}]
+		}
+
+		data "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = artifactory_remote_hex_repository.{{ .repo_name }}.key
+		}
+	`, map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: remoteRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "hex"),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "url", "https://repo.hex.pm"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef("remote", "hex"); return r }()),
+				),
+			},
+		},
+	})
+}

--- a/pkg/artifactory/datasource/repository/remote/remote.go
+++ b/pkg/artifactory/datasource/repository/remote/remote.go
@@ -1,12 +1,261 @@
 package remote
 
 import (
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkv2_schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	datasource_repository "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/datasource/repository"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/remote"
+	"github.com/samber/lo"
 )
 
-var getSchema = func(schemas map[int16]map[string]*schema.Schema) map[string]*schema.Schema {
+// Framework types and functions
+
+// BaseRemoteRepositoryDataSourceModel contains common fields for all remote repository data sources
+type BaseRemoteRepositoryDataSourceModel struct {
+	datasource_repository.BaseRepositoryDataSourceModel
+	URL                               types.String `tfsdk:"url"`
+	Username                          types.String `tfsdk:"username"`
+	Password                          types.String `tfsdk:"password"`
+	Proxy                             types.String `tfsdk:"proxy"`
+	DisableProxy                      types.Bool   `tfsdk:"disable_proxy"`
+	RemoteRepoLayoutRef               types.String `tfsdk:"remote_repo_layout_ref"`
+	HardFail                          types.Bool   `tfsdk:"hard_fail"`
+	Offline                           types.Bool   `tfsdk:"offline"`
+	QueryParams                       types.String `tfsdk:"query_params"`
+	StoreArtifactsLocally             types.Bool   `tfsdk:"store_artifacts_locally"`
+	SocketTimeoutMillis               types.Int64  `tfsdk:"socket_timeout_millis"`
+	LocalAddress                      types.String `tfsdk:"local_address"`
+	RetrievalCachePeriodSecs          types.Int64  `tfsdk:"retrieval_cache_period_seconds"`
+	MissedRetrievalCachePeriodSecs    types.Int64  `tfsdk:"missed_cache_period_seconds"`
+	MetadataRetrievalTimeoutSecs      types.Int64  `tfsdk:"metadata_retrieval_timeout_secs"`
+	UnusedArtifactsCleanupPeriodHours types.Int64  `tfsdk:"unused_artifacts_cleanup_period_hours"`
+	AssumedOfflinePeriodSecs          types.Int64  `tfsdk:"assumed_offline_period_secs"`
+	ShareConfiguration                types.Bool   `tfsdk:"share_configuration"`
+	SynchronizeProperties             types.Bool   `tfsdk:"synchronize_properties"`
+	BlockMismatchingMimeTypes         types.Bool   `tfsdk:"block_mismatching_mime_types"`
+	AllowAnyHostAuth                  types.Bool   `tfsdk:"allow_any_host_auth"`
+	EnableCookieManagement            types.Bool   `tfsdk:"enable_cookie_management"`
+	BypassHeadRequests                types.Bool   `tfsdk:"bypass_head_requests"`
+	ClientTLSCertificate              types.String `tfsdk:"client_tls_certificate"`
+	MismatchingMimeTypeOverrideList   types.String `tfsdk:"mismatching_mime_types_override_list"`
+	ListRemoteFolderItems             types.Bool   `tfsdk:"list_remote_folder_items"`
+	DisableURLNormalization           types.Bool   `tfsdk:"disable_url_normalization"`
+}
+
+// BaseRemoteRepositoryAPIModel contains common fields for all remote repository API models
+// This is a helper type for conversion - actual API models embed remote.RemoteAPIModel
+type BaseRemoteRepositoryAPIModel struct {
+	datasource_repository.BaseRepositoryAPIModel
+	remote.RemoteAPIModel
+}
+
+// BaseRemoteSchemaAttributes returns the base schema attributes for all remote repository data sources
+func BaseRemoteSchemaAttributes() map[string]schema.Attribute {
+	return lo.Assign(
+		datasource_repository.BaseDataSourceAttributes,
+		map[string]schema.Attribute{
+			"url": schema.StringAttribute{
+				MarkdownDescription: "This is a URL to the remote registry. Consider using HTTPS to ensure a secure connection.",
+				Computed:            true,
+			},
+			"username": schema.StringAttribute{
+				MarkdownDescription: "The username to use when connecting to the remote repository.",
+				Computed:            true,
+			},
+			"password": schema.StringAttribute{
+				MarkdownDescription: "The password to use when connecting to the remote repository.",
+				Computed:            true,
+				Sensitive:           true,
+			},
+			"proxy": schema.StringAttribute{
+				MarkdownDescription: "Proxy key from Artifactory Proxies settings.",
+				Computed:            true,
+			},
+			"disable_proxy": schema.BoolAttribute{
+				MarkdownDescription: "When set, this repository will not use the Artifactory proxy configuration.",
+				Computed:            true,
+			},
+			"remote_repo_layout_ref": schema.StringAttribute{
+				MarkdownDescription: "Repository layout key for the remote layout mapping.",
+				Computed:            true,
+			},
+			"hard_fail": schema.BoolAttribute{
+				MarkdownDescription: "When set, Artifactory will return an error to the client that causes the build to fail if there is a failure to communicate with this repository.",
+				Computed:            true,
+			},
+			"offline": schema.BoolAttribute{
+				MarkdownDescription: "When set, the repository is treated as a Remote repository. The default value is `true`.",
+				Computed:            true,
+			},
+			"query_params": schema.StringAttribute{
+				MarkdownDescription: "Query parameters to include in the request to the remote repository.",
+				Computed:            true,
+			},
+			"store_artifacts_locally": schema.BoolAttribute{
+				MarkdownDescription: "When set, the repository should store cached artifacts locally.",
+				Computed:            true,
+			},
+			"socket_timeout_millis": schema.Int64Attribute{
+				MarkdownDescription: "Network timeout (in ms) to use when establishing a connection and for unanswered requests.",
+				Computed:            true,
+			},
+			"local_address": schema.StringAttribute{
+				MarkdownDescription: "The network address of the local machine that should be used to connect to the remote repository system.",
+				Computed:            true,
+			},
+			"retrieval_cache_period_seconds": schema.Int64Attribute{
+				MarkdownDescription: "The metadataRetrievalCachePeriod (in seconds) specifies how long the cache metadata should be considered valid.",
+				Computed:            true,
+			},
+			"missed_cache_period_seconds": schema.Int64Attribute{
+				MarkdownDescription: "The number of seconds to cache artifact retrieval misses (artifact not found).",
+				Computed:            true,
+			},
+			"metadata_retrieval_timeout_secs": schema.Int64Attribute{
+				MarkdownDescription: "The number of seconds to wait for an artifact to be downloaded before considering the download failed.",
+				Computed:            true,
+			},
+			"unused_artifacts_cleanup_period_hours": schema.Int64Attribute{
+				MarkdownDescription: "The number of hours to cache items that were not accessed.",
+				Computed:            true,
+			},
+			"assumed_offline_period_secs": schema.Int64Attribute{
+				MarkdownDescription: "The number of seconds the repository should wait before checking whether a remote VCS repository has been changed.",
+				Computed:            true,
+			},
+			"share_configuration": schema.BoolAttribute{
+				MarkdownDescription: "When set, the repository should store cached artifacts locally.",
+				Computed:            true,
+			},
+			"synchronize_properties": schema.BoolAttribute{
+				MarkdownDescription: "When set, remote artifacts are downloaded along with their properties and metadata to the local repository as well.",
+				Computed:            true,
+			},
+			"block_mismatching_mime_types": schema.BoolAttribute{
+				MarkdownDescription: "Before caching an artifact, Artifactory first sends a HEAD request to the remote resource.",
+				Computed:            true,
+			},
+			"allow_any_host_auth": schema.BoolAttribute{
+				MarkdownDescription: "Also known as 'Lenient Host Authentication', Allow credentials of this repository to be used on requests redirected to any other host.",
+				Computed:            true,
+			},
+			"enable_cookie_management": schema.BoolAttribute{
+				MarkdownDescription: "Enables cookie management if the remote repository uses cookies to manage client state.",
+				Computed:            true,
+			},
+			"bypass_head_requests": schema.BoolAttribute{
+				MarkdownDescription: "Before caching an artifact, Artifactory first sends a HEAD request to the remote resource.",
+				Computed:            true,
+			},
+			"client_tls_certificate": schema.StringAttribute{
+				MarkdownDescription: "Client TLS certificate name.",
+				Computed:            true,
+			},
+			"mismatching_mime_types_override_list": schema.StringAttribute{
+				MarkdownDescription: "Lists of artifacts that should be accepted by the proxy repository.",
+				Computed:            true,
+			},
+			"list_remote_folder_items": schema.BoolAttribute{
+				MarkdownDescription: "When set, Artifactory will list remote folder items when listing the repository contents.",
+				Computed:            true,
+			},
+			"disable_url_normalization": schema.BoolAttribute{
+				MarkdownDescription: "When set, Artifactory will not normalize URLs when downloading artifacts.",
+				Computed:            true,
+			},
+		},
+	)
+}
+
+// RemoteDataSourceAttributes defines the attributes for remote repository datasources
+var RemoteDataSourceAttributes = BaseRemoteSchemaAttributes
+
+// CommonRemoteFromAPIModel provides common conversion logic from API model to Terraform model for remote repositories
+func CommonRemoteFromAPIModel(ctx context.Context, baseModel *BaseRemoteRepositoryDataSourceModel, apiModel BaseRemoteRepositoryAPIModel) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	// Convert common fields using the base repository function
+	diags.Append(datasource_repository.CommonFromAPIModel(ctx, &baseModel.BaseRepositoryDataSourceModel, apiModel.BaseRepositoryAPIModel)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	// Convert remote-specific fields
+	baseModel.URL = types.StringValue(apiModel.URL)
+	baseModel.Username = types.StringValue(apiModel.Username)
+	baseModel.Password = types.StringValue(apiModel.Password)
+	baseModel.Proxy = types.StringValue(apiModel.Proxy)
+	baseModel.DisableProxy = types.BoolValue(apiModel.DisableProxy)
+	baseModel.RemoteRepoLayoutRef = types.StringValue(apiModel.RemoteRepoLayoutRef)
+	if apiModel.HardFail != nil {
+		baseModel.HardFail = types.BoolValue(*apiModel.HardFail)
+	} else {
+		baseModel.HardFail = types.BoolNull()
+	}
+	if apiModel.Offline != nil {
+		baseModel.Offline = types.BoolValue(*apiModel.Offline)
+	} else {
+		baseModel.Offline = types.BoolNull()
+	}
+	baseModel.QueryParams = types.StringValue(apiModel.QueryParams)
+	if apiModel.StoreArtifactsLocally != nil {
+		baseModel.StoreArtifactsLocally = types.BoolValue(*apiModel.StoreArtifactsLocally)
+	} else {
+		baseModel.StoreArtifactsLocally = types.BoolNull()
+	}
+	baseModel.SocketTimeoutMillis = types.Int64Value(apiModel.SocketTimeoutMillis)
+	baseModel.LocalAddress = types.StringValue(apiModel.LocalAddress)
+	baseModel.RetrievalCachePeriodSecs = types.Int64Value(apiModel.RetrievalCachePeriodSecs)
+	baseModel.MissedRetrievalCachePeriodSecs = types.Int64Value(apiModel.MissedRetrievalCachePeriodSecs)
+	baseModel.MetadataRetrievalTimeoutSecs = types.Int64Value(apiModel.MetadataRetrievalTimeoutSecs)
+	baseModel.UnusedArtifactsCleanupPeriodHours = types.Int64Value(apiModel.UnusedArtifactsCleanupPeriodHours)
+	baseModel.AssumedOfflinePeriodSecs = types.Int64Value(apiModel.AssumedOfflinePeriodSecs)
+	if apiModel.ShareConfiguration != nil {
+		baseModel.ShareConfiguration = types.BoolValue(*apiModel.ShareConfiguration)
+	} else {
+		baseModel.ShareConfiguration = types.BoolNull()
+	}
+	if apiModel.SynchronizeProperties != nil {
+		baseModel.SynchronizeProperties = types.BoolValue(*apiModel.SynchronizeProperties)
+	} else {
+		baseModel.SynchronizeProperties = types.BoolNull()
+	}
+	if apiModel.BlockMismatchingMimeTypes != nil {
+		baseModel.BlockMismatchingMimeTypes = types.BoolValue(*apiModel.BlockMismatchingMimeTypes)
+	} else {
+		baseModel.BlockMismatchingMimeTypes = types.BoolNull()
+	}
+	if apiModel.AllowAnyHostAuth != nil {
+		baseModel.AllowAnyHostAuth = types.BoolValue(*apiModel.AllowAnyHostAuth)
+	} else {
+		baseModel.AllowAnyHostAuth = types.BoolNull()
+	}
+	if apiModel.EnableCookieManagement != nil {
+		baseModel.EnableCookieManagement = types.BoolValue(*apiModel.EnableCookieManagement)
+	} else {
+		baseModel.EnableCookieManagement = types.BoolNull()
+	}
+	if apiModel.BypassHeadRequests != nil {
+		baseModel.BypassHeadRequests = types.BoolValue(*apiModel.BypassHeadRequests)
+	} else {
+		baseModel.BypassHeadRequests = types.BoolNull()
+	}
+	baseModel.ClientTLSCertificate = types.StringValue(apiModel.ClientTLSCertificate)
+	baseModel.MismatchingMimeTypeOverrideList = types.StringValue(apiModel.MismatchingMimeTypeOverrideList)
+	baseModel.ListRemoteFolderItems = types.BoolValue(apiModel.ListRemoteFolderItems)
+	baseModel.DisableURLNormalization = types.BoolValue(apiModel.DisableURLNormalization)
+
+	return diags
+}
+
+// SDKv2 types and functions
+
+var getSchema = func(schemas map[int16]map[string]*sdkv2_schema.Schema) map[string]*sdkv2_schema.Schema {
 	s := schemas[remote.CurrentSchemaVersion]
 
 	s["url"].Required = false
@@ -15,16 +264,16 @@ var getSchema = func(schemas map[int16]map[string]*schema.Schema) map[string]*sc
 	return s
 }
 
-var VcsRemoteRepoSchemaSDKv2 = map[string]*schema.Schema{
+var VcsRemoteRepoSchemaSDKv2 = map[string]*sdkv2_schema.Schema{
 	"vcs_git_provider": {
-		Type:             schema.TypeString,
+		Type:             sdkv2_schema.TypeString,
 		Optional:         true,
 		Default:          "GITHUB",
 		ValidateDiagFunc: validation.ToDiagFunc(validation.StringInSlice([]string{"GITHUB", "BITBUCKET", "OLDSTASH", "STASH", "ARTIFACTORY", "CUSTOM"}, false)),
 		Description:      `Artifactory supports proxying the following Git providers out-of-the-box: GitHub or a remote Artifactory instance. Default value is "GITHUB".`,
 	},
 	"vcs_git_download_url": {
-		Type:             schema.TypeString,
+		Type:             sdkv2_schema.TypeString,
 		Optional:         true,
 		ValidateDiagFunc: validation.ToDiagFunc(validation.StringIsNotEmpty),
 		Description:      `This attribute is used when vcs_git_provider is set to 'CUSTOM'. Provided URL will be used as proxy.`,

--- a/pkg/artifactory/datasource/repository/repository.go
+++ b/pkg/artifactory/datasource/repository/repository.go
@@ -4,13 +4,140 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/jfrog/terraform-provider-shared/util"
-
-	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
-	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	sdkv2_diag "github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	sdkv2_schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/packer"
+	"github.com/jfrog/terraform-provider-shared/util"
 )
+
+// Framework types and functions
+
+// BaseRepositoryDataSourceModel contains common fields for all repository data sources
+type BaseRepositoryDataSourceModel struct {
+	Key                 types.String `tfsdk:"key"`
+	ProjectKey          types.String `tfsdk:"project_key"`
+	ProjectEnvironments types.Set    `tfsdk:"project_environments"`
+	Description         types.String `tfsdk:"description"`
+	Notes               types.String `tfsdk:"notes"`
+	IncludesPattern     types.String `tfsdk:"includes_pattern"`
+	ExcludesPattern     types.String `tfsdk:"excludes_pattern"`
+	RepoLayoutRef       types.String `tfsdk:"repo_layout_ref"`
+	PackageType         types.String `tfsdk:"package_type"`
+}
+
+// BaseRepositoryAPIModel contains common fields for all repository API models
+// This is a helper type for conversion - actual API models embed resource repository.BaseAPIModel
+type BaseRepositoryAPIModel struct {
+	Key                 string
+	ProjectKey          string
+	ProjectEnvironments []string
+	Description         string
+	Notes               string
+	IncludesPattern     string
+	ExcludesPattern     string
+	RepoLayoutRef       string
+	PackageType         string
+}
+
+// BaseDataSourceAttributes defines the common attributes for all repository datasources
+var BaseDataSourceAttributes = map[string]schema.Attribute{
+	"key": schema.StringAttribute{
+		Required:            true,
+		MarkdownDescription: "A mandatory identifier for the repository that must be unique. Must be 1 - 64 alphanumeric and hyphen characters. It cannot contain spaces or special characters.",
+	},
+	"project_key": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "Project key for assigning this repository to. Must be 2 - 32 lowercase alphanumeric and hyphen characters.",
+	},
+	"project_environments": schema.SetAttribute{
+		ElementType:         types.StringType,
+		Computed:            true,
+		MarkdownDescription: "Project environments.",
+	},
+	"description": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "Public description.",
+	},
+	"notes": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "Internal description.",
+	},
+	"includes_pattern": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "List of comma-separated artifact patterns to include when evaluating artifact requests.",
+	},
+	"excludes_pattern": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "List of artifact patterns to exclude when evaluating artifact requests.",
+	},
+	"repo_layout_ref": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "Sets the layout that the repository should use for storing and identifying modules.",
+	},
+	"package_type": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "Package type.",
+	},
+}
+
+// CommonFromAPIModel provides common conversion logic from API model to Terraform model for repositories
+func CommonFromAPIModel(ctx context.Context, baseModel *BaseRepositoryDataSourceModel, apiModel BaseRepositoryAPIModel) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	// Base fields
+	baseModel.Key = types.StringValue(apiModel.Key)
+	baseModel.ProjectKey = types.StringValue(apiModel.ProjectKey)
+	baseModel.Description = types.StringValue(apiModel.Description)
+	baseModel.Notes = types.StringValue(apiModel.Notes)
+	baseModel.IncludesPattern = types.StringValue(apiModel.IncludesPattern)
+	baseModel.ExcludesPattern = types.StringValue(apiModel.ExcludesPattern)
+	baseModel.RepoLayoutRef = types.StringValue(apiModel.RepoLayoutRef)
+	baseModel.PackageType = types.StringValue(apiModel.PackageType)
+
+	// Project environments
+	var projectEnvironments []types.String
+	for _, env := range apiModel.ProjectEnvironments {
+		projectEnvironments = append(projectEnvironments, types.StringValue(env))
+	}
+	if len(projectEnvironments) > 0 {
+		envSet, d := types.SetValueFrom(ctx, types.StringType, projectEnvironments)
+		if d.HasError() {
+			diags.Append(d...)
+			return diags
+		}
+		baseModel.ProjectEnvironments = envSet
+	} else {
+		baseModel.ProjectEnvironments = types.SetNull(types.StringType)
+	}
+
+	return diags
+}
+
+// HexDataSourceAttributes defines the Hex-specific attributes for Hex repository datasources
+var HexDataSourceAttributes = map[string]schema.Attribute{
+	"hex_primary_keypair_ref": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "Select the RSA key pair to sign and encrypt content for secure communication between Artifactory and the Mix client.",
+	},
+}
+
+// HexRemoteDataSourceAttributes defines the Hex-specific attributes for remote Hex repository datasources
+var HexRemoteDataSourceAttributes = map[string]schema.Attribute{
+	"hex_primary_keypair_ref": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "Select the RSA key pair to sign and encrypt content for secure communication between Artifactory and the Mix client.",
+	},
+	"public_key": schema.StringAttribute{
+		Computed:            true,
+		MarkdownDescription: "Contains the public key used when downloading packages from the Hex remote registry (public, private, or self-hosted Hex server).",
+	},
+}
+
+// SDKv2 types and functions
 
 var validRepositoryTypes = []string{"local", "remote", "virtual", "federated", "distribution"}
 var validPackageTypes = []string{
@@ -31,6 +158,7 @@ var validPackageTypes = []string{
 	repository.GoPackageType,
 	repository.GradlePackageType,
 	repository.HelmPackageType,
+	repository.HexPackageType,
 	repository.HuggingFacePackageType,
 	repository.IvyPackageType,
 	repository.MavenPackageType,
@@ -49,11 +177,11 @@ var validPackageTypes = []string{
 	repository.VagrantPackageType,
 }
 
-func MkRepoReadDataSource(pack packer.PackFunc, construct repository.Constructor) schema.ReadContextFunc {
-	return func(ctx context.Context, d *schema.ResourceData, m interface{}) diag.Diagnostics {
+func MkRepoReadDataSource(pack packer.PackFunc, construct repository.Constructor) sdkv2_schema.ReadContextFunc {
+	return func(ctx context.Context, d *sdkv2_schema.ResourceData, m interface{}) sdkv2_diag.Diagnostics {
 		repo, err := construct()
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkv2_diag.FromErr(err)
 		}
 
 		key := d.Get("key").(string)
@@ -64,7 +192,7 @@ func MkRepoReadDataSource(pack packer.PackFunc, construct repository.Constructor
 			Get(repository.RepositoriesEndpoint)
 
 		if err != nil {
-			return diag.FromErr(err)
+			return sdkv2_diag.FromErr(err)
 		}
 
 		if resp.StatusCode() == http.StatusBadRequest || resp.StatusCode() == http.StatusNotFound {
@@ -73,11 +201,11 @@ func MkRepoReadDataSource(pack packer.PackFunc, construct repository.Constructor
 		}
 
 		if resp.IsError() {
-			return diag.Errorf("%s", resp.String())
+			return sdkv2_diag.Errorf("%s", resp.String())
 		}
 
 		d.SetId(key)
 
-		return diag.FromErr(pack(repo, d))
+		return sdkv2_diag.FromErr(pack(repo, d))
 	}
 }

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_hex_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_hex_repository.go
@@ -1,0 +1,153 @@
+package virtual
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	datasource_repository "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/datasource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/util"
+	"github.com/samber/lo"
+)
+
+var _ datasource.DataSource = &VirtualHexRepositoryDataSource{}
+
+func NewVirtualHexRepositoryDataSource() datasource.DataSource {
+	return &VirtualHexRepositoryDataSource{}
+}
+
+type VirtualHexRepositoryDataSource struct {
+	ProviderData util.ProviderMetadata
+}
+
+type VirtualHexRepositoryDataSourceModel struct {
+	Key                  types.String `tfsdk:"key"`
+	ProjectKey           types.String `tfsdk:"project_key"`
+	ProjectEnvironments  types.Set    `tfsdk:"project_environments"`
+	Description          types.String `tfsdk:"description"`
+	Notes                types.String `tfsdk:"notes"`
+	IncludesPattern      types.String `tfsdk:"includes_pattern"`
+	ExcludesPattern      types.String `tfsdk:"excludes_pattern"`
+	PackageType          types.String `tfsdk:"package_type"`
+	RepoLayoutRef        types.String `tfsdk:"repo_layout_ref"`
+	HexPrimaryKeyPairRef types.String `tfsdk:"hex_primary_keypair_ref"`
+}
+
+type VirtualHexRepositoryAPIModel struct {
+	virtual.VirtualAPIModel
+	HexPrimaryKeyPairRef string `json:"primaryKeyPairRef"`
+}
+
+func (d *VirtualHexRepositoryDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "artifactory_virtual_hex_repository"
+}
+
+func (d *VirtualHexRepositoryDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	attributes := lo.Assign(
+		VirtualDataSourceAttributes,
+		datasource_repository.HexDataSourceAttributes,
+	)
+
+	resp.Schema = schema.Schema{
+		Attributes:  attributes,
+		Description: "Provides a data source for a virtual Hex repository",
+	}
+}
+
+func (d *VirtualHexRepositoryDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	d.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+func (d *VirtualHexRepositoryDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data VirtualHexRepositoryDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var apiModel VirtualHexRepositoryAPIModel
+	var jfrogErrors util.JFrogErrors
+
+	response, err := d.ProviderData.Client.R().
+		SetPathParam("key", data.Key.ValueString()).
+		SetResult(&apiModel).
+		SetError(&jfrogErrors).
+		Get(repository.RepositoriesEndpoint)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while fetching the data source. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+err.Error(),
+		)
+		return
+	}
+
+	if response.StatusCode() == http.StatusBadRequest || response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while fetching the data source. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+jfrogErrors.String(),
+		)
+		return
+	}
+
+	// Convert from API model to Terraform model
+	data.FromAPIModel(ctx, &apiModel)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (m *VirtualHexRepositoryDataSourceModel) FromAPIModel(ctx context.Context, apiModel *VirtualHexRepositoryAPIModel) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	// Base fields
+	m.Key = types.StringValue(apiModel.VirtualAPIModel.Key)
+	m.ProjectKey = types.StringValue(apiModel.VirtualAPIModel.ProjectKey)
+	m.Description = types.StringValue(apiModel.VirtualAPIModel.Description)
+	m.Notes = types.StringValue(apiModel.VirtualAPIModel.Notes)
+	m.IncludesPattern = types.StringValue(apiModel.VirtualAPIModel.IncludesPattern)
+	m.ExcludesPattern = types.StringValue(apiModel.VirtualAPIModel.ExcludesPattern)
+	m.PackageType = types.StringValue(repository.HexPackageType)
+	m.RepoLayoutRef = types.StringValue(apiModel.VirtualAPIModel.RepoLayoutRef)
+
+	// Hex-specific field
+	m.HexPrimaryKeyPairRef = types.StringValue(apiModel.HexPrimaryKeyPairRef)
+
+	// Project environments
+	var projectEnvironments []types.String
+	for _, env := range apiModel.VirtualAPIModel.ProjectEnvironments {
+		projectEnvironments = append(projectEnvironments, types.StringValue(env))
+	}
+	if len(projectEnvironments) > 0 {
+		envSet, d := types.SetValueFrom(ctx, types.StringType, projectEnvironments)
+		if d.HasError() {
+			diags.Append(d...)
+			return diags
+		}
+		m.ProjectEnvironments = envSet
+	} else {
+		m.ProjectEnvironments = types.SetNull(types.StringType)
+	}
+
+	return diags
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_hex_repository_test.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_hex_repository_test.go
@@ -1,0 +1,99 @@
+package virtual_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/security"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccDataSourceVirtualHexRepository(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-virtual-test-repo-basic", "data.artifactory_virtual_hex_repository")
+	kpId, _, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+	kpFqrn := "artifactory_keypair." + kpName
+	virtualRepositoryBasic := util.ExecuteTemplate("keypair", `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+			lifecycle {
+				ignore_changes = [
+					private_key,
+					passphrase,
+				]
+			}
+		}
+
+		resource "artifactory_local_hex_repository" "local-hex" {
+			key                     = "{{ .repo_name }}-local"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			depends_on              = [artifactory_keypair.{{ .kp_name }}]
+		}
+
+		resource "artifactory_remote_hex_repository" "remote-hex" {
+			key                     = "{{ .repo_name }}-remote"
+			url                     = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key              = <<EOF
+{{ .public_key }}
+EOF
+			depends_on              = [artifactory_keypair.{{ .kp_name }}]
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key                     = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			repositories            = [
+				artifactory_local_hex_repository.local-hex.key,
+				artifactory_remote_hex_repository.remote-hex.key
+			]
+			depends_on              = [
+				artifactory_keypair.{{ .kp_name }},
+				artifactory_local_hex_repository.local-hex,
+				artifactory_remote_hex_repository.remote-hex
+			]
+		}
+
+		data "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = artifactory_virtual_hex_repository.{{ .repo_name }}.key
+		}
+	`, map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: virtualRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "hex"),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string { r, _ := repository.GetDefaultRepoLayoutRef(virtual.Rclass, "hex"); return r }()),
+				),
+			},
+		},
+	})
+}

--- a/pkg/artifactory/datasource/repository/virtual/virtual.go
+++ b/pkg/artifactory/datasource/repository/virtual/virtual.go
@@ -1,0 +1,13 @@
+package virtual
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	datasource_repository "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/datasource/repository"
+	"github.com/samber/lo"
+)
+
+// VirtualDataSourceAttributes defines the attributes for virtual repository datasources
+var VirtualDataSourceAttributes = lo.Assign(
+	datasource_repository.BaseDataSourceAttributes,
+	map[string]schema.Attribute{},
+)

--- a/pkg/artifactory/provider/framework.go
+++ b/pkg/artifactory/provider/framework.go
@@ -16,6 +16,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	datasource_artifact "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/datasource/artifact"
 	datasource_repository "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/datasource/repository"
+	datasource_local "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/datasource/repository/local"
+	datasource_remote "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/datasource/repository/remote"
+	datasource_virtual "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/datasource/repository/virtual"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/artifact"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/configuration"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/lifecycle"
@@ -23,6 +26,7 @@ import (
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/local"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/remote"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/virtual"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/security"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/user"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/webhook"
@@ -277,6 +281,7 @@ func (p *ArtifactoryProvider) Resources(ctx context.Context) []func() resource.R
 			local.NewDockerV1LocalRepositoryResource,
 			local.NewHelmLocalRepositoryResource,
 			local.NewHelmOCILocalRepositoryResource,
+			local.NewHexLocalRepositoryResource,
 			local.NewMachineLearningLocalRepositoryResource,
 			local.NewNugetLocalRepositoryResource,
 			local.NewOCILocalRepositoryResource,
@@ -296,6 +301,7 @@ func (p *ArtifactoryProvider) Resources(ctx context.Context) []func() resource.R
 			remote.NewGradleRemoteRepositoryResource,
 			remote.NewHelmRemoteRepositoryResource,
 			remote.NewHelmOCIRemoteRepositoryResource,
+			remote.NewHexRemoteRepositoryResource,
 			remote.NewHuggingFaceMLRemoteRepositoryResource,
 			remote.NewJavaRemoteRepositoryResource(repository.IvyPackageType, true),
 			remote.NewMavenRemoteRepositoryResource,
@@ -330,6 +336,7 @@ func (p *ArtifactoryProvider) Resources(ctx context.Context) []func() resource.R
 			webhook.NewReleaseBundleV2PromotionCustomWebhookResource,
 			webhook.NewUserWebhookResource,
 			webhook.NewUserCustomWebhookResource,
+			virtual.NewHexVirtualRepositoryResource,
 		}...,
 	)
 }
@@ -339,6 +346,9 @@ func (p *ArtifactoryProvider) DataSources(_ context.Context) []func() datasource
 	return []func() datasource.DataSource{
 		datasource_repository.NewRepositoriesDataSource,
 		datasource_artifact.NewFileListDataSource,
+		datasource_local.NewLocalHexRepositoryDataSource,
+		datasource_remote.NewRemoteHexRepositoryDataSource,
+		datasource_virtual.NewVirtualHexRepositoryDataSource,
 	}
 }
 

--- a/pkg/artifactory/resource/repository/default_repo_layout_map.go
+++ b/pkg/artifactory/resource/repository/default_repo_layout_map.go
@@ -172,6 +172,14 @@ var defaultRepoLayoutMap = map[string]SupportedRepoClasses{
 			"federated": true,
 		},
 	},
+	HexPackageType: {
+		RepoLayoutRef: "simple-default",
+		SupportedRepoTypes: map[string]bool{
+			"local":   true,
+			"remote":  true,
+			"virtual": true,
+		},
+	},
 	HuggingFacePackageType: {
 		RepoLayoutRef: "simple-default",
 		SupportedRepoTypes: map[string]bool{

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_hex_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_hex_repository.go
@@ -1,0 +1,121 @@
+package local
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/samber/lo"
+)
+
+func NewHexLocalRepositoryResource() resource.Resource {
+	return &localHexResource{
+		localResource: NewLocalRepositoryResource(
+			repository.HexPackageType,
+			repository.PackageNameLookup[repository.HexPackageType],
+			reflect.TypeFor[LocalHexResourceModel](),
+			reflect.TypeFor[LocalHexAPIModel](),
+		),
+	}
+}
+
+type localHexResource struct {
+	localResource
+}
+
+type LocalHexResourceModel struct {
+	LocalResourceModel
+	HexPrimaryKeyPairRef types.String `tfsdk:"hex_primary_keypair_ref"`
+}
+
+func (r *LocalHexResourceModel) GetCreateResourcePlanData(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, r)...)
+}
+
+func (r LocalHexResourceModel) SetCreateResourceStateData(ctx context.Context, resp *resource.CreateResponse) {
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r *LocalHexResourceModel) GetReadResourceStateData(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Read Terraform state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, r)...)
+}
+
+func (r LocalHexResourceModel) SetReadResourceStateData(ctx context.Context, resp *resource.ReadResponse) {
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r *LocalHexResourceModel) GetUpdateResourcePlanData(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, r)...)
+}
+
+func (r *LocalHexResourceModel) GetUpdateResourceStateData(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Read Terraform state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, r)...)
+}
+
+func (r LocalHexResourceModel) SetUpdateResourceStateData(ctx context.Context, resp *resource.UpdateResponse) {
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r LocalHexResourceModel) ToAPIModel(ctx context.Context, packageType string) (interface{}, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	model, d := r.LocalResourceModel.ToAPIModel(ctx, packageType)
+	if d != nil {
+		diags.Append(d...)
+	}
+
+	localAPIModel := model.(LocalAPIModel)
+	localAPIModel.RepoLayoutRef = r.RepoLayoutRef.ValueString()
+
+	return LocalHexAPIModel{
+		LocalAPIModel:        localAPIModel,
+		HexPrimaryKeyPairRef: r.HexPrimaryKeyPairRef.ValueString(),
+	}, diags
+}
+
+func (r *LocalHexResourceModel) FromAPIModel(ctx context.Context, apiModel interface{}) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	model := apiModel.(*LocalHexAPIModel)
+
+	r.LocalResourceModel.FromAPIModel(ctx, model.LocalAPIModel)
+	r.RepoLayoutRef = types.StringValue(model.RepoLayoutRef)
+	r.HexPrimaryKeyPairRef = types.StringValue(model.HexPrimaryKeyPairRef)
+
+	return diags
+}
+
+type LocalHexAPIModel struct {
+	LocalAPIModel
+	HexPrimaryKeyPairRef string `json:"primaryKeyPairRef"`
+}
+
+func (r *localHexResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	attributes := lo.Assign(
+		LocalAttributes,
+		repository.RepoLayoutRefAttribute(r.Rclass, r.PackageType),
+		map[string]schema.Attribute{
+			"hex_primary_keypair_ref": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Select the RSA key pair to sign and encrypt content for secure communication between Artifactory and the Mix client.",
+			},
+		},
+	)
+
+	resp.Schema = schema.Schema{
+		Version:     CurrentSchemaVersion,
+		Attributes:  attributes,
+		Description: r.Description,
+	}
+}

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_hex_repository_test.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_hex_repository_test.go
@@ -1,0 +1,546 @@
+package local_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/security"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccLocalHexRepository_full(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-local-test-repo", "artifactory_local_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			description = "Test repository for Hex"
+			notes = "Internal notes"
+			includes_pattern = "**/*"
+			excludes_pattern = ""
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccLocalHexRepository_full", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			description = "Updated description"
+			notes = "Updated notes"
+			includes_pattern = "**/*"
+			excludes_pattern = "*.tmp"
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccLocalHexRepository_full", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "description", "Test repository for Hex"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Internal notes"),
+					resource.TestCheckResourceAttr(fqrn, "includes_pattern", "**/*"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", ""),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("local", repository.HexPackageType)
+						return r
+					}()), //Check to ensure repository layout is set as per default even when it is not passed.
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "description", "Updated description"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Updated notes"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", "*.tmp"),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+			},
+		},
+	})
+}
+
+func TestAccLocalHexRepository_basic(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-local", "artifactory_local_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccLocalHexRepository_basic", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("local", repository.HexPackageType)
+						return r
+					}()),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+			},
+		},
+	})
+}
+
+func TestAccLocalHexRepository_missingKeyPairRef(t *testing.T) {
+	_, _, name := testutil.MkNames("hex-local", "artifactory_local_hex_repository")
+
+	temp := `
+		resource "artifactory_local_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+		}
+	`
+
+	testData := map[string]interface{}{
+		"repo_name": name,
+	}
+
+	config := util.ExecuteTemplate("TestAccLocalHexRepository_missingKeyPairRef", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`(?s).*(Missing required argument|The argument.*is required|no definition was found).*hex_primary_keypair_ref.*`),
+			},
+		},
+	})
+}
+
+func TestAccLocalHexRepository_updateKeyPairRef(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-local", "artifactory_local_hex_repository")
+	kpId1, kpFqrn1, kpName1 := testutil.MkNames("keypair1", "artifactory_keypair")
+	kpId2, kpFqrn2, kpName2 := testutil.MkNames("keypair2", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name1 }}" {
+			pair_name  = "{{ .kp_name1 }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id1 }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_keypair" "{{ .kp_name2 }}" {
+			pair_name  = "{{ .kp_name2 }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id2 }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name1 }}.pair_name
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id1":      kpId1,
+		"kp_name1":    kpName1,
+		"kp_id2":      kpId2,
+		"kp_name2":    kpName2,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccLocalHexRepository_updateKeyPairRef", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_keypair" "{{ .kp_name1 }}" {
+			pair_name  = "{{ .kp_name1 }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id1 }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_keypair" "{{ .kp_name2 }}" {
+			pair_name  = "{{ .kp_name2 }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id2 }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name2 }}.pair_name
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccLocalHexRepository_updateKeyPairRef", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn1, "pair_name", security.VerifyKeyPair),
+			acctest.VerifyDeleted(t, kpFqrn2, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName1),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLocalHexRepository_withProject(t *testing.T) {
+	projectKey := fmt.Sprintf("t%d", testutil.RandomInt())
+	repoName := fmt.Sprintf("%s-hex-local", projectKey)
+	_, fqrn, name := testutil.MkNames(repoName, "artifactory_local_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			project_key = "{{ .project_key }}"
+			project_environments = ["DEV", "PROD"]
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"project_key": projectKey,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccLocalHexRepository_withProject", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			project_key = "{{ .project_key }}"
+			project_environments = ["DEV"]
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccLocalHexRepository_withProject", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.CreateProject(t, projectKey)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+			func(state *terraform.State) error {
+				acctest.DeleteProject(t, projectKey)
+				return nil
+			},
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "project_key", projectKey),
+					resource.TestCheckResourceAttr(fqrn, "project_environments.#", "2"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "project_environments.#", "1"),
+					resource.TestCheckResourceAttr(fqrn, "project_environments.0", "DEV"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccLocalHexRepository_allFields(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-local", "artifactory_local_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			description = "Test description"
+			notes = "Test notes"
+			includes_pattern = "**/*"
+			excludes_pattern = "*.tmp"
+			repo_layout_ref = "simple-default"
+			blacked_out = false
+			xray_index = true
+			priority_resolution = false
+			archive_browsing_enabled = true
+			download_direct = false
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccLocalHexRepository_allFields", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "description", "Test description"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Test notes"),
+					resource.TestCheckResourceAttr(fqrn, "includes_pattern", "**/*"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", "*.tmp"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", "simple-default"),
+					resource.TestCheckResourceAttr(fqrn, "blacked_out", "false"),
+					resource.TestCheckResourceAttr(fqrn, "xray_index", "true"),
+					resource.TestCheckResourceAttr(fqrn, "priority_resolution", "false"),
+					resource.TestCheckResourceAttr(fqrn, "archive_browsing_enabled", "true"),
+					resource.TestCheckResourceAttr(fqrn, "download_direct", "false"),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+			},
+		},
+	})
+}
+
+func TestAccLocalHexRepository_invalidKey(t *testing.T) {
+	_, _, name := testutil.MkNames("hex-local", "artifactory_local_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	// Skip if keypair env vars are not set
+	privateKey := os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY")
+	publicKey := os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY")
+	if privateKey == "" || publicKey == "" {
+		t.Skip("JFROG_TEST_RSA_PRIVATE_KEY and JFROG_TEST_RSA_PUBLIC_KEY must be set for this test")
+	}
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .invalid_key }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"invalid_key": "invalid key with spaces",
+		"private_key": privateKey,
+		"public_key":  publicKey,
+	}
+
+	config := util.ExecuteTemplate("TestAccLocalHexRepository_invalidKey", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`.*(invalid|cannot contain spaces|must not contain).*key.*`),
+			},
+		},
+	})
+}

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_hex_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_hex_repository.go
@@ -1,0 +1,128 @@
+package remote
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/samber/lo"
+)
+
+func NewHexRemoteRepositoryResource() resource.Resource {
+	return &remoteHexResource{
+		remoteResource: NewRemoteRepositoryResource(
+			repository.HexPackageType,
+			repository.PackageNameLookup[repository.HexPackageType],
+			reflect.TypeFor[remoteHexResourceModel](),
+			reflect.TypeFor[RemoteHexAPIModel](),
+		),
+	}
+}
+
+type remoteHexResource struct {
+	remoteResource
+}
+
+type remoteHexResourceModel struct {
+	RemoteResourceModel
+	HexPrimaryKeyPairRef types.String `tfsdk:"hex_primary_keypair_ref"`
+	PublicKey            types.String `tfsdk:"public_key"`
+}
+
+func (r *remoteHexResourceModel) GetCreateResourcePlanData(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, r)...)
+}
+
+func (r remoteHexResourceModel) SetCreateResourceStateData(ctx context.Context, resp *resource.CreateResponse) {
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r *remoteHexResourceModel) GetReadResourceStateData(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Read Terraform state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, r)...)
+}
+
+func (r remoteHexResourceModel) SetReadResourceStateData(ctx context.Context, resp *resource.ReadResponse) {
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r *remoteHexResourceModel) GetUpdateResourcePlanData(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, r)...)
+}
+
+func (r *remoteHexResourceModel) GetUpdateResourceStateData(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Read Terraform state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, r)...)
+}
+
+func (r remoteHexResourceModel) SetUpdateResourceStateData(ctx context.Context, resp *resource.UpdateResponse) {
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r remoteHexResourceModel) ToAPIModel(ctx context.Context, packageType string) (interface{}, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	remoteAPIModel, d := r.RemoteResourceModel.ToAPIModel(ctx, packageType)
+	if d != nil {
+		diags.Append(d...)
+	}
+
+	return RemoteHexAPIModel{
+		RemoteAPIModel:       remoteAPIModel,
+		HexPrimaryKeyPairRef: r.HexPrimaryKeyPairRef.ValueString(),
+		PublicKey:            r.PublicKey.ValueString(),
+	}, diags
+}
+
+func (r *remoteHexResourceModel) FromAPIModel(ctx context.Context, apiModel interface{}) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	model := apiModel.(*RemoteHexAPIModel)
+
+	r.RemoteResourceModel.FromAPIModel(ctx, model.RemoteAPIModel)
+
+	r.RepoLayoutRef = types.StringValue(model.RepoLayoutRef)
+	r.HexPrimaryKeyPairRef = types.StringValue(model.HexPrimaryKeyPairRef)
+	r.PublicKey = types.StringValue(model.PublicKey)
+
+	return diags
+}
+
+type RemoteHexAPIModel struct {
+	RemoteAPIModel
+	HexPrimaryKeyPairRef string `json:"primaryKeyPairRef"`
+	PublicKey            string `json:"hexPublicKey"`
+}
+
+func (r *remoteHexResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	remoteHexAttributes := lo.Assign(
+		RemoteAttributes,
+		repository.RepoLayoutRefAttribute(Rclass, r.PackageType),
+		map[string]schema.Attribute{
+			"hex_primary_keypair_ref": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Select the RSA key pair to sign and encrypt content for secure communication between Artifactory and the Mix client.",
+			},
+			"public_key": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Contains the public key used when downloading packages from the Hex remote registry (public, private, or self-hosted Hex server).",
+			},
+		},
+	)
+
+	resp.Schema = schema.Schema{
+		Version:     CurrentSchemaVersion,
+		Attributes:  remoteHexAttributes,
+		Blocks:      remoteBlocks,
+		Description: r.Description,
+	}
+}

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_hex_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_hex_repository_test.go
@@ -1,0 +1,838 @@
+package remote_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/security"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccRemoteHexRepository_full(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-remote-test-repo", "artifactory_remote_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+			description = "Test repository for Hex"
+			notes = "Internal notes"
+			includes_pattern = "**/*"
+			excludes_pattern = ""
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteHexRepository_full", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+			description = "Updated description"
+			notes = "Updated notes"
+			includes_pattern = "**/*"
+			excludes_pattern = "*.tmp"
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccRemoteHexRepository_full", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "url", "https://repo.hex.pm"),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttrSet(fqrn, "public_key"),
+					resource.TestCheckResourceAttr(fqrn, "description", "Test repository for Hex"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Internal notes"),
+					resource.TestCheckResourceAttr(fqrn, "includes_pattern", "**/*"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", ""),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("remote", repository.HexPackageType)
+						return r
+					}()),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "description", "Updated description"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Updated notes"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", "*.tmp"),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+				ImportStateVerifyIgnore:              []string{"password", "public_key"},
+			},
+		},
+	})
+}
+
+func TestAccRemoteHexRepository_basic(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-remote", "artifactory_remote_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteHexRepository_basic", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "url", "https://repo.hex.pm"),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttrSet(fqrn, "public_key"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("remote", repository.HexPackageType)
+						return r
+					}()),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+				ImportStateVerifyIgnore:              []string{"password", "public_key"},
+			},
+		},
+	})
+}
+
+func TestAccRemoteHexRepository_missingKeyPairRef(t *testing.T) {
+	_, _, name := testutil.MkNames("hex-remote", "artifactory_remote_hex_repository")
+
+	temp := `
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://repo.hex.pm"
+			public_key = "test-public-key"
+		}
+	`
+
+	testData := map[string]interface{}{
+		"repo_name": name,
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteHexRepository_missingKeyPairRef", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`(?s).*(Missing required argument|The argument.*is required|no definition was found).*hex_primary_keypair_ref.*`),
+			},
+		},
+	})
+}
+
+func TestAccRemoteHexRepository_missingPublicKey(t *testing.T) {
+	_, _, name := testutil.MkNames("hex-remote", "artifactory_remote_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteHexRepository_missingPublicKey", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`(?s).*(Missing required argument|The argument.*is required|no definition was found).*public_key.*`),
+			},
+		},
+	})
+}
+
+func TestAccRemoteHexRepository_missingURL(t *testing.T) {
+	_, _, name := testutil.MkNames("hex-remote", "artifactory_remote_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteHexRepository_missingURL", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`(?s).*(Missing required argument|The argument.*is required|no definition was found).*url.*`),
+			},
+		},
+	})
+}
+
+func TestAccRemoteHexRepository_updateKeyPairRef(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-remote", "artifactory_remote_hex_repository")
+	kpId1, kpFqrn1, kpName1 := testutil.MkNames("keypair1", "artifactory_keypair")
+	kpId2, kpFqrn2, kpName2 := testutil.MkNames("keypair2", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name1 }}" {
+			pair_name  = "{{ .kp_name1 }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id1 }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_keypair" "{{ .kp_name2 }}" {
+			pair_name  = "{{ .kp_name2 }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id2 }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name1 }}.pair_name
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id1":      kpId1,
+		"kp_name1":    kpName1,
+		"kp_id2":      kpId2,
+		"kp_name2":    kpName2,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteHexRepository_updateKeyPairRef", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_keypair" "{{ .kp_name1 }}" {
+			pair_name  = "{{ .kp_name1 }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id1 }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_keypair" "{{ .kp_name2 }}" {
+			pair_name  = "{{ .kp_name2 }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id2 }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name2 }}.pair_name
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccRemoteHexRepository_updateKeyPairRef", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn1, "pair_name", security.VerifyKeyPair),
+			acctest.VerifyDeleted(t, kpFqrn2, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName1),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRemoteHexRepository_updatePublicKey(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-remote", "artifactory_remote_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteHexRepository_updatePublicKey", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key = <<EOF
+-----BEGIN PUBLIC KEY-----
+MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEApqREcFDt5vV21JVe2QNB
+Edvzk6w36aNFhVGWN5toNJRjRJ6m4hIuG4KaXtDWVLjnvct6MYMfqhC79HAGwyF+
+IqR6Q6a5bbFSsImgBJwz1oadoVKD6ZNetAuCIK84cjMrEFRkELtEIPNHblCzUkkM
+3rS9+DPlnfG8hBvGi6tvQIuZmXGCxF/73hU0/MyGhbmEjIKRtG6b0sJYKelRLTPW
+XgK7s5pESgiwf2YC/2MGDXjAJfpfCd0RpLdvd4eRiXtVlE9qO9bND94E7PgQ/xqZ
+J1i2xWFndWa6nfFnRxZmCStCOZWYYPlaxr+FZceFbpMwzTNs4g3d4tLNUcbKAIH4
+0wIDAQAB
+-----END PUBLIC KEY-----
+EOF
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccRemoteHexRepository_updatePublicKey", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttrSet(fqrn, "public_key"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttrSet(fqrn, "public_key"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRemoteHexRepository_withProject(t *testing.T) {
+	projectKey := fmt.Sprintf("t%d", testutil.RandomInt())
+	repoName := fmt.Sprintf("%s-hex-remote", projectKey)
+	_, fqrn, name := testutil.MkNames(repoName, "artifactory_remote_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+			project_key = "{{ .project_key }}"
+			project_environments = ["DEV", "PROD"]
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"project_key": projectKey,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteHexRepository_withProject", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+			project_key = "{{ .project_key }}"
+			project_environments = ["DEV"]
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccRemoteHexRepository_withProject", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.CreateProject(t, projectKey)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+			func(state *terraform.State) error {
+				acctest.DeleteProject(t, projectKey)
+				return nil
+			},
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "project_key", projectKey),
+					resource.TestCheckResourceAttr(fqrn, "project_environments.#", "2"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "project_environments.#", "1"),
+					resource.TestCheckResourceAttr(fqrn, "project_environments.0", "DEV"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccRemoteHexRepository_allFields(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-remote", "artifactory_remote_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+			description = "Test description"
+			notes = "Test notes"
+			includes_pattern = "**/*"
+			excludes_pattern = "*.tmp"
+			repo_layout_ref = "simple-default"
+			hard_fail = true
+			offline = false
+			store_artifacts_locally = true
+			socket_timeout_millis = 20000
+			retrieval_cache_period_seconds = 7200
+			missed_cache_period_seconds = 1800
+			synchronize_properties = true
+			block_mismatching_mime_types = true
+			bypass_head_requests = false
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteHexRepository_allFields", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "url", "https://repo.hex.pm"),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttrSet(fqrn, "public_key"),
+					resource.TestCheckResourceAttr(fqrn, "description", "Test description"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Test notes"),
+					resource.TestCheckResourceAttr(fqrn, "includes_pattern", "**/*"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", "*.tmp"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", "simple-default"),
+					resource.TestCheckResourceAttr(fqrn, "hard_fail", "true"),
+					resource.TestCheckResourceAttr(fqrn, "offline", "false"),
+					resource.TestCheckResourceAttr(fqrn, "store_artifacts_locally", "true"),
+					resource.TestCheckResourceAttr(fqrn, "socket_timeout_millis", "20000"),
+					resource.TestCheckResourceAttr(fqrn, "retrieval_cache_period_seconds", "7200"),
+					resource.TestCheckResourceAttr(fqrn, "missed_cache_period_seconds", "1800"),
+					resource.TestCheckResourceAttr(fqrn, "synchronize_properties", "true"),
+					resource.TestCheckResourceAttr(fqrn, "block_mismatching_mime_types", "true"),
+					resource.TestCheckResourceAttr(fqrn, "bypass_head_requests", "false"),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+				ImportStateVerifyIgnore:              []string{"password", "public_key"},
+			},
+		},
+	})
+}
+
+func TestAccRemoteHexRepository_invalidURL(t *testing.T) {
+	_, _, name := testutil.MkNames("hex-remote", "artifactory_remote_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "not-a-valid-url"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteHexRepository_invalidURL", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`(?s).*(invalid|must be a valid URL|Invalid Attribute Value).*url.*`),
+			},
+		},
+	})
+}
+
+func TestAccRemoteHexRepository_invalidKey(t *testing.T) {
+	_, _, name := testutil.MkNames("hex-remote", "artifactory_remote_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_remote_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .invalid_key }}"
+			url = "https://repo.hex.pm"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"invalid_key": "invalid key with spaces",
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteHexRepository_invalidKey", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`.*invalid.*key.*`),
+			},
+		},
+	})
+}

--- a/pkg/artifactory/resource/repository/repository.go
+++ b/pkg/artifactory/resource/repository/repository.go
@@ -60,6 +60,7 @@ const (
 	GradlePackageType            = "gradle"
 	HelmPackageType              = "helm"
 	HelmOCIPackageType           = "helmoci"
+	HexPackageType               = "hex"
 	HuggingFacePackageType       = "huggingfaceml"
 	IvyPackageType               = "ivy"
 	MachineLearningType          = "machinelearning"
@@ -97,6 +98,7 @@ var PackageNameLookup = map[string]string{
 	GoPackageType:               "Go",
 	GradlePackageType:           "Gradle",
 	HelmPackageType:             "Helm",
+	HexPackageType:              "Hex",
 	HuggingFacePackageType:      "HuggingFace ML",
 	IvyPackageType:              "Ivy",
 	NPMPackageType:              "Npm",

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_hex_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_hex_repository.go
@@ -1,0 +1,117 @@
+package virtual
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/samber/lo"
+)
+
+func NewHexVirtualRepositoryResource() resource.Resource {
+	return &virtualHexResource{
+		virtualResource: NewVirtualRepositoryResource(
+			repository.HexPackageType,
+			repository.PackageNameLookup[repository.HexPackageType],
+			reflect.TypeFor[virtualHexResourceModel](),
+			reflect.TypeFor[VirtualHexAPIModel](),
+		),
+	}
+}
+
+type virtualHexResource struct {
+	virtualResource
+}
+
+type virtualHexResourceModel struct {
+	VirtualResourceModel
+	HexPrimaryKeyPairRef types.String `tfsdk:"hex_primary_keypair_ref"`
+}
+
+func (r *virtualHexResourceModel) GetCreateResourcePlanData(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, r)...)
+}
+
+func (r virtualHexResourceModel) SetCreateResourceStateData(ctx context.Context, resp *resource.CreateResponse) {
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r *virtualHexResourceModel) GetReadResourceStateData(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	// Read Terraform state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, r)...)
+}
+
+func (r virtualHexResourceModel) SetReadResourceStateData(ctx context.Context, resp *resource.ReadResponse) {
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r *virtualHexResourceModel) GetUpdateResourcePlanData(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Read Terraform plan data into the model
+	resp.Diagnostics.Append(req.Plan.Get(ctx, r)...)
+}
+
+func (r *virtualHexResourceModel) GetUpdateResourceStateData(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	// Read Terraform state data into the model
+	resp.Diagnostics.Append(req.State.Get(ctx, r)...)
+}
+
+func (r virtualHexResourceModel) SetUpdateResourceStateData(ctx context.Context, resp *resource.UpdateResponse) {
+	// Save data into Terraform state
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r virtualHexResourceModel) ToAPIModel(ctx context.Context, packageType string) (interface{}, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	virtualAPIModel, d := r.VirtualResourceModel.ToAPIModel(ctx, packageType)
+	if d != nil {
+		diags.Append(d...)
+	}
+
+	return VirtualHexAPIModel{
+		VirtualAPIModel:      virtualAPIModel.(VirtualAPIModel),
+		HexPrimaryKeyPairRef: r.HexPrimaryKeyPairRef.ValueString(),
+	}, diags
+}
+
+func (r *virtualHexResourceModel) FromAPIModel(ctx context.Context, apiModel interface{}) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	model := apiModel.(*VirtualHexAPIModel)
+
+	r.VirtualResourceModel.FromAPIModel(ctx, model.VirtualAPIModel)
+	r.HexPrimaryKeyPairRef = types.StringValue(model.HexPrimaryKeyPairRef)
+
+	return diags
+}
+
+type VirtualHexAPIModel struct {
+	VirtualAPIModel
+	HexPrimaryKeyPairRef string `json:"primaryKeyPairRef"`
+}
+
+func (r *virtualHexResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	virtualHexAttributes := lo.Assign(
+		VirtualAttributes,
+		repository.RepoLayoutRefAttribute(Rclass, r.PackageType),
+		map[string]schema.Attribute{
+			"hex_primary_keypair_ref": schema.StringAttribute{
+				Required:            true,
+				MarkdownDescription: "Select the RSA key pair to sign and encrypt content for secure communication between Artifactory and the Mix client.",
+			},
+		},
+	)
+
+	resp.Schema = schema.Schema{
+		Version:     1,
+		Attributes:  virtualHexAttributes,
+		Description: r.Description,
+	}
+}

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_hex_repository_test.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_hex_repository_test.go
@@ -1,0 +1,837 @@
+package virtual_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/terraform"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/security"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccVirtualHexRepository_full(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-virtual-test-repo", "artifactory_virtual_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+	localRepoName := testutil.RandSelect("local-repo-1", "local-repo-2", "local-repo-3").(string)
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .local_repo_name }}" {
+			key = "{{ .local_repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			repositories = [artifactory_local_hex_repository.{{ .local_repo_name }}.key]
+			description = "Test repository for Hex"
+			notes = "Internal notes"
+			includes_pattern = "**/*"
+			excludes_pattern = ""
+			artifactory_requests_can_retrieve_remote_artifacts = true
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":           kpId,
+		"kp_name":         kpName,
+		"repo_name":       name,
+		"local_repo_name": localRepoName,
+		"private_key":     os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":      os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccVirtualHexRepository_full", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .local_repo_name }}" {
+			key = "{{ .local_repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			repositories = [artifactory_local_hex_repository.{{ .local_repo_name }}.key]
+			description = "Updated description"
+			notes = "Updated notes"
+			includes_pattern = "**/*"
+			excludes_pattern = "*.tmp"
+			artifactory_requests_can_retrieve_remote_artifacts = false
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccVirtualHexRepository_full", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "repositories.#", "1"),
+					resource.TestCheckResourceAttr(fqrn, "description", "Test repository for Hex"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Internal notes"),
+					resource.TestCheckResourceAttr(fqrn, "includes_pattern", "**/*"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", ""),
+					resource.TestCheckResourceAttr(fqrn, "artifactory_requests_can_retrieve_remote_artifacts", "true"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("virtual", repository.HexPackageType)
+						return r
+					}()),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "description", "Updated description"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Updated notes"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", "*.tmp"),
+					resource.TestCheckResourceAttr(fqrn, "artifactory_requests_can_retrieve_remote_artifacts", "false"),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+			},
+		},
+	})
+}
+
+func TestAccVirtualHexRepository_basic(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-virtual", "artifactory_virtual_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			repositories = []
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccVirtualHexRepository_basic", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "repositories.#", "0"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("virtual", repository.HexPackageType)
+						return r
+					}()),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+			},
+		},
+	})
+}
+
+func TestAccVirtualHexRepository_missingKeyPairRef(t *testing.T) {
+	_, _, name := testutil.MkNames("hex-virtual", "artifactory_virtual_hex_repository")
+
+	temp := `
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+		}
+	`
+
+	testData := map[string]interface{}{
+		"repo_name": name,
+	}
+
+	config := util.ExecuteTemplate("TestAccVirtualHexRepository_missingKeyPairRef", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`(?s).*(Missing required argument|The argument.*is required|no definition was found).*hex_primary_keypair_ref.*`),
+			},
+		},
+	})
+}
+
+func TestAccVirtualHexRepository_updateKeyPairRef(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-virtual", "artifactory_virtual_hex_repository")
+	kpId1, kpFqrn1, kpName1 := testutil.MkNames("keypair1", "artifactory_keypair")
+	kpId2, kpFqrn2, kpName2 := testutil.MkNames("keypair2", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name1 }}" {
+			pair_name  = "{{ .kp_name1 }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id1 }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_keypair" "{{ .kp_name2 }}" {
+			pair_name  = "{{ .kp_name2 }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id2 }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name1 }}.pair_name
+			repositories = []
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id1":      kpId1,
+		"kp_name1":    kpName1,
+		"kp_id2":      kpId2,
+		"kp_name2":    kpName2,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccVirtualHexRepository_updateKeyPairRef", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_keypair" "{{ .kp_name1 }}" {
+			pair_name  = "{{ .kp_name1 }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id1 }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_keypair" "{{ .kp_name2 }}" {
+			pair_name  = "{{ .kp_name2 }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id2 }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name2 }}.pair_name
+			repositories = []
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccVirtualHexRepository_updateKeyPairRef", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn1, "pair_name", security.VerifyKeyPair),
+			acctest.VerifyDeleted(t, kpFqrn2, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName1),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName2),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVirtualHexRepository_withRepositories(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-virtual", "artifactory_virtual_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+	localRepoName1 := testutil.RandSelect("local-repo-1", "local-repo-2", "local-repo-3").(string)
+	localRepoName2 := testutil.RandSelect("local-repo-4", "local-repo-5", "local-repo-6").(string)
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .local_repo_name1 }}" {
+			key = "{{ .local_repo_name1 }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .local_repo_name2 }}" {
+			key = "{{ .local_repo_name2 }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			repositories = [
+				artifactory_local_hex_repository.{{ .local_repo_name1 }}.key,
+				artifactory_local_hex_repository.{{ .local_repo_name2 }}.key
+			]
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":            kpId,
+		"kp_name":          kpName,
+		"repo_name":        name,
+		"local_repo_name1": localRepoName1,
+		"local_repo_name2": localRepoName2,
+		"private_key":      os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":       os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccVirtualHexRepository_withRepositories", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .local_repo_name1 }}" {
+			key = "{{ .local_repo_name1 }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .local_repo_name2 }}" {
+			key = "{{ .local_repo_name2 }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			repositories = [artifactory_local_hex_repository.{{ .local_repo_name1 }}.key]
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccVirtualHexRepository_withRepositories", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "repositories.#", "2"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "repositories.#", "1"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVirtualHexRepository_withProject(t *testing.T) {
+	projectKey := fmt.Sprintf("t%d", testutil.RandomInt())
+	repoName := fmt.Sprintf("%s-hex-virtual", projectKey)
+	_, fqrn, name := testutil.MkNames(repoName, "artifactory_virtual_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			repositories = []
+			project_key = "{{ .project_key }}"
+			project_environments = ["DEV", "PROD"]
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"project_key": projectKey,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccVirtualHexRepository_withProject", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			repositories = []
+			project_key = "{{ .project_key }}"
+			project_environments = ["DEV"]
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccVirtualHexRepository_withProject", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			acctest.PreCheck(t)
+			acctest.CreateProject(t, projectKey)
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+			func(state *terraform.State) error {
+				acctest.DeleteProject(t, projectKey)
+				return nil
+			},
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "project_key", projectKey),
+					resource.TestCheckResourceAttr(fqrn, "project_environments.#", "2"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "project_environments.#", "1"),
+					resource.TestCheckResourceAttr(fqrn, "project_environments.0", "DEV"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVirtualHexRepository_allFields(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-virtual", "artifactory_virtual_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+	localRepoName := testutil.RandSelect("local-repo-1", "local-repo-2", "local-repo-3").(string)
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .local_repo_name }}" {
+			key = "{{ .local_repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			repositories = [artifactory_local_hex_repository.{{ .local_repo_name }}.key]
+			description = "Test description"
+			notes = "Test notes"
+			includes_pattern = "**/*"
+			excludes_pattern = "*.tmp"
+			repo_layout_ref = "simple-default"
+			artifactory_requests_can_retrieve_remote_artifacts = true
+			default_deployment_repo = artifactory_local_hex_repository.{{ .local_repo_name }}.key
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":           kpId,
+		"kp_name":         kpName,
+		"repo_name":       name,
+		"local_repo_name": localRepoName,
+		"private_key":     os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":      os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccVirtualHexRepository_allFields", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "repositories.#", "1"),
+					resource.TestCheckResourceAttr(fqrn, "description", "Test description"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Test notes"),
+					resource.TestCheckResourceAttr(fqrn, "includes_pattern", "**/*"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", "*.tmp"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", "simple-default"),
+					resource.TestCheckResourceAttr(fqrn, "artifactory_requests_can_retrieve_remote_artifacts", "true"),
+					resource.TestCheckResourceAttr(fqrn, "default_deployment_repo", localRepoName),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+			},
+		},
+	})
+}
+
+func TestAccVirtualHexRepository_invalidKey(t *testing.T) {
+	_, _, name := testutil.MkNames("hex-virtual", "artifactory_virtual_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .invalid_key }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"invalid_key": "invalid key with spaces",
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccVirtualHexRepository_invalidKey", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config:      config,
+				ExpectError: regexp.MustCompile(`.*invalid.*key.*`),
+			},
+		},
+	})
+}
+
+func TestAccVirtualHexRepository_updateRepositories(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-virtual", "artifactory_virtual_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+	localRepoName1 := testutil.RandSelect("local-repo-1", "local-repo-2", "local-repo-3").(string)
+	localRepoName2 := testutil.RandSelect("local-repo-4", "local-repo-5", "local-repo-6").(string)
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .local_repo_name1 }}" {
+			key = "{{ .local_repo_name1 }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .local_repo_name2 }}" {
+			key = "{{ .local_repo_name2 }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			repositories = [artifactory_local_hex_repository.{{ .local_repo_name1 }}.key]
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":            kpId,
+		"kp_name":          kpName,
+		"repo_name":        name,
+		"local_repo_name1": localRepoName1,
+		"local_repo_name2": localRepoName2,
+		"private_key":      os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":       os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccVirtualHexRepository_updateRepositories", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .local_repo_name1 }}" {
+			key = "{{ .local_repo_name1 }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+
+		resource "artifactory_local_hex_repository" "{{ .local_repo_name2 }}" {
+			key = "{{ .local_repo_name2 }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			repositories = [
+				artifactory_local_hex_repository.{{ .local_repo_name1 }}.key,
+				artifactory_local_hex_repository.{{ .local_repo_name2 }}.key
+			]
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccVirtualHexRepository_updateRepositories", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "repositories.#", "1"),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "repositories.#", "2"),
+				),
+			},
+		},
+	})
+}
+
+func TestAccVirtualHexRepository_emptyRepositories(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("hex-virtual", "artifactory_virtual_hex_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	temp := `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "RSA"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+		}
+
+		resource "artifactory_virtual_hex_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			hex_primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+			repositories = []
+		}
+	`
+
+	testData := map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"private_key": os.Getenv("JFROG_TEST_RSA_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_RSA_PUBLIC_KEY"),
+	}
+
+	config := util.ExecuteTemplate("TestAccVirtualHexRepository_emptyRepositories", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "pair_name", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "hex_primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "repositories.#", "0"),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
Fixes: [#1230](https://github.com/jfrog/terraform-provider-artifactory/issues/1230)
# Add Hex Repository Support

## Summary

This PR adds comprehensive support for Hex repositories in the Terraform Provider for Artifactory. Hex is the package manager for the Elixir/Erlang ecosystem, and this implementation enables users to manage and read local, remote, and virtual Hex repositories through Terraform.

**What's included:**
- ✅ 3 new resources: `artifactory_local_hex_repository`, `artifactory_remote_hex_repository`, `artifactory_virtual_hex_repository`
- ✅ 3 new data sources: `artifactory_local_hex_repository`, `artifactory_remote_hex_repository`, `artifactory_virtual_hex_repository` (implemented with Terraform Plugin Framework)
- ✅ Complete test coverage for all resources and data sources
- ✅ Full documentation for all resources and data sources
- ✅ Example configurations and import scripts
- ✅ Updated sample.tf with Hex repository examples

## Changes

### New Resources

- **`artifactory_local_hex_repository`** - Creates and manages local Hex repositories for storing Elixir/Erlang packages
- **`artifactory_remote_hex_repository`** - Creates and manages remote Hex repositories for proxying packages from remote Hex registries (e.g., https://repo.hex.pm)
- **`artifactory_virtual_hex_repository`** - Creates and manages virtual Hex repositories that aggregate local and remote Hex repositories

### New Data Sources

- **`artifactory_local_hex_repository`** - Reads local Hex repository configuration
- **`artifactory_remote_hex_repository`** - Reads remote Hex repository configuration
- **`artifactory_virtual_hex_repository`** - Reads virtual Hex repository configuration

All data sources are implemented using Terraform Plugin Framework for consistency with modern provider patterns.

### Core Implementation

1. **Package Type Definition**
   - Added `HexPackageType` constant in `pkg/artifactory/resource/repository/repository.go`
   - Added Hex entry to `PackageNameLookup` map

2. **Repository Layout Configuration**
   - Added Hex to default repository layout map in `pkg/artifactory/resource/repository/default_repo_layout_map.go`
   - Configured default layout reference for Hex repositories

3. **Resource Implementations**
   - Created custom resource implementations for all three repository types:
     - `pkg/artifactory/resource/repository/local/resource_artifactory_local_hex_repository.go`
     - `pkg/artifactory/resource/repository/remote/resource_artifactory_remote_hex_repository.go`
     - `pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_hex_repository.go`

4. **Data Source Implementations**
   - Created Terraform Plugin Framework-based data source implementations for all three repository types:
     - `pkg/artifactory/datasource/repository/local/datasource_artifactory_local_hex_repository_fw.go`
     - `pkg/artifactory/datasource/repository/remote/datasource_artifactory_remote_hex_repository_fw.go`
     - `pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_hex_repository_fw.go`
   - Updated datasource registration in:
     - `pkg/artifactory/datasource/repository/local/local.go`
     - `pkg/artifactory/datasource/repository/remote/remote.go`
     - `pkg/artifactory/datasource/repository/virtual/virtual.go`
     - `pkg/artifactory/datasource/repository/repository.go`

5. **Provider Registration**
   - Registered all three Hex repository resources in `pkg/artifactory/provider/framework.go`

6. **Virtual Repository Updates**
   - Enhanced virtual repository implementation in `pkg/artifactory/resource/repository/virtual/virtual.go` to support Hex-specific attributes

### Testing

Comprehensive test coverage has been added for all three repository types (resources and data sources):

**Resource Tests:**
- **Local Hex Repository Tests** (`resource_artifactory_local_hex_repository_test.go`)
  - Basic repository creation test
  - Full attribute test with all configuration options
  - 546 lines of test code

- **Remote Hex Repository Tests** (`resource_artifactory_remote_hex_repository_test.go`)
  - Basic remote repository creation test
  - Full attribute test including URL configuration
  - 838 lines of test code

- **Virtual Hex Repository Tests** (`resource_artifactory_virtual_hex_repository_test.go`)
  - Virtual repository creation with member repositories
  - Full attribute test
  - 837 lines of test code

**Data Source Tests:**
- **Local Hex Repository Data Source Tests** (`datasource_artifactory_local_hex_repository_test.go`)
  - Tests reading local Hex repository configuration
  - All tests passing ✅

- **Remote Hex Repository Data Source Tests** (`datasource_artifactory_remote_hex_repository_test.go`)
  - Tests reading remote Hex repository configuration
  - All tests passing ✅

- **Virtual Hex Repository Data Source Tests** (`datasource_artifactory_virtual_hex_repository_test.go`)
  - Tests reading virtual Hex repository configuration
  - All tests passing ✅

### Documentation

Complete documentation has been added for all three repository types (resources and data sources):

**Resource Documentation:**
- `docs/resources/local_hex_repository.md` - Local Hex repository documentation
- `docs/resources/remote_hex_repository.md` - Remote Hex repository documentation
- `docs/resources/virtual_hex_repository.md` - Virtual Hex repository documentation

**Data Source Documentation:**
- `docs/data-sources/local_hex_repository.md` - Local Hex repository data source documentation
- `docs/data-sources/remote_hex_repository.md` - Remote Hex repository data source documentation
- `docs/data-sources/virtual_hex_repository.md` - Virtual Hex repository data source documentation

Each documentation file includes:
- Example usage with HCL code blocks
- Complete argument reference
- Import instructions (for resources)
- Links to official JFrog documentation

### Examples

Example Terraform configurations have been added:

- `examples/resources/artifactory_local_hex_repository/resource.tf`
- `examples/resources/artifactory_local_hex_repository/import.sh`
- `examples/resources/artifactory_remote_hex_repository/resource.tf`
- `examples/resources/artifactory_remote_hex_repository/import.sh`
- `examples/resources/artifactory_virtual_hex_repository/resource.tf`
- `examples/resources/artifactory_virtual_hex_repository/import.sh`

### Sample Configuration

Added sample configuration in `sample.tf` demonstrating usage of all three Hex repository types (local, remote, and virtual), including:
- Hex-specific keypair creation
- Local Hex repository with keypair reference
- Remote Hex repository with URL and public key configuration
- Virtual Hex repository aggregating local and remote repositories

## Key Features

### Hex-Specific Attributes

All Hex repositories support the following Hex-specific attributes:

- **`hex_primary_keypair_ref`** (Required) - RSA key pair reference for signing and encrypting content for secure communication between Artifactory and the Mix client

### Remote Hex Repository Additional Attributes

- **`public_key`** (Required) - Public key used when downloading packages from the Hex remote registry

### Security

Hex repositories require RSA key pairs for secure communication. The implementation properly handles key pair lifecycle management and ensures secure package signing and encryption.

## Testing

All tests have been implemented and should pass. The test suite includes:

- Basic creation tests for all repository types
- Full attribute configuration tests
- Import functionality tests
- Update operation tests

## Files Changed

### New Files Created

**Resources:**
- 3 resource implementation files
- 3 resource test files

**Data Sources:**
- 3 data source implementation files (Terraform Plugin Framework)
- 3 data source test files

**Documentation:**
- 3 resource documentation files (`docs/resources/`)
- 3 data source documentation files (`docs/data-sources/`)

**Examples:**
- 6 example files (3 resource.tf + 3 import.sh)

### Modified Files

- `pkg/artifactory/provider/framework.go` - Resource registration
- `pkg/artifactory/resource/repository/repository.go` - Package type definition
- `pkg/artifactory/resource/repository/default_repo_layout_map.go` - Layout configuration
- `pkg/artifactory/resource/repository/virtual/virtual.go` - Virtual repository enhancements
- `pkg/artifactory/datasource/repository/local/local.go` - Data source registration
- `pkg/artifactory/datasource/repository/remote/remote.go` - Data source registration
- `pkg/artifactory/datasource/repository/virtual/virtual.go` - Data source registration
- `pkg/artifactory/datasource/repository/repository.go` - Data source registration
- `sample.tf` - Sample configuration with Hex repositories
- `CHANGELOG.md` - Updated with new features

## Breaking Changes

None. This is a new feature addition with no breaking changes to existing functionality.

## Related Issues

This PR implements Hex repository support as requested in the Hex repository implementation checklist.

## Checklist

- [x] All three repository types implemented (local, remote, virtual)
- [x] All three data source types implemented (local, remote, virtual)
- [x] Data sources migrated to Terraform Plugin Framework
- [x] Comprehensive test coverage added for resources
- [x] Comprehensive test coverage added for data sources
- [x] All data source tests passing ✅
- [x] Documentation complete for all repository types (resources)
- [x] Documentation complete for all repository types (data sources)
- [x] Examples provided for all repository types
- [x] Provider registration completed
- [x] Data source registration completed
- [x] Package type definitions added
- [x] Default repository layout configured
- [x] Import functionality supported
- [x] Sample configuration updated in `sample.tf`
- [x] CHANGELOG.md updated
- [x] Code follows existing patterns and conventions

