### PR TITLE
Add Nix resources and data sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-### 12.11.4 (Apr 30, 2026). Tested on Artifactory 7.146.8 with Terraform 1.15.0 and OpenTofu 1.11.6
+### 12.11.4 (Apr 30, 2026).
 
 FEATURES:
 
+**New Resource:** `artifactory_*_nix_repository` to support local, remote, virtual Nix repository. Issue: [#1388](https://github.com/jfrog/terraform-provider-artifactory/issues/1388)
 * resource/`artifactory_remote_generic_repository`: Add `custom_http_headers` — a list of up to 5 custom HTTP headers (`name`, `value`, `sensitive`) sent on every outbound request to the remote URL. `sensitive` defaults to `false`; when set to `true`, Artifactory encrypts the value server-side. Header values are masked in Terraform plan output. Requires Artifactory support for the `customHttpHeaders` repository configuration. PR: [#1393](https://github.com/jfrog/terraform-provider-artifactory/pull/1393)
 
 IMPROVEMENTS:

--- a/docs/data-sources/local_nix_repository.md
+++ b/docs/data-sources/local_nix_repository.md
@@ -1,0 +1,23 @@
+---
+subcategory: "Local Repositories"
+---
+
+# Artifactory Local Nix Repository Data Source
+
+Retrieves configuration for a local Nix repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_local_nix_repository" "example" {
+  key = "my-nix-local"
+}
+```
+
+## Argument Reference
+
+* `key` - (Required) Repository key.
+
+## Attribute Reference
+
+See the [common attributes for local repository data sources](local.md). `package_type` is `nix` and the default layout is `nix-default`.

--- a/docs/data-sources/remote_nix_repository.md
+++ b/docs/data-sources/remote_nix_repository.md
@@ -1,0 +1,23 @@
+---
+subcategory: "Remote Repositories"
+---
+
+# Artifactory Remote Nix Repository Data Source
+
+Retrieves configuration for a remote Nix repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_remote_nix_repository" "example" {
+  key = "my-nix-remote"
+}
+```
+
+## Argument Reference
+
+* `key` - (Required) Repository key.
+
+## Attribute Reference
+
+See the [common attributes for remote repository data sources](remote.md). `package_type` is `nix` and the default layout is `nix-default`.

--- a/docs/data-sources/virtual_nix_repository.md
+++ b/docs/data-sources/virtual_nix_repository.md
@@ -1,0 +1,23 @@
+---
+subcategory: "Virtual Repositories"
+---
+
+# Artifactory Virtual Nix Repository Data Source
+
+Retrieves configuration for a virtual Nix repository.
+
+## Example Usage
+
+```hcl
+data "artifactory_virtual_nix_repository" "example" {
+  key = "my-nix-virtual"
+}
+```
+
+## Argument Reference
+
+* `key` - (Required) Repository key.
+
+## Attribute Reference
+
+See the [common attributes for virtual repository data sources](virtual.md). `package_type` is `nix` and the default layout is `nix-default`.

--- a/docs/resources/local_nix_repository.md
+++ b/docs/resources/local_nix_repository.md
@@ -1,0 +1,31 @@
+---
+subcategory: "Local Repositories"
+---
+# Artifactory Local Nix Repository Resource
+
+Creates a local Nix repository for hosting Nix store artifacts and channels. See [Nix repositories](https://docs.jfrog.com/artifactory/docs/nix-repositories) in the JFrog documentation.
+
+## Example Usage
+
+```hcl
+resource "artifactory_local_nix_repository" "my-nix-local" {
+  key         = "my-nix-local"
+  description = "Local Nix repository"
+  notes       = "Internal repository"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported, along with the [common arguments for local repositories](local.md):
+
+* `key` - (Required) Repository key.
+* `repo_layout_ref` - (Optional) Repository layout reference. Defaults to `nix-default` when unset.
+
+## Import
+
+Repositories can be imported using the repository key, for example:
+
+```
+$ terraform import artifactory_local_nix_repository.my-nix-local my-nix-local
+```

--- a/docs/resources/remote_nix_repository.md
+++ b/docs/resources/remote_nix_repository.md
@@ -1,0 +1,32 @@
+---
+subcategory: "Remote Repositories"
+---
+# Artifactory Remote Nix Repository Resource
+
+Creates a remote Nix repository that proxies and caches a Nix binary cache (for example `https://cache.nixos.org`). See [Nix repositories](https://docs.jfrog.com/artifactory/docs/nix-repositories).
+
+## Example Usage
+
+```hcl
+resource "artifactory_remote_nix_repository" "my-nix-remote" {
+  key         = "my-nix-remote"
+  url         = "https://cache.nixos.org"
+  description = "Remote Nix cache"
+}
+```
+
+## Argument Reference
+
+The following arguments are supported, along with the [common arguments for remote repositories](remote.md):
+
+* `key` - (Required) Repository key.
+* `url` - (Required) URL of the upstream Nix binary cache.
+* `repo_layout_ref` - (Optional) Repository layout reference. Defaults to `nix-default` when unset.
+
+## Import
+
+Repositories can be imported using the repository key, for example:
+
+```
+$ terraform import artifactory_remote_nix_repository.my-nix-remote my-nix-remote
+```

--- a/docs/resources/virtual_nix_repository.md
+++ b/docs/resources/virtual_nix_repository.md
@@ -1,0 +1,43 @@
+---
+subcategory: "Virtual Repositories"
+---
+# Artifactory Virtual Nix Repository Resource
+
+Creates a virtual Nix repository that aggregates local and remote Nix repositories behind a single URL. See [Nix repositories](https://docs.jfrog.com/artifactory/docs/nix-repositories).
+
+## Example Usage
+
+```hcl
+resource "artifactory_local_nix_repository" "local" {
+  key = "nix-local"
+}
+
+resource "artifactory_remote_nix_repository" "remote" {
+  key = "nix-remote"
+  url = "https://cache.nixos.org"
+}
+
+resource "artifactory_virtual_nix_repository" "nix" {
+  key            = "nix-virtual"
+  repositories   = [
+    artifactory_local_nix_repository.local.key,
+    artifactory_remote_nix_repository.remote.key,
+  ]
+}
+```
+
+## Argument Reference
+
+The following arguments are supported, along with the [common arguments for virtual repositories](virtual.md):
+
+* `key` - (Required) Repository key.
+* `repositories` - (Optional) Ordered list of repository keys included in the virtual repository.
+* `repo_layout_ref` - (Optional) Repository layout reference. Defaults to `nix-default` when unset.
+
+## Import
+
+Repositories can be imported using the repository key, for example:
+
+```
+$ terraform import artifactory_virtual_nix_repository.nix nix-virtual
+```

--- a/examples/resources/artifactory_local_nix_repository/import.sh
+++ b/examples/resources/artifactory_local_nix_repository/import.sh
@@ -1,0 +1,1 @@
+terraform import artifactory_local_nix_repository.my-nix-local my-nix-local

--- a/examples/resources/artifactory_local_nix_repository/resource.tf
+++ b/examples/resources/artifactory_local_nix_repository/resource.tf
@@ -1,0 +1,5 @@
+resource "artifactory_local_nix_repository" "my-nix-local" {
+  key         = "my-nix-local"
+  description = "Local Nix repository"
+  notes       = "Internal repository"
+}

--- a/examples/resources/artifactory_remote_nix_repository/import.sh
+++ b/examples/resources/artifactory_remote_nix_repository/import.sh
@@ -1,0 +1,1 @@
+terraform import artifactory_remote_nix_repository.my-nix-remote my-nix-remote

--- a/examples/resources/artifactory_remote_nix_repository/resource.tf
+++ b/examples/resources/artifactory_remote_nix_repository/resource.tf
@@ -1,0 +1,5 @@
+resource "artifactory_remote_nix_repository" "my-nix-remote" {
+  key         = "my-nix-remote"
+  url         = "https://cache.nixos.org"
+  description = "Remote Nix binary cache"
+}

--- a/examples/resources/artifactory_virtual_nix_repository/import.sh
+++ b/examples/resources/artifactory_virtual_nix_repository/import.sh
@@ -1,0 +1,1 @@
+terraform import artifactory_virtual_nix_repository.nix-virtual example-nix-virtual

--- a/examples/resources/artifactory_virtual_nix_repository/resource.tf
+++ b/examples/resources/artifactory_virtual_nix_repository/resource.tf
@@ -1,0 +1,16 @@
+resource "artifactory_local_nix_repository" "nix-local" {
+  key = "example-nix-local"
+}
+
+resource "artifactory_remote_nix_repository" "nix-remote" {
+  key = "example-nix-remote"
+  url = "https://cache.nixos.org"
+}
+
+resource "artifactory_virtual_nix_repository" "nix-virtual" {
+  key = "example-nix-virtual"
+  repositories = [
+    artifactory_local_nix_repository.nix-local.key,
+    artifactory_remote_nix_repository.nix-remote.key,
+  ]
+}

--- a/pkg/artifactory/datasource/repository/local/datasource_artifactory_local_nix_repository.go
+++ b/pkg/artifactory/datasource/repository/local/datasource_artifactory_local_nix_repository.go
@@ -1,0 +1,183 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/local"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+var _ datasource.DataSource = &LocalNixRepositoryDataSource{}
+
+func NewLocalNixRepositoryDataSource() datasource.DataSource {
+	return &LocalNixRepositoryDataSource{}
+}
+
+type LocalNixRepositoryDataSource struct {
+	ProviderData util.ProviderMetadata
+}
+
+type LocalNixRepositoryDataSourceModel struct {
+	Key                    types.String `tfsdk:"key"`
+	ProjectKey             types.String `tfsdk:"project_key"`
+	ProjectEnvironments    types.Set    `tfsdk:"project_environments"`
+	Description            types.String `tfsdk:"description"`
+	Notes                  types.String `tfsdk:"notes"`
+	IncludesPattern        types.String `tfsdk:"includes_pattern"`
+	ExcludesPattern        types.String `tfsdk:"excludes_pattern"`
+	RepoLayoutRef          types.String `tfsdk:"repo_layout_ref"`
+	BlackedOut             types.Bool   `tfsdk:"blacked_out"`
+	XrayIndex              types.Bool   `tfsdk:"xray_index"`
+	PropertySets           types.Set    `tfsdk:"property_sets"`
+	ArchiveBrowsingEnabled types.Bool   `tfsdk:"archive_browsing_enabled"`
+	DownloadDirect         types.Bool   `tfsdk:"download_direct"`
+	PriorityResolution     types.Bool   `tfsdk:"priority_resolution"`
+	CDNRedirect            types.Bool   `tfsdk:"cdn_redirect"`
+	PackageType            types.String `tfsdk:"package_type"`
+}
+
+// LocalNixRepositoryAPIModel mirrors the repository JSON shape (same field layout as other local repository API models).
+type LocalNixRepositoryAPIModel struct {
+	repository.BaseAPIModel
+	local.LocalAPIModel
+}
+
+func (d *LocalNixRepositoryDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "artifactory_local_nix_repository"
+}
+
+func (d *LocalNixRepositoryDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes:  LocalDataSourceAttributes,
+		Description: "Provides a data source for a local Nix repository",
+	}
+}
+
+func (d *LocalNixRepositoryDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	d.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+func (d *LocalNixRepositoryDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data LocalNixRepositoryDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var apiModel LocalNixRepositoryAPIModel
+	var jfrogErrors util.JFrogErrors
+
+	response, err := d.ProviderData.Client.R().
+		SetPathParam("key", data.Key.ValueString()).
+		SetResult(&apiModel).
+		SetError(&jfrogErrors).
+		Get(repository.RepositoriesEndpoint)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while fetching the data source. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+err.Error(),
+		)
+		return
+	}
+
+	if response.StatusCode() == http.StatusBadRequest || response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while fetching the data source. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+jfrogErrors.String(),
+		)
+		return
+	}
+
+	data.FromAPIModel(ctx, &apiModel)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (m *LocalNixRepositoryDataSourceModel) FromAPIModel(ctx context.Context, apiModel *LocalNixRepositoryAPIModel) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	m.Key = types.StringValue(apiModel.Key)
+	m.ProjectKey = types.StringValue(apiModel.ProjectKey)
+	m.Description = types.StringValue(apiModel.Description)
+	m.Notes = types.StringValue(apiModel.Notes)
+	m.IncludesPattern = types.StringValue(apiModel.IncludesPattern)
+	m.ExcludesPattern = types.StringValue(apiModel.ExcludesPattern)
+	m.PackageType = types.StringValue(repository.NixPackageType)
+
+	m.RepoLayoutRef = types.StringValue(apiModel.RepoLayoutRef)
+	m.BlackedOut = types.BoolValue(apiModel.LocalAPIModel.BlackedOut)
+	m.XrayIndex = types.BoolValue(apiModel.LocalAPIModel.XrayIndex)
+	m.ArchiveBrowsingEnabled = types.BoolValue(apiModel.LocalAPIModel.ArchiveBrowsingEnabled)
+	m.DownloadDirect = types.BoolValue(apiModel.LocalAPIModel.DownloadRedirect)
+	m.PriorityResolution = types.BoolValue(apiModel.LocalAPIModel.PriorityResolution)
+	m.CDNRedirect = types.BoolValue(apiModel.LocalAPIModel.CDNRedirect)
+
+	var propertySets []types.String
+	for _, ps := range apiModel.LocalAPIModel.PropertySets {
+		propertySets = append(propertySets, types.StringValue(ps))
+	}
+	if len(propertySets) > 0 {
+		psSet, d := types.SetValueFrom(ctx, types.StringType, propertySets)
+		if d.HasError() {
+			diags.Append(d...)
+			return diags
+		}
+		m.PropertySets = psSet
+	} else {
+		m.PropertySets = types.SetNull(types.StringType)
+	}
+
+	var projectEnvironments []types.String
+	for _, env := range apiModel.ProjectEnvironments {
+		projectEnvironments = append(projectEnvironments, types.StringValue(env))
+	}
+	if len(projectEnvironments) > 0 {
+		envSet, d := types.SetValueFrom(ctx, types.StringType, projectEnvironments)
+		if d.HasError() {
+			diags.Append(d...)
+			return diags
+		}
+		m.ProjectEnvironments = envSet
+	} else {
+		m.ProjectEnvironments = types.SetNull(types.StringType)
+	}
+
+	return diags
+}

