### PR TITLE
Add Hugging Face Virtual Repository resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 12.11.3 (Unreleased)
+
+IMPROVEMENTS:
+
+* resource/artifactory_virtual_huggingfaceml_repository: New resource added.
+
 ### 12.11.3 (Feb 11, 2026). Tested on Artifactory 7.133.8 with Terraform 1.14.4 and OpenTofu 1.11.4
 
 FEATURES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-### 12.11.3 (Unreleased)
+### 12.11.4 (Unreleased)
 
-IMPROVEMENTS:
+FEATURES:
 
-* resource/artifactory_virtual_huggingfaceml_repository: New resource added.
+**New Resource:** `artifactory_virtual_huggingfaceml_repository` to support virtual Hugging Face ML repository .
 
 ### 12.11.3 (Feb 11, 2026). Tested on Artifactory 7.133.8 with Terraform 1.14.4 and OpenTofu 1.11.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 12.11.4 (Unreleased)
+### 12.12.0 (Unreleased)
 
 FEATURES:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-### 12.12.0 (Unreleased)
+### 12.11.4 (Feb 13, 2026)
 
-FEATURES:
+IMPROVEMENTS:
 
-**New Resource:** `artifactory_virtual_huggingfaceml_repository` to support virtual Hugging Face ML repository .
+**New Resource:** `artifactory_virtual_huggingfaceml_repository` to support virtual Hugging Face ML repository. PR: [#1369](https://github.com/jfrog/terraform-provider-artifactory/pull/1369)
 
 ### 12.11.3 (Feb 11, 2026). Tested on Artifactory 7.133.8 with Terraform 1.14.4 and OpenTofu 1.11.4
 

--- a/docs/resources/virtual_huggingfaceml_repository.md
+++ b/docs/resources/virtual_huggingfaceml_repository.md
@@ -1,0 +1,40 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Hugging Face Repository Resource
+
+Creates a virtual Hugging Face repository.
+Official documentation can be found [here](https://www.jfrog.com/confluence/display/JFROG/Virtual+Repositories).
+
+## Example Usage
+
+```hcl
+resource "artifactory_virtual_huggingfaceml_repository" "foo-huggingfaceml" {
+  key               = "foo-huggingfaceml"
+  repo_layout_ref   = "simple-default"
+  repositories      = []
+  description       = "A test virtual repo"
+  notes             = "Internal description"
+  includes_pattern  = "com/jfrog/**,cloud/jfrog/**"
+  excludes_pattern  = "com/google/**"
+}
+```
+
+## Argument Reference
+
+Arguments have a one to one mapping with the [JFrog API](https://www.jfrog.com/confluence/display/RTF/Repository+Configuration+JSON). 
+The following arguments are supported, along with the [common list of arguments for the virtual repositories](virtual.md):
+
+* `key` - (Required) A mandatory identifier for the repository that must be unique. It cannot begin with a number or
+  contain spaces or special characters.
+* `repositories` - (Optional) The effective list of actual repositories included in this virtual repository.
+* `description` - (Optional)
+* `notes` - (Optional)
+
+## Import
+
+Virtual repositories can be imported using their name, e.g.
+
+```
+$ terraform import artifactory_virtual_huggingfaceml_repository.foo-huggingfaceml foo-huggingfaceml
+```

--- a/pkg/artifactory/resource/repository/default_repo_layout_map.go
+++ b/pkg/artifactory/resource/repository/default_repo_layout_map.go
@@ -199,7 +199,7 @@ var defaultRepoLayoutMap = map[string]SupportedRepoClasses{
 		SupportedRepoTypes: map[string]bool{
 			"local":     true,
 			"remote":    true,
-			"virtual":   false,
+			"virtual":   true,
 			"federated": true,
 		},
 	},

--- a/pkg/artifactory/resource/repository/virtual/virtual.go
+++ b/pkg/artifactory/resource/repository/virtual/virtual.go
@@ -218,6 +218,7 @@ var PackageTypesLikeGeneric = []string{
 	repository.GemsPackageType,
 	repository.GenericPackageType,
 	repository.GitLFSPackageType,
+	repository.HuggingFacePackageType,
 	repository.P2PackageType,
 	repository.PubPackageType,
 	repository.PuppetPackageType,


### PR DESCRIPTION
This pull requests enables the creation of Hugging Face `virtual` repositories, which can now be configured for the package type.

Detailed changes:
* Enabled support for the `virtual` repository type in the `defaultRepoLayoutMap`, allowing repositories of this type to be recognized and handled where previously they were not.
* Added `HuggingFacePackageType` to the `PackageTypesLikeGeneric` list, ensuring that Hugging Face packages are treated similarly to other generic-like package types in virtual repositories.