### PR TITLE
allow empty string for v3_feed_url and symbol_server_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-### 12.11.4 (Apr 30, 2026). Tested on Artifactory 7.146.8 with Terraform 1.15.0 and OpenTofu 1.11.6
+### 12.11.4 (Apr 30, 2026).
 
 FEATURES:
 
 * resource/`artifactory_remote_generic_repository`: Add `custom_http_headers` — a list of up to 5 custom HTTP headers (`name`, `value`, `sensitive`) sent on every outbound request to the remote URL. `sensitive` defaults to `false`; when set to `true`, Artifactory encrypts the value server-side. Header values are masked in Terraform plan output. Requires Artifactory support for the `customHttpHeaders` repository configuration. PR: [#1393](https://github.com/jfrog/terraform-provider-artifactory/pull/1393)
+
+BUG FIXES:
+
+* resource/artifactory_remote_nuget_repository: Fix `v3_feed_url` and `symbol_server_url` rejecting empty string values. The Artifactory API accepts empty values for these fields and applies its own defaults server-side; the provider now allows `""` to clear the field. Non-empty values are still validated as valid HTTP/HTTPS URLs. Since the API does not return these fields in GET responses, the configured value is preserved in state to prevent perpetual drift. PR: [#1394](https://github.com/jfrog/terraform-provider-artifactory/pull/1394)
 
 IMPROVEMENTS:
 

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository.go
@@ -125,9 +125,13 @@ func (r *remoteNugetResourceModel) FromAPIModel(ctx context.Context, apiModel in
 	r.PassThrough = types.BoolValue(model.CurationAPIModel.PassThrough)
 	r.FeedContextPath = types.StringValue(model.FeedContextPath)
 	r.DownloadContextPath = types.StringValue(model.DownloadContextPath)
-	r.V3FeedURL = types.StringValue(model.V3FeedURL)
+	if model.V3FeedURL != "" {
+		r.V3FeedURL = types.StringValue(model.V3FeedURL)
+	}
 	r.ForceNugetAuthentication = types.BoolValue(model.ForceNugetAuthentication)
-	r.SymbolServerURL = types.StringValue(model.SymbolServerURL)
+	if model.SymbolServerURL != "" {
+		r.SymbolServerURL = types.StringValue(model.SymbolServerURL)
+	}
 	return diags
 }
 
@@ -167,8 +171,10 @@ func (r *remoteNugetResource) Schema(ctx context.Context, req resource.SchemaReq
 				Computed: true,
 				Default:  stringdefault.StaticString("https://api.nuget.org/v3/index.json"),
 				Validators: []validator.String{
-					stringvalidator.LengthAtLeast(1),
-					validatorfw_string.IsURLHttpOrHttps(),
+					stringvalidator.Any(
+						stringvalidator.LengthAtMost(0),
+						validatorfw_string.IsURLHttpOrHttps(),
+					),
 				},
 				MarkdownDescription: "The URL to the NuGet v3 feed. Default value is 'https://api.nuget.org/v3/index.json'.",
 			},
@@ -183,8 +189,10 @@ func (r *remoteNugetResource) Schema(ctx context.Context, req resource.SchemaReq
 				Computed: true,
 				Default:  stringdefault.StaticString("https://symbols.nuget.org/download/symbols"),
 				Validators: []validator.String{
-					stringvalidator.LengthAtLeast(1),
-					validatorfw_string.IsURLHttpOrHttps(),
+					stringvalidator.Any(
+						stringvalidator.LengthAtMost(0),
+						validatorfw_string.IsURLHttpOrHttps(),
+					),
 				},
 				MarkdownDescription: "NuGet symbol server URL.",
 			},

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository_test.go
@@ -37,6 +37,74 @@ func TestAccRemoteNugetRepository(t *testing.T) {
 	}))
 }
 
+func TestAccRemoteNugetRepository_url_fields(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("test-nuget-remote", "artifactory_remote_nuget_repository")
+
+	const temp = `
+		resource "artifactory_remote_nuget_repository" "{{ .name }}" {
+			key                        = "{{ .name }}"
+			url                        = "https://www.nuget.org/"
+			v3_feed_url                = "{{ .v3FeedUrl }}"
+			symbol_server_url          = "{{ .symbolServerUrl }}"
+			force_nuget_authentication = true
+		}
+	`
+
+	const tempEmpty = `
+		resource "artifactory_remote_nuget_repository" "{{ .name }}" {
+			key                        = "{{ .name }}"
+			url                        = "https://www.nuget.org/"
+			v3_feed_url                = ""
+			symbol_server_url          = ""
+			force_nuget_authentication = true
+		}
+	`
+
+	params := map[string]interface{}{
+		"name":            name,
+		"v3FeedUrl":       "https://api.nuget.org/v3/index.json",
+		"symbolServerUrl": "https://symbols.nuget.org/download/symbols",
+	}
+
+	configWithURLs := util.ExecuteTemplate("TestAccRemoteNugetRepository_url_fields_with_urls", temp, params)
+	configEmpty := util.ExecuteTemplate("TestAccRemoteNugetRepository_url_fields_empty", tempEmpty, map[string]interface{}{"name": name})
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: configWithURLs,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "v3_feed_url", "https://api.nuget.org/v3/index.json"),
+					resource.TestCheckResourceAttr(fqrn, "symbol_server_url", "https://symbols.nuget.org/download/symbols"),
+				),
+			},
+			{
+				Config: configEmpty,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "v3_feed_url", ""),
+					resource.TestCheckResourceAttr(fqrn, "symbol_server_url", ""),
+				),
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectNonEmptyPlan(),
+					},
+				},
+			},
+			{
+				Config: configEmpty,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectEmptyPlan(),
+					},
+				},
+			},
+		},
+	})
+}
+
 func TestAccRemoteNugetRepository_migrate_from_SDKv2(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("test-nuget-remote", "artifactory_remote_nuget_repository")
 


### PR DESCRIPTION
## Summary

- Fix `v3_feed_url` and `symbol_server_url` on `artifactory_remote_nuget_repository` rejecting empty string values during `terraform plan`
- Allow `""` to clear these fields; Artifactory applies its own defaults server-side
- Retain configured value in state to prevent perpetual drift (API never returns these fields in GET responses)

## Problem

Users setting `v3_feed_url = ""` or `symbol_server_url = ""` received two validation errors at plan time:
string length must be at least 1, got: 0
value must be a valid URL with host and http or https scheme, got: ''

Investigation of the Artifactory service code confirmed:
- Both fields are defined as `required = false` with no URL format validation server-side
- The API applies defaults (`https://api.nuget.org/v3/index.json` / `https://symbols.nuget.org/download/symbols`) when values are empty
- The GET response never includes these fields, so reading them back always returns `""`
## Changes
| File | Change |
|------|--------|
| `resource_artifactory_remote_nuget_repository.go` | Replace `LengthAtLeast(1) + IsURLHttpOrHttps()` with `Any(empty, IsURLHttpOrHttps())` on both fields; skip overwriting state in `FromAPIModel` when API returns empty |
| `resource_artifactory_remote_nuget_repository_test.go` | Add `TestAccRemoteNugetRepository_url_fields` covering explicit URLs, clearing to empty, and no-drift on subsequent plan |
| `CHANGELOG.md` | BUG FIXES entry under `12.11.4` |
## Test plan
- [ ] `TestAccRemoteNugetRepository_url_fields` — create with URLs, clear to `""`, verify no drift
- [ ] `TestAccRemoteNugetRepository` — existing full test still passes
- [ ] `TestAccRemoteNugetRepository_migrate_from_SDKv2` — migration still clean