--- a/pkg/artifactory/datasource/repository/local/datasource_artifactory_local_nix_repository_test.go
+++ b/pkg/artifactory/datasource/repository/local/datasource_artifactory_local_nix_repository_test.go
@@ -1,0 +1,59 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccDataSourceLocalNixRepository(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("nix-local-test-repo-basic", "data.artifactory_local_nix_repository")
+
+	localRepositoryBasic := util.ExecuteTemplate("nix-local-ds", `
+		resource "artifactory_local_nix_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+		}
+
+		data "artifactory_local_nix_repository" "{{ .repo_name }}" {
+			key = artifactory_local_nix_repository.{{ .repo_name }}.key
+		}
+	`, map[string]interface{}{
+		"repo_name": name,
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: localRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "nix"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("local", repository.NixPackageType)
+						return r
+					}()),
+				),
+			},
+		},
+	})
+}

--- a/pkg/artifactory/datasource/repository/remote/datasource_artifactory_remote_nix_repository.go
+++ b/pkg/artifactory/datasource/repository/remote/datasource_artifactory_remote_nix_repository.go
@@ -1,0 +1,145 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	datasource_repository "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/datasource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	resourceremote "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/remote"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+var _ datasource.DataSource = &RemoteNixRepositoryDataSource{}
+
+func NewRemoteNixRepositoryDataSource() datasource.DataSource {
+	return &RemoteNixRepositoryDataSource{}
+}
+
+type RemoteNixRepositoryDataSource struct {
+	ProviderData util.ProviderMetadata
+}
+
+type RemoteNixRepositoryDataSourceModel struct {
+	BaseRemoteRepositoryDataSourceModel
+}
+
+type RemoteNixRepositoryAPIModel struct {
+	resourceremote.RemoteAPIModel
+}
+
+func (d *RemoteNixRepositoryDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "artifactory_remote_nix_repository"
+}
+
+func (d *RemoteNixRepositoryDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes:  BaseRemoteSchemaAttributes(),
+		Description: "Provides a data source for a remote Nix repository",
+	}
+}
+
+func (d *RemoteNixRepositoryDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	d.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+func (d *RemoteNixRepositoryDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data RemoteNixRepositoryDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var apiModel RemoteNixRepositoryAPIModel
+	var jfrogErrors util.JFrogErrors
+
+	response, err := d.ProviderData.Client.R().
+		SetPathParam("key", data.Key.ValueString()).
+		SetResult(&apiModel).
+		SetError(&jfrogErrors).
+		Get(repository.RepositoriesEndpoint)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while fetching the data source. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+err.Error(),
+		)
+		return
+	}
+
+	if response.StatusCode() == http.StatusBadRequest || response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while fetching the data source. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+jfrogErrors.String(),
+		)
+		return
+	}
+
+	data.FromAPIModel(ctx, &apiModel)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (m *RemoteNixRepositoryDataSourceModel) FromAPIModel(ctx context.Context, apiModel *RemoteNixRepositoryAPIModel) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	baseAPIModel := datasource_repository.BaseRepositoryAPIModel{
+		Key:                 apiModel.RemoteAPIModel.Key,
+		ProjectKey:          apiModel.RemoteAPIModel.ProjectKey,
+		ProjectEnvironments: apiModel.RemoteAPIModel.ProjectEnvironments,
+		Description:         apiModel.RemoteAPIModel.Description,
+		Notes:               apiModel.RemoteAPIModel.Notes,
+		IncludesPattern:     apiModel.RemoteAPIModel.IncludesPattern,
+		ExcludesPattern:     apiModel.RemoteAPIModel.ExcludesPattern,
+		RepoLayoutRef:       apiModel.RemoteAPIModel.RepoLayoutRef,
+		PackageType:         repository.NixPackageType,
+	}
+	diags.Append(datasource_repository.CommonFromAPIModel(ctx, &m.BaseRepositoryDataSourceModel, baseAPIModel)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	remoteAPIModel := BaseRemoteRepositoryAPIModel{
+		BaseRepositoryAPIModel: baseAPIModel,
+		RemoteAPIModel:         apiModel.RemoteAPIModel,
+	}
+	diags.Append(CommonRemoteFromAPIModel(ctx, &m.BaseRemoteRepositoryDataSourceModel, remoteAPIModel)...)
+	if diags.HasError() {
+		return diags
+	}
+
+	return diags
+}

