### PR TITLE
feat: add refresh_operation and refresh_username attributes to ldap_group_setting_v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 12.11.4 (Feb 14, 2026). Tested on Artifactory 7.133.8 with Terraform 1.14.4 and OpenTofu 1.11.4
+
+IMPROVEMENTS:
+
+* resource/artifactory_ldap_group_setting_v2: Add `refresh_operation` and `refresh_username` attributes to trigger LDAP group import/refresh after create and update operations. PR: [#1374](https://github.com/jfrog/terraform-provider-artifactory/pull/1374)
+
 ### 12.11.3 (Feb 11, 2026). Tested on Artifactory 7.133.8 with Terraform 1.14.4 and OpenTofu 1.11.4
 
 FEATURES:

--- a/docs/resources/ldap_group_setting_v2.md
+++ b/docs/resources/ldap_group_setting_v2.md
@@ -28,6 +28,8 @@ resource "artifactory_ldap_group_setting_v2" "ldap_group_name" {
   filter                 = "(objectClass=groupOfNames)"
   description_attribute  = "description"
   strategy               = "STATIC"
+  refresh_operation      = "UPDATE_AND_IMPORT"
+  refresh_username       = ""
 }
 ```
 
@@ -50,6 +52,8 @@ resource "artifactory_ldap_group_setting_v2" "ldap_group_name" {
 - `enabled_ldap` (String) The LDAP setting key you want to use for group retrieval.
 - `force_attribute_search` (Boolean) This attribute is used in very specific cases of LDAP group settings. Don't switch it to `false`, unless instructed by the JFrog support team. Default value is `false`.
 - `group_base_dn` (String) A search base for group entry DNs, relative to the DN on the LDAP server’s URL (and not relative to the LDAP Setting’s “Search Base”). Used when importing groups.
+- `refresh_operation` (String) Operation to perform after creating or updating the LDAP group setting. Triggers a sync of LDAP groups into Artifactory. Valid values: `UPDATE` (update existing groups), `IMPORT` (import new groups), `UPDATE_AND_IMPORT` (both). Defaults to `UPDATE_AND_IMPORT`.
+- `refresh_username` (String) Optional username to limit the group refresh to a specific user's group membership. When empty (default), all group memberships are refreshed.
 - `sub_tree` (Boolean) When set, enables deep search through the sub-tree of the LDAP URL + Search Base. `true` by default. `sub_tree` can be set to true only with `STATIC` or `DYNAMIC` strategy.
 
 ### Read-Only

--- a/examples/resources/artifactory_ldap_group_setting_v2/resource.tf
+++ b/examples/resources/artifactory_ldap_group_setting_v2/resource.tf
@@ -9,4 +9,6 @@ resource "artifactory_ldap_group_setting_v2" "ldap_group_name" {
   filter                 = "(objectClass=groupOfNames)"
   description_attribute  = "description"
   strategy               = "STATIC"
+  refresh_operation      = "UPDATE_AND_IMPORT"
+  refresh_username       = ""
 }

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_v2.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_v2.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/go-resty/resty/v2"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
@@ -182,11 +181,11 @@ func (r *ArtifactoryLdapGroupSettingResource) Schema(ctx context.Context, req re
 	}
 }
 
-func refreshLdapGroup(client *resty.Client, groupName, operation, username string) error {
+func (r *ArtifactoryLdapGroupSettingResource) refreshLdapGroup(groupName, operation, username string) error {
 	groupNameEscaped := url.PathEscape(groupName)
 	refreshURL := fmt.Sprintf("%s%s/refresh?operation=%s", LdapGroupEndpoint, groupNameEscaped, operation)
 	refreshURL += "&username=" + url.QueryEscape(username)
-	resp, err := client.R().Post(refreshURL)
+	resp, err := r.ProviderData.Client.R().Post(refreshURL)
 	if err != nil {
 		return fmt.Errorf("failed to trigger LDAP group refresh: %w", err)
 	}
@@ -254,7 +253,7 @@ func (r *ArtifactoryLdapGroupSettingResource) Create(ctx context.Context, req re
 	// Trigger LDAP group refresh
 	operation := data.RefreshOperation.ValueString()
 	username := data.RefreshUsername.ValueString()
-	if err := refreshLdapGroup(r.ProviderData.Client, ldapGroup.Name, operation, username); err != nil {
+	if err := r.refreshLdapGroup(ldapGroup.Name, operation, username); err != nil {
 		utilfw.UnableToCreateResourceError(resp, err.Error())
 		return
 	}
@@ -360,7 +359,7 @@ func (r *ArtifactoryLdapGroupSettingResource) Update(ctx context.Context, req re
 	// Trigger LDAP group refresh
 	operation := data.RefreshOperation.ValueString()
 	username := data.RefreshUsername.ValueString()
-	if err := refreshLdapGroup(r.ProviderData.Client, ldapGroup.Name, operation, username); err != nil {
+	if err := r.refreshLdapGroup(ldapGroup.Name, operation, username); err != nil {
 		utilfw.UnableToUpdateResourceError(resp, err.Error())
 		return
 	}


### PR DESCRIPTION
Adds `refresh_operation` and `refresh_username` attributes to `artifactory_ldap_group_setting_v2`
to trigger LDAP group import/refresh after create and update operations.

**API endpoint:** `POST access/api/v1/ldap/groups/{settingName}/refresh?operation={OP}&username={USER}`

I have tested that this api works fine on artifactory  v7.133.6 rev 83306900