--- a/pkg/artifactory/datasource/repository/remote/datasource_artifactory_remote_nix_repository_test.go
+++ b/pkg/artifactory/datasource/repository/remote/datasource_artifactory_remote_nix_repository_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccDataSourceRemoteNixRepository(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("nix-remote-test-repo-basic", "data.artifactory_remote_nix_repository")
+
+	cfg := util.ExecuteTemplate("nix-remote-ds", `
+		resource "artifactory_remote_nix_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://cache.nixos.org"
+		}
+
+		data "artifactory_remote_nix_repository" "{{ .repo_name }}" {
+			key = artifactory_remote_nix_repository.{{ .repo_name }}.key
+		}
+	`, map[string]interface{}{
+		"repo_name": name,
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "nix"),
+					resource.TestCheckResourceAttr(fqrn, "url", "https://cache.nixos.org"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("remote", repository.NixPackageType)
+						return r
+					}()),
+				),
+			},
+		},
+	})
+}

--- a/pkg/artifactory/datasource/repository/repository.go
+++ b/pkg/artifactory/datasource/repository/repository.go
@@ -174,6 +174,7 @@ var validPackageTypes = []string{
 	repository.HelmPackageType,
 	repository.HexPackageType,
 	repository.HuggingFacePackageType,
+	repository.NixPackageType,
 	repository.IvyPackageType,
 	repository.MavenPackageType,
 	repository.NPMPackageType,

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_nix_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_nix_repository.go
@@ -1,0 +1,152 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package virtual
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/hashicorp/terraform-plugin-framework/datasource"
+	"github.com/hashicorp/terraform-plugin-framework/datasource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	resourcevirtual "github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+var _ datasource.DataSource = &VirtualNixRepositoryDataSource{}
+
+func NewVirtualNixRepositoryDataSource() datasource.DataSource {
+	return &VirtualNixRepositoryDataSource{}
+}
+
+type VirtualNixRepositoryDataSource struct {
+	ProviderData util.ProviderMetadata
+}
+
+type VirtualNixRepositoryDataSourceModel struct {
+	Key                 types.String `tfsdk:"key"`
+	ProjectKey          types.String `tfsdk:"project_key"`
+	ProjectEnvironments types.Set    `tfsdk:"project_environments"`
+	Description         types.String `tfsdk:"description"`
+	Notes               types.String `tfsdk:"notes"`
+	IncludesPattern     types.String `tfsdk:"includes_pattern"`
+	ExcludesPattern     types.String `tfsdk:"excludes_pattern"`
+	PackageType         types.String `tfsdk:"package_type"`
+	RepoLayoutRef       types.String `tfsdk:"repo_layout_ref"`
+}
+
+type VirtualNixRepositoryAPIModel struct {
+	resourcevirtual.VirtualAPIModel
+}
+
+func (d *VirtualNixRepositoryDataSource) Metadata(ctx context.Context, req datasource.MetadataRequest, resp *datasource.MetadataResponse) {
+	resp.TypeName = "artifactory_virtual_nix_repository"
+}
+
+func (d *VirtualNixRepositoryDataSource) Schema(ctx context.Context, req datasource.SchemaRequest, resp *datasource.SchemaResponse) {
+	resp.Schema = schema.Schema{
+		Attributes:  VirtualDataSourceAttributes,
+		Description: "Provides a data source for a virtual Nix repository",
+	}
+}
+
+func (d *VirtualNixRepositoryDataSource) Configure(ctx context.Context, req datasource.ConfigureRequest, resp *datasource.ConfigureResponse) {
+	if req.ProviderData == nil {
+		return
+	}
+	d.ProviderData = req.ProviderData.(util.ProviderMetadata)
+}
+
+func (d *VirtualNixRepositoryDataSource) Read(ctx context.Context, req datasource.ReadRequest, resp *datasource.ReadResponse) {
+	var data VirtualNixRepositoryDataSourceModel
+
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	var apiModel VirtualNixRepositoryAPIModel
+	var jfrogErrors util.JFrogErrors
+
+	response, err := d.ProviderData.Client.R().
+		SetPathParam("key", data.Key.ValueString()).
+		SetResult(&apiModel).
+		SetError(&jfrogErrors).
+		Get(repository.RepositoriesEndpoint)
+
+	if err != nil {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while fetching the data source. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+err.Error(),
+		)
+		return
+	}
+
+	if response.StatusCode() == http.StatusBadRequest || response.StatusCode() == http.StatusNotFound {
+		resp.State.RemoveResource(ctx)
+		return
+	}
+
+	if response.IsError() {
+		resp.Diagnostics.AddError(
+			"Unable to Read Data Source",
+			"An unexpected error occurred while fetching the data source. "+
+				"Please report this issue to the provider developers.\n\n"+
+				"Error: "+jfrogErrors.String(),
+		)
+		return
+	}
+
+	data.FromAPIModel(ctx, &apiModel)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
+}
+
+func (m *VirtualNixRepositoryDataSourceModel) FromAPIModel(ctx context.Context, apiModel *VirtualNixRepositoryAPIModel) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	m.Key = types.StringValue(apiModel.VirtualAPIModel.Key)
+	m.ProjectKey = types.StringValue(apiModel.VirtualAPIModel.ProjectKey)
+	m.Description = types.StringValue(apiModel.VirtualAPIModel.Description)
+	m.Notes = types.StringValue(apiModel.VirtualAPIModel.Notes)
+	m.IncludesPattern = types.StringValue(apiModel.VirtualAPIModel.IncludesPattern)
+	m.ExcludesPattern = types.StringValue(apiModel.VirtualAPIModel.ExcludesPattern)
+	m.PackageType = types.StringValue(repository.NixPackageType)
+	m.RepoLayoutRef = types.StringValue(apiModel.VirtualAPIModel.RepoLayoutRef)
+
+	var projectEnvironments []types.String
+	for _, env := range apiModel.VirtualAPIModel.ProjectEnvironments {
+		projectEnvironments = append(projectEnvironments, types.StringValue(env))
+	}
+	if len(projectEnvironments) > 0 {
+		envSet, d := types.SetValueFrom(ctx, types.StringType, projectEnvironments)
+		if d.HasError() {
+			diags.Append(d...)
+			return diags
+		}
+		m.ProjectEnvironments = envSet
+	} else {
+		m.ProjectEnvironments = types.SetNull(types.StringType)
+	}
+
+	return diags
+}

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_nix_repository_test.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_nix_repository_test.go
@@ -1,0 +1,77 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package virtual_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccDataSourceVirtualNixRepository(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("nix-virtual-test-repo-basic", "data.artifactory_virtual_nix_repository")
+
+	cfg := util.ExecuteTemplate("nix-virtual-ds", `
+		resource "artifactory_local_nix_repository" "local-nix" {
+			key = "{{ .repo_name }}-local"
+		}
+
+		resource "artifactory_remote_nix_repository" "remote-nix" {
+			key = "{{ .repo_name }}-remote"
+			url = "https://cache.nixos.org"
+		}
+
+		resource "artifactory_virtual_nix_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			repositories = [
+				artifactory_local_nix_repository.local-nix.key,
+				artifactory_remote_nix_repository.remote-nix.key
+			]
+			depends_on = [
+				artifactory_local_nix_repository.local-nix,
+				artifactory_remote_nix_repository.remote-nix
+			]
+		}
+
+		data "artifactory_virtual_nix_repository" "{{ .repo_name }}" {
+			key = artifactory_virtual_nix_repository.{{ .repo_name }}.key
+		}
+	`, map[string]interface{}{
+		"repo_name": name,
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: cfg,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "nix"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef(virtual.Rclass, repository.NixPackageType)
+						return r
+					}()),
+				),
+			},
+		},
+	})
+}

--- a/pkg/artifactory/provider/framework.go
+++ b/pkg/artifactory/provider/framework.go
@@ -358,6 +358,7 @@ func (p *ArtifactoryProvider) Resources(ctx context.Context) []func() resource.R
 			local.NewHelmLocalRepositoryResource,
 			local.NewHelmOCILocalRepositoryResource,
 			local.NewHexLocalRepositoryResource,
+			local.NewNixLocalRepositoryResource,
 			local.NewMachineLearningLocalRepositoryResource,
 			local.NewNugetLocalRepositoryResource,
 			local.NewOCILocalRepositoryResource,
@@ -378,6 +379,7 @@ func (p *ArtifactoryProvider) Resources(ctx context.Context) []func() resource.R
 			remote.NewHelmRemoteRepositoryResource,
 			remote.NewHelmOCIRemoteRepositoryResource,
 			remote.NewHexRemoteRepositoryResource,
+			remote.NewNixRemoteRepositoryResource,
 			remote.NewHuggingFaceMLRemoteRepositoryResource,
 			remote.NewJavaRemoteRepositoryResource(repository.IvyPackageType, true),
 			remote.NewMavenRemoteRepositoryResource,
@@ -413,6 +415,7 @@ func (p *ArtifactoryProvider) Resources(ctx context.Context) []func() resource.R
 			webhook.NewUserWebhookResource,
 			webhook.NewUserCustomWebhookResource,
 			virtual.NewHexVirtualRepositoryResource,
+			virtual.NewNixVirtualRepositoryResource,
 		}...,
 	)
 }
@@ -423,8 +426,11 @@ func (p *ArtifactoryProvider) DataSources(_ context.Context) []func() datasource
 		datasource_repository.NewRepositoriesDataSource,
 		datasource_artifact.NewFileListDataSource,
 		datasource_local.NewLocalHexRepositoryDataSource,
+		datasource_local.NewLocalNixRepositoryDataSource,
 		datasource_remote.NewRemoteHexRepositoryDataSource,
+		datasource_remote.NewRemoteNixRepositoryDataSource,
 		datasource_virtual.NewVirtualHexRepositoryDataSource,
+		datasource_virtual.NewVirtualNixRepositoryDataSource,
 	}
 }
 

--- a/pkg/artifactory/resource/repository/default_repo_layout_map.go
+++ b/pkg/artifactory/resource/repository/default_repo_layout_map.go
@@ -194,6 +194,14 @@ var defaultRepoLayoutMap = map[string]SupportedRepoClasses{
 			"virtual": true,
 		},
 	},
+	NixPackageType: {
+		RepoLayoutRef: "nix-default",
+		SupportedRepoTypes: map[string]bool{
+			"local":   true,
+			"remote":  true,
+			"virtual": true,
+		},
+	},
 	HuggingFacePackageType: {
 		RepoLayoutRef: "simple-default",
 		SupportedRepoTypes: map[string]bool{

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_nix_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_nix_repository.go
@@ -1,0 +1,119 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/samber/lo"
+)
+
+func NewNixLocalRepositoryResource() resource.Resource {
+	return &localNixResource{
+		localResource: NewLocalRepositoryResource(
+			repository.NixPackageType,
+			repository.PackageNameLookup[repository.NixPackageType],
+			reflect.TypeFor[LocalNixResourceModel](),
+			reflect.TypeFor[LocalNixAPIModel](),
+		),
+	}
+}
+
+type localNixResource struct {
+	localResource
+}
+
+type LocalNixResourceModel struct {
+	LocalResourceModel
+}
+
+func (r *LocalNixResourceModel) GetCreateResourcePlanData(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	resp.Diagnostics.Append(req.Plan.Get(ctx, r)...)
+}
+
+func (r LocalNixResourceModel) SetCreateResourceStateData(ctx context.Context, resp *resource.CreateResponse) {
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r *LocalNixResourceModel) GetReadResourceStateData(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	resp.Diagnostics.Append(req.State.Get(ctx, r)...)
+}
+
+func (r LocalNixResourceModel) SetReadResourceStateData(ctx context.Context, resp *resource.ReadResponse) {
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r *LocalNixResourceModel) GetUpdateResourcePlanData(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.Append(req.Plan.Get(ctx, r)...)
+}
+
+func (r *LocalNixResourceModel) GetUpdateResourceStateData(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.Append(req.State.Get(ctx, r)...)
+}
+
+func (r LocalNixResourceModel) SetUpdateResourceStateData(ctx context.Context, resp *resource.UpdateResponse) {
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r LocalNixResourceModel) ToAPIModel(ctx context.Context, packageType string) (interface{}, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	model, d := r.LocalResourceModel.ToAPIModel(ctx, packageType)
+	if d != nil {
+		diags.Append(d...)
+	}
+
+	localAPIModel := model.(LocalAPIModel)
+	localAPIModel.RepoLayoutRef = r.RepoLayoutRef.ValueString()
+
+	return LocalNixAPIModel{
+		LocalAPIModel: localAPIModel,
+	}, diags
+}
+
+func (r *LocalNixResourceModel) FromAPIModel(ctx context.Context, apiModel interface{}) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	model := apiModel.(*LocalNixAPIModel)
+
+	r.LocalResourceModel.FromAPIModel(ctx, model.LocalAPIModel)
+
+	r.RepoLayoutRef = types.StringValue(model.RepoLayoutRef)
+
+	return diags
+}
+
+type LocalNixAPIModel struct {
+	LocalAPIModel
+}
+
+func (r *localNixResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	attributes := lo.Assign(
+		LocalAttributes,
+		repository.RepoLayoutRefAttribute(Rclass, r.PackageType),
+	)
+
+	resp.Schema = schema.Schema{
+		Version:     CurrentSchemaVersion,
+		Attributes:  attributes,
+		Description: r.Description,
+	}
+}

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_nix_repository_test.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_nix_repository_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package local_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccLocalNixRepository_full(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("nix-local-test-repo", "artifactory_local_nix_repository")
+
+	temp := `
+		resource "artifactory_local_nix_repository" "{{ .repo_name }}" {
+			key             = "{{ .repo_name }}"
+			description     = "Test repository for Nix"
+			notes           = "Internal notes"
+			includes_pattern = "**/*"
+			excludes_pattern   = ""
+		}
+	`
+
+	testData := map[string]interface{}{
+		"repo_name": name,
+	}
+
+	config := util.ExecuteTemplate("TestAccLocalNixRepository_full", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_local_nix_repository" "{{ .repo_name }}" {
+			key             = "{{ .repo_name }}"
+			description     = "Updated description"
+			notes           = "Updated notes"
+			includes_pattern = "**/*"
+			excludes_pattern   = "*.tmp"
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccLocalNixRepository_full", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "description", "Test repository for Nix"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Internal notes"),
+					resource.TestCheckResourceAttr(fqrn, "includes_pattern", "**/*"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", ""),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("local", repository.NixPackageType)
+						return r
+					}()),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "description", "Updated description"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Updated notes"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", "*.tmp"),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+			},
+		},
+	})
+}
+
+func TestAccLocalNixRepository_basic(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("nix-local", "artifactory_local_nix_repository")
+
+	temp := `
+		resource "artifactory_local_nix_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+		}
+	`
+
+	testData := map[string]interface{}{
+		"repo_name": name,
+	}
+
+	config := util.ExecuteTemplate("TestAccLocalNixRepository_basic", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("local", repository.NixPackageType)
+						return r
+					}()),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+			},
+		},
+	})
+}

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nix_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nix_repository.go
@@ -1,0 +1,117 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/samber/lo"
+)
+
+func NewNixRemoteRepositoryResource() resource.Resource {
+	return &remoteNixResource{
+		remoteResource: NewRemoteRepositoryResource(
+			repository.NixPackageType,
+			repository.PackageNameLookup[repository.NixPackageType],
+			reflect.TypeFor[RemoteNixResourceModel](),
+			reflect.TypeFor[RemoteNixAPIModel](),
+		),
+	}
+}
+
+type remoteNixResource struct {
+	remoteResource
+}
+
+type RemoteNixResourceModel struct {
+	RemoteResourceModel
+}
+
+func (r *RemoteNixResourceModel) GetCreateResourcePlanData(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	resp.Diagnostics.Append(req.Plan.Get(ctx, r)...)
+}
+
+func (r RemoteNixResourceModel) SetCreateResourceStateData(ctx context.Context, resp *resource.CreateResponse) {
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r *RemoteNixResourceModel) GetReadResourceStateData(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	resp.Diagnostics.Append(req.State.Get(ctx, r)...)
+}
+
+func (r RemoteNixResourceModel) SetReadResourceStateData(ctx context.Context, resp *resource.ReadResponse) {
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r *RemoteNixResourceModel) GetUpdateResourcePlanData(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.Append(req.Plan.Get(ctx, r)...)
+}
+
+func (r *RemoteNixResourceModel) GetUpdateResourceStateData(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.Append(req.State.Get(ctx, r)...)
+}
+
+func (r RemoteNixResourceModel) SetUpdateResourceStateData(ctx context.Context, resp *resource.UpdateResponse) {
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r RemoteNixResourceModel) ToAPIModel(ctx context.Context, packageType string) (interface{}, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	remoteAPIModel, d := r.RemoteResourceModel.ToAPIModel(ctx, packageType)
+	if d != nil {
+		diags.Append(d...)
+	}
+
+	return RemoteNixAPIModel{
+		RemoteAPIModel: remoteAPIModel,
+	}, diags
+}
+
+func (r *RemoteNixResourceModel) FromAPIModel(ctx context.Context, apiModel interface{}) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	model := apiModel.(*RemoteNixAPIModel)
+
+	r.RemoteResourceModel.FromAPIModel(ctx, model.RemoteAPIModel)
+
+	r.RepoLayoutRef = types.StringValue(model.RepoLayoutRef)
+
+	return diags
+}
+
+type RemoteNixAPIModel struct {
+	RemoteAPIModel
+}
+
+func (r *remoteNixResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	remoteNixAttributes := lo.Assign(
+		RemoteAttributes,
+		repository.RepoLayoutRefAttribute(Rclass, r.PackageType),
+	)
+
+	resp.Schema = schema.Schema{
+		Version:     CurrentSchemaVersion,
+		Attributes:  remoteNixAttributes,
+		Blocks:      remoteBlocks,
+		Description: r.Description,
+	}
+}

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nix_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nix_repository_test.go
@@ -1,0 +1,141 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remote_test
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccRemoteNixRepository_full(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("nix-remote-test-repo", "artifactory_remote_nix_repository")
+
+	temp := `
+		resource "artifactory_remote_nix_repository" "{{ .repo_name }}" {
+			key                = "{{ .repo_name }}"
+			url                = "https://cache.nixos.org"
+			description        = "Test repository for Nix"
+			notes              = "Internal notes"
+			includes_pattern   = "**/*"
+			excludes_pattern   = ""
+		}
+	`
+
+	testData := map[string]interface{}{
+		"repo_name": name,
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteNixRepository_full", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_remote_nix_repository" "{{ .repo_name }}" {
+			key                = "{{ .repo_name }}"
+			url                = "https://cache.nixos.org"
+			description        = "Updated description"
+			notes              = "Updated notes"
+			includes_pattern   = "**/*"
+			excludes_pattern   = "*.tmp"
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccRemoteNixRepository_full", updatedTemp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "url", "https://cache.nixos.org"),
+					resource.TestCheckResourceAttr(fqrn, "description", "Test repository for Nix"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Internal notes"),
+					resource.TestCheckResourceAttr(fqrn, "includes_pattern", "**/*"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", ""),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("remote", repository.NixPackageType)
+						return r
+					}()),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "description", "Updated description"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Updated notes"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", "*.tmp"),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+				ImportStateVerifyIgnore:              []string{"password"},
+			},
+		},
+	})
+}
+
+func TestAccRemoteNixRepository_basic(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("nix-remote", "artifactory_remote_nix_repository")
+
+	temp := `
+		resource "artifactory_remote_nix_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			url = "https://cache.nixos.org"
+		}
+	`
+
+	testData := map[string]interface{}{
+		"repo_name": name,
+	}
+
+	config := util.ExecuteTemplate("TestAccRemoteNixRepository_basic", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "url", "https://cache.nixos.org"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("remote", repository.NixPackageType)
+						return r
+					}()),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+				ImportStateVerifyIgnore:              []string{"password"},
+			},
+		},
+	})
+}

--- a/pkg/artifactory/resource/repository/repository.go
+++ b/pkg/artifactory/resource/repository/repository.go
@@ -80,6 +80,7 @@ const (
 	MachineLearningType          = "machinelearning"
 	MavenPackageType             = "maven"
 	NPMPackageType               = "npm"
+	NixPackageType               = "nix"
 	NugetPackageType             = "nuget"
 	OCIPackageType               = "oci"
 	OpkgPackageType              = "opkg"
@@ -116,6 +117,7 @@ var PackageNameLookup = map[string]string{
 	HuggingFacePackageType:      "HuggingFace ML",
 	IvyPackageType:              "Ivy",
 	NPMPackageType:              "Npm",
+	NixPackageType:              "Nix",
 	OpkgPackageType:             "Opkg",
 	PubPackageType:              "Pub",
 	PuppetPackageType:           "Puppet",

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_nix_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_nix_repository.go
@@ -1,0 +1,113 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package virtual
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/samber/lo"
+)
+
+func NewNixVirtualRepositoryResource() resource.Resource {
+	return &virtualNixResource{
+		virtualResource: NewVirtualRepositoryResource(
+			repository.NixPackageType,
+			repository.PackageNameLookup[repository.NixPackageType],
+			reflect.TypeFor[VirtualNixResourceModel](),
+			reflect.TypeFor[VirtualNixAPIModel](),
+		),
+	}
+}
+
+type virtualNixResource struct {
+	virtualResource
+}
+
+type VirtualNixResourceModel struct {
+	VirtualResourceModel
+}
+
+func (r *VirtualNixResourceModel) GetCreateResourcePlanData(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
+	resp.Diagnostics.Append(req.Plan.Get(ctx, r)...)
+}
+
+func (r VirtualNixResourceModel) SetCreateResourceStateData(ctx context.Context, resp *resource.CreateResponse) {
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r *VirtualNixResourceModel) GetReadResourceStateData(ctx context.Context, req resource.ReadRequest, resp *resource.ReadResponse) {
+	resp.Diagnostics.Append(req.State.Get(ctx, r)...)
+}
+
+func (r VirtualNixResourceModel) SetReadResourceStateData(ctx context.Context, resp *resource.ReadResponse) {
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r *VirtualNixResourceModel) GetUpdateResourcePlanData(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.Append(req.Plan.Get(ctx, r)...)
+}
+
+func (r *VirtualNixResourceModel) GetUpdateResourceStateData(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
+	resp.Diagnostics.Append(req.State.Get(ctx, r)...)
+}
+
+func (r VirtualNixResourceModel) SetUpdateResourceStateData(ctx context.Context, resp *resource.UpdateResponse) {
+	resp.Diagnostics.Append(resp.State.Set(ctx, &r)...)
+}
+
+func (r VirtualNixResourceModel) ToAPIModel(ctx context.Context, packageType string) (interface{}, diag.Diagnostics) {
+	diags := diag.Diagnostics{}
+
+	virtualAPIModel, d := r.VirtualResourceModel.ToAPIModel(ctx, packageType)
+	if d != nil {
+		diags.Append(d...)
+	}
+
+	return VirtualNixAPIModel{
+		VirtualAPIModel: virtualAPIModel.(VirtualAPIModel),
+	}, diags
+}
+
+func (r *VirtualNixResourceModel) FromAPIModel(ctx context.Context, apiModel interface{}) diag.Diagnostics {
+	diags := diag.Diagnostics{}
+
+	model := apiModel.(*VirtualNixAPIModel)
+
+	r.VirtualResourceModel.FromAPIModel(ctx, model.VirtualAPIModel)
+
+	return diags
+}
+
+type VirtualNixAPIModel struct {
+	VirtualAPIModel
+}
+
+func (r *virtualNixResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
+	virtualNixAttributes := lo.Assign(
+		VirtualAttributes,
+		repository.RepoLayoutRefAttribute(Rclass, r.PackageType),
+	)
+
+	resp.Schema = schema.Schema{
+		Version:     1,
+		Attributes:  virtualNixAttributes,
+		Description: r.Description,
+	}
+}

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_nix_repository_test.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_nix_repository_test.go
@@ -1,0 +1,186 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package virtual_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/acctest"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/virtual"
+	"github.com/jfrog/terraform-provider-shared/testutil"
+	"github.com/jfrog/terraform-provider-shared/util"
+)
+
+func TestAccVirtualNixRepository_full(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("nix-virtual-test-repo", "artifactory_virtual_nix_repository")
+	localRepoName := testutil.RandSelect("nix-local-repo-1", "nix-local-repo-2", "nix-local-repo-3").(string)
+
+	temp := `
+		resource "artifactory_local_nix_repository" "{{ .local_repo_name }}" {
+			key = "{{ .local_repo_name }}"
+		}
+
+		resource "artifactory_remote_nix_repository" "{{ .repo_name }}-remote" {
+			key = "{{ .repo_name }}-remote"
+			url = "https://cache.nixos.org"
+		}
+
+		resource "artifactory_virtual_nix_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			repositories = [
+				artifactory_local_nix_repository.{{ .local_repo_name }}.key,
+				artifactory_remote_nix_repository.{{ .repo_name }}-remote.key
+			]
+			description = "Test repository for Nix"
+			notes       = "Internal notes"
+			includes_pattern = "**/*"
+			excludes_pattern   = ""
+			artifactory_requests_can_retrieve_remote_artifacts = true
+			depends_on = [
+				artifactory_local_nix_repository.{{ .local_repo_name }},
+				artifactory_remote_nix_repository.{{ .repo_name }}-remote
+			]
+		}
+	`
+
+	testData := map[string]interface{}{
+		"repo_name":       name,
+		"local_repo_name": localRepoName,
+	}
+
+	config := util.ExecuteTemplate("TestAccVirtualNixRepository_full", temp, testData)
+
+	updatedTemp := `
+		resource "artifactory_local_nix_repository" "{{ .local_repo_name }}" {
+			key = "{{ .local_repo_name }}"
+		}
+
+		resource "artifactory_remote_nix_repository" "{{ .repo_name }}-remote" {
+			key = "{{ .repo_name }}-remote"
+			url = "https://cache.nixos.org"
+		}
+
+		resource "artifactory_virtual_nix_repository" "{{ .repo_name }}" {
+			key = "{{ .repo_name }}"
+			repositories = [
+				artifactory_local_nix_repository.{{ .local_repo_name }}.key,
+				artifactory_remote_nix_repository.{{ .repo_name }}-remote.key
+			]
+			description = "Updated description"
+			notes       = "Updated notes"
+			includes_pattern = "**/*"
+			excludes_pattern   = "*.tmp"
+			artifactory_requests_can_retrieve_remote_artifacts = false
+			depends_on = [
+				artifactory_local_nix_repository.{{ .local_repo_name }},
+				artifactory_remote_nix_repository.{{ .repo_name }}-remote
+			]
+		}
+	`
+
+	updatedConfig := util.ExecuteTemplate("TestAccVirtualNixRepository_full", updatedTemp, testData)
+
+	localFqrn := fmt.Sprintf("artifactory_local_nix_repository.%s", localRepoName)
+	remoteFqrn := fmt.Sprintf("artifactory_remote_nix_repository.%s-remote", name)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, localFqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, remoteFqrn, "key", acctest.CheckRepo),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "repositories.#", "2"),
+					resource.TestCheckResourceAttr(fqrn, "description", "Test repository for Nix"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Internal notes"),
+					resource.TestCheckResourceAttr(fqrn, "includes_pattern", "**/*"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", ""),
+					resource.TestCheckResourceAttr(fqrn, "artifactory_requests_can_retrieve_remote_artifacts", "true"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("virtual", repository.NixPackageType)
+						return r
+					}()),
+				),
+			},
+			{
+				Config: updatedConfig,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "description", "Updated description"),
+					resource.TestCheckResourceAttr(fqrn, "notes", "Updated notes"),
+					resource.TestCheckResourceAttr(fqrn, "excludes_pattern", "*.tmp"),
+					resource.TestCheckResourceAttr(fqrn, "artifactory_requests_can_retrieve_remote_artifacts", "false"),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+			},
+		},
+	})
+}
+
+func TestAccVirtualNixRepository_basic(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("nix-virtual", "artifactory_virtual_nix_repository")
+
+	temp := `
+		resource "artifactory_virtual_nix_repository" "{{ .repo_name }}" {
+			key            = "{{ .repo_name }}"
+			repositories   = []
+		}
+	`
+
+	testData := map[string]interface{}{
+		"repo_name": name,
+	}
+
+	config := util.ExecuteTemplate("TestAccVirtualNixRepository_basic", temp, testData)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "repositories.#", "0"),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef(virtual.Rclass, repository.NixPackageType)
+						return r
+					}()),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+			},
+		},
+	})
+}

--- a/sample.tf
+++ b/sample.tf
@@ -211,6 +211,15 @@ data "artifactory_local_hex_repository" "hex-local" {
   key = artifactory_local_hex_repository.hex-local.key
 }
 
+resource "artifactory_local_nix_repository" "nix-local" {
+  key         = "nix-local"
+  description = "Repo created by Terraform Provider Artifactory"
+}
+
+data "artifactory_local_nix_repository" "nix-local" {
+  key = artifactory_local_nix_repository.nix-local.key
+}
+
 resource "random_id" "randid" {
   byte_length = 16
 }
@@ -476,6 +485,16 @@ resource "artifactory_remote_hex_repository" "my-remote-hex" {
 
 data "artifactory_remote_hex_repository" "my-remote-hex" {
   key = artifactory_remote_hex_repository.my-remote-hex.key
+}
+
+resource "artifactory_remote_nix_repository" "my-remote-nix" {
+  key         = "my-remote-nix"
+  url         = "https://cache.nixos.org"
+  description = "Repo created by Terraform Provider Artifactory"
+}
+
+data "artifactory_remote_nix_repository" "my-remote-nix" {
+  key = artifactory_remote_nix_repository.my-remote-nix.key
 }
 
 resource "artifactory_remote_rpm_repository" "my-remote-rpm" {
@@ -771,6 +790,24 @@ resource "artifactory_virtual_hex_repository" "my-hex-virtual" {
 
 data "artifactory_virtual_hex_repository" "my-hex-virtual" {
   key = artifactory_virtual_hex_repository.my-hex-virtual.key
+}
+
+resource "artifactory_virtual_nix_repository" "my-nix-virtual" {
+  key            = "my-nix-virtual"
+  repositories   = [
+    artifactory_local_nix_repository.nix-local.key,
+    artifactory_remote_nix_repository.my-remote-nix.key
+  ]
+  description    = "A test virtual repo"
+  notes          = "Internal description"
+  depends_on     = [
+    artifactory_local_nix_repository.nix-local,
+    artifactory_remote_nix_repository.my-remote-nix
+  ]
+}
+
+data "artifactory_virtual_nix_repository" "my-nix-virtual" {
+  key = artifactory_virtual_nix_repository.my-nix-virtual.key
 }
 
 resource "artifactory_federated_generic_repository" "generic-federated-1" {


### PR DESCRIPTION
Add Nix repository resources and data sources

- Add local, remote, and virtual Nix repository resources (Plugin Framework), mirroring the Hex repository pattern without signing/keypair fields
- Add local, remote, and virtual Nix repository data sources (Plugin Framework)
- Register Nix resources and data sources in the framework provider; add NixPackageType, PackageNameLookup, and nix-default layout map entries for local/remote/virtual
- Add documentation, examples, sample.tf, and CHANGELOG entries (Issue #1388)