### PR TITLE
resource/artifactory_ldap_group_setting_v2: Add refresh_operation attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 12.11.5 (May 22, 2026).
+### 12.11.5 (May 22, 2026)
 
 BUG FIXES:
 
@@ -6,7 +6,8 @@ BUG FIXES:
 
 IMPROVEMENTS:
 
-* resource/artifactory_ldap_group_setting_v2: Add `refresh_operation` attribute (`UPDATE`, `IMPORT`, `UPDATE_AND_IMPORT`, default: `UPDATE_AND_IMPORT`) to trigger LDAP group synchronization automatically after create or update. Previously, the group config was saved but Artifactory did not sync groups until a manual UI click or API call. Existing resources upgrading to this version will see `+ refresh_operation = "UPDATE_AND_IMPORT"` in the plan and a one-time sync on apply — safe and idempotent. Since the Artifactory API does not return this field, the value is preserved in state. PR: [#1400](https://github.com/jfrog/terraform-provider-artifactory/pull/1400)
+* resource/artifactory_ldap_group_setting_v2: Add `refresh_operation` attribute (`UPDATE`, `IMPORT`, `UPDATE_AND_IMPORT`, default: `UPDATE_AND_IMPORT`) to trigger LDAP group synchronization automatically after create or update. Previously, the group config was saved but Artifactory did not sync groups until a manual UI click or API call. Existing resources upgrading to this version will see `+ refresh_operation = "UPDATE_AND_IMPORT"` in the plan and a one-time sync on apply — safe and idempotent. Since the Artifactory API does not return this field, the value is preserved in state. PR: [#1377](https://github.com/jfrog/terraform-provider-artifactory/pull/1377)
+
 
 ### 12.11.4 (Apr 30, 2026). Tested on Artifactory 7.146.8 with Terraform 1.15.1 and OpenTofu 1.11.6
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+### 12.11.5 (May 22, 2026).
+
+BUG FIXES:
+
+* resource/artifactory_\*\_repository: Use `types.String` to support "unknown" `project_environments` elements during `terraform plan`. This fixes a `Value Conversion Error` when `project_environments` contains values from other resources (e.g., `project_environment` resource IDs). Issue: [#1251](https://github.com/jfrog/terraform-provider-artifactory/issues/1251). PR: [#1252](https://github.com/jfrog/terraform-provider-artifactory/pull/1252)
+
+IMPROVEMENTS:
+
+* resource/artifactory_ldap_group_setting_v2: Add `refresh_operation` attribute (`UPDATE`, `IMPORT`, `UPDATE_AND_IMPORT`, default: `UPDATE_AND_IMPORT`) to trigger LDAP group synchronization automatically after create or update. Previously, the group config was saved but Artifactory did not sync groups until a manual UI click or API call. Existing resources upgrading to this version will see `+ refresh_operation = "UPDATE_AND_IMPORT"` in the plan and a one-time sync on apply — safe and idempotent. Since the Artifactory API does not return this field, the value is preserved in state. PR: [#1400](https://github.com/jfrog/terraform-provider-artifactory/pull/1400)
+
 ### 12.11.4 (Apr 30, 2026). Tested on Artifactory 7.146.8 with Terraform 1.15.1 and OpenTofu 1.11.6
 
 FEATURES:
@@ -13,6 +23,7 @@ IMPROVEMENTS:
 
 * resource/artifactory_archive_policy, resource/artifactory_package_cleanup_policy: Relax search criteria validation so **time-based** conditions (days or months) and **properties-based** conditions (`included_properties`) can be used together. **Version-based** condition (`keep_last_n_versions`) remains mutually exclusive and cannot be combined with time-based or properties-based conditions. For package cleanup policies, combined time + properties behavior follows Artifactory **7.129+** (AND semantics). JTFPR-173.
 * resource/artifactory_remote_vcs_repository: Add `GITLAB` and `GITHUBENTERPRISE` to `vcs_git_provider` validation. Artifactory supports proxying GitLab and GitHub Enterprise in addition to existing providers; the attribute description was updated to list all supported providers. PR: [#1383](https://github.com/jfrog/terraform-provider-artifactory/pull/1383) 
+
 
 ### 12.11.3 (Feb 11, 2026). Tested on Artifactory 7.133.8 with Terraform 1.14.4 and OpenTofu 1.11.4
 

--- a/docs/resources/ldap_group_setting_v2.md
+++ b/docs/resources/ldap_group_setting_v2.md
@@ -28,6 +28,7 @@ resource "artifactory_ldap_group_setting_v2" "ldap_group_name" {
   filter                 = "(objectClass=groupOfNames)"
   description_attribute  = "description"
   strategy               = "STATIC"
+  refresh_operation      = "UPDATE_AND_IMPORT"
 }
 ```
 
@@ -48,6 +49,7 @@ resource "artifactory_ldap_group_setting_v2" "ldap_group_name" {
 ### Optional
 
 - `enabled_ldap` (String) The LDAP setting key you want to use for group retrieval.
+- `refresh_operation` (String) Operation used when refreshing LDAP groups after create/update. Valid values: `UPDATE`, `IMPORT`, `UPDATE_AND_IMPORT`. Defaults to `UPDATE_AND_IMPORT`.
 - `force_attribute_search` (Boolean) This attribute is used in very specific cases of LDAP group settings. Don't switch it to `false`, unless instructed by the JFrog support team. Default value is `false`.
 - `group_base_dn` (String) A search base for group entry DNs, relative to the DN on the LDAP server’s URL (and not relative to the LDAP Setting’s “Search Base”). Used when importing groups.
 - `sub_tree` (Boolean) When set, enables deep search through the sub-tree of the LDAP URL + Search Base. `true` by default. `sub_tree` can be set to true only with `STATIC` or `DYNAMIC` strategy.

--- a/examples/resources/artifactory_ldap_group_setting_v2/resource.tf
+++ b/examples/resources/artifactory_ldap_group_setting_v2/resource.tf
@@ -9,4 +9,5 @@ resource "artifactory_ldap_group_setting_v2" "ldap_group_name" {
   filter                 = "(objectClass=groupOfNames)"
   description_attribute  = "description"
   strategy               = "STATIC"
+  refresh_operation      = "UPDATE_AND_IMPORT"
 }

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_v2.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_v2.go
@@ -61,6 +61,7 @@ type ArtifactoryLdapGroupSettingResourceModel struct {
 	Filter               types.String `tfsdk:"filter"`
 	DescriptionAttribute types.String `tfsdk:"description_attribute"`
 	Strategy             types.String `tfsdk:"strategy"`
+	RefreshOperation     types.String `tfsdk:"refresh_operation"`
 }
 
 // ArtifactoryLdapGroupSettingResourceAPIModel describes the API data model.
@@ -154,6 +155,18 @@ func (r *ArtifactoryLdapGroupSettingResource) Schema(ctx context.Context, req re
 					stringvalidator.OneOf("STATIC", "DYNAMIC", "HIERARCHICAL"),
 				},
 			},
+			"refresh_operation": schema.StringAttribute{
+				MarkdownDescription: "Operation used when refreshing LDAP groups after create/update. Valid values: `UPDATE`, `IMPORT`, `UPDATE_AND_IMPORT`. Defaults to `UPDATE_AND_IMPORT`.",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString("UPDATE_AND_IMPORT"),
+				Validators: []validator.String{
+					stringvalidator.OneOf("UPDATE", "IMPORT", "UPDATE_AND_IMPORT"),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.UseStateForUnknown(),
+				},
+			},
 		},
 	}
 }
@@ -190,6 +203,11 @@ func (r *ArtifactoryLdapGroupSettingResource) Create(ctx context.Context, req re
 		Strategy:             data.Strategy.ValueString(),
 	}
 
+	refreshOperation := data.RefreshOperation.ValueString()
+	if refreshOperation == "" {
+		refreshOperation = "UPDATE_AND_IMPORT"
+	}
+
 	response, err := r.ProviderData.Client.R().
 		SetBody(ldapGroup).
 		Post(LdapGroupEndpoint)
@@ -210,8 +228,21 @@ func (r *ArtifactoryLdapGroupSettingResource) Create(ctx context.Context, req re
 		return
 	}
 
+	refreshResp, err := r.ProviderData.Client.R().
+		SetQueryParam("operation", refreshOperation).
+		Post(LdapGroupEndpoint + ldapGroup.Name + "/refresh")
+	if err != nil {
+		utilfw.UnableToCreateResourceError(resp, err.Error())
+		return
+	}
+	if refreshResp.StatusCode() != http.StatusOK || refreshResp.IsError() {
+		utilfw.UnableToCreateResourceError(resp, refreshResp.String())
+		return
+	}
+
 	// Assign the resource ID for the resource in the state
 	data.Id = types.StringValue(ldapGroup.Name)
+	data.RefreshOperation = types.StringValue(refreshOperation)
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
@@ -251,11 +282,18 @@ func (r *ArtifactoryLdapGroupSettingResource) Read(ctx context.Context, req reso
 		return
 	}
 
+	// Preserve configured refresh_operation from state (API does not return it)
+	currentRefreshOperation := data.RefreshOperation
+
 	// Convert from the API data model to the Terraform data model
 	// and refresh any attribute values.
 	resp.Diagnostics.Append(data.ToState(ctx, ldapGroup)...)
 	if resp.Diagnostics.HasError() {
 		return
+	}
+
+	if !currentRefreshOperation.IsNull() && !currentRefreshOperation.IsUnknown() {
+		data.RefreshOperation = currentRefreshOperation
 	}
 
 	// Save updated data into Terraform state
@@ -284,6 +322,11 @@ func (r *ArtifactoryLdapGroupSettingResource) Update(ctx context.Context, req re
 		Strategy:             data.Strategy.ValueString(),
 	}
 
+	refreshOperation := data.RefreshOperation.ValueString()
+	if refreshOperation == "" {
+		refreshOperation = "UPDATE_AND_IMPORT"
+	}
+
 	response, err := r.ProviderData.Client.R().
 		SetBody(ldapGroup).
 		Put(LdapGroupEndpoint)
@@ -303,10 +346,24 @@ func (r *ArtifactoryLdapGroupSettingResource) Update(ctx context.Context, req re
 		return
 	}
 
+	refreshResp, err := r.ProviderData.Client.R().
+		SetQueryParam("operation", refreshOperation).
+		Post(LdapGroupEndpoint + ldapGroup.Name + "/refresh")
+	if err != nil {
+		utilfw.UnableToUpdateResourceError(resp, err.Error())
+		return
+	}
+	if refreshResp.StatusCode() != http.StatusOK || refreshResp.IsError() {
+		utilfw.UnableToUpdateResourceError(resp, refreshResp.String())
+		return
+	}
+
 	resp.Diagnostics.Append(data.ToState(ctx, ldapGroup)...)
 	if resp.Diagnostics.HasError() {
 		return
 	}
+
+	data.RefreshOperation = types.StringValue(refreshOperation)
 
 	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_v2_test.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_v2_test.go
@@ -43,6 +43,7 @@ func TestAccLdapGroupSettingV2_full(t *testing.T) {
 		filter = "(objectClass=groupOfNames)"
 		description_attribute = "description"
 		strategy = "{{ .strategy }}"
+		refresh_operation = "{{ .refresh_operation }}"
 	}
 	`
 	params := map[string]interface{}{
@@ -51,6 +52,7 @@ func TestAccLdapGroupSettingV2_full(t *testing.T) {
 		"group_base_dn":          "CN=Users,DC=MyDomain,DC=com",
 		"group_member_attribute": "uniqueMember",
 		"strategy":               "STATIC",
+		"refresh_operation":      "UPDATE_AND_IMPORT",
 	}
 	LdapSettingTemplateFull := util.ExecuteTemplate("TestLdap", ldapGroupSetting, params)
 
@@ -60,6 +62,7 @@ func TestAccLdapGroupSettingV2_full(t *testing.T) {
 		"group_base_dn":          "CN=Users,DC=MyDomain,DC=org",
 		"group_member_attribute": "uniqueMember1",
 		"strategy":               "DYNAMIC",
+		"refresh_operation":      "UPDATE",
 	}
 	LdapSettingTemplateFullUpdate := util.ExecuteTemplate("TestLdap", ldapGroupSetting, paramsUpdate)
 
@@ -82,6 +85,7 @@ func TestAccLdapGroupSettingV2_full(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "filter", "(objectClass=groupOfNames)"),
 					resource.TestCheckResourceAttr(fqrn, "description_attribute", "description"),
 					resource.TestCheckResourceAttr(fqrn, "strategy", "STATIC"),
+					resource.TestCheckResourceAttr(fqrn, "refresh_operation", "UPDATE_AND_IMPORT"),
 				),
 			},
 			{
@@ -97,13 +101,15 @@ func TestAccLdapGroupSettingV2_full(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "filter", "(objectClass=groupOfNames)"),
 					resource.TestCheckResourceAttr(fqrn, "description_attribute", "description"),
 					resource.TestCheckResourceAttr(fqrn, "strategy", "DYNAMIC"),
+					resource.TestCheckResourceAttr(fqrn, "refresh_operation", "UPDATE"),
 				),
 			},
 			{
-				ResourceName:      fqrn,
-				ImportState:       true,
-				ImportStateVerify: true,
-				ImportStateCheck:  validator.CheckImportState(name, "name"),
+				ResourceName:            fqrn,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateVerifyIgnore: []string{"refresh_operation"},
+				ImportStateCheck:        validator.CheckImportState(name, "name"),
 			},
 		},
 	})

--- a/pkg/artifactory/resource/repository/repository.go
+++ b/pkg/artifactory/resource/repository/repository.go
@@ -169,7 +169,7 @@ func (r BaseResource) ValidateConfig(ctx context.Context, req resource.ValidateC
 		return
 	}
 
-	var envs []string
+	var envs []types.String
 	resp.Diagnostics.Append(projectEnviroments.ElementsAs(ctx, &envs, false)...)
 	if resp.Diagnostics.HasError() {
 		return
@@ -208,10 +208,10 @@ func (r BaseResource) ValidateConfig(ctx context.Context, req resource.ValidateC
 	if !isSupported {
 		// Before 7.53.1
 		for _, env := range envs {
-			if !slices.Contains(ProjectEnvironmentsSupported, env) {
+			if !slices.Contains(ProjectEnvironmentsSupported, env.ValueString()) {
 				resp.Diagnostics.AddError(
 					"Invalid project_environment not allowed",
-					env,
+					env.ValueString(),
 				)
 				return
 			}

--- a/pkg/artifactory/resource/repository/repository_test.go
+++ b/pkg/artifactory/resource/repository/repository_test.go
@@ -469,3 +469,63 @@ func TestAccRepository_invalid_key(t *testing.T) {
 		},
 	})
 }
+
+func TestAccRepository_unknown_project_environments(t *testing.T) {
+	projectKey := fmt.Sprintf("t%d", testutil.RandomInt())
+	repoName := fmt.Sprintf("%s-generic-local", projectKey)
+	environment := fmt.Sprintf("prjenv%d", testutil.RandomInt())
+
+	_, fqrn, name := testutil.MkNames(repoName, "artifactory_local_generic_repository")
+
+	params := map[string]interface{}{
+		"name":        name,
+		"projectKey":  projectKey,
+		"environment": environment,
+	}
+	localRepositoryBasic := util.ExecuteTemplate("TestAccLocalGenericRepository", `
+		resource "project" "{{ .projectKey }}" {
+			key = "{{ .projectKey }}"
+			display_name = "{{ .projectKey }}"
+			description  = "My Project"
+			admin_privileges {
+				manage_members   = true
+				manage_resources = true
+				index_resources  = true
+			}
+			max_storage_in_gibibytes   = 10
+			block_deployments_on_limit = false
+			email_notification         = true
+		}
+
+		resource "project_environment" "{{ .environment }}" {
+			name        = "{{ .environment }}"
+			project_key = project.{{ .projectKey }}.id
+		}
+
+		resource "artifactory_local_generic_repository" "{{ .name }}" {
+			key                  = "{{ .name }}"
+			project_key          = project.{{ .projectKey }}.key
+			project_environments = [ project_environment.{{ .environment }}.id ]
+		}
+	`, params)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() { acctest.PreCheck(t) },
+		ExternalProviders: map[string]resource.ExternalProvider{
+			"project": {
+				Source: "jfrog/project",
+			},
+		},
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: localRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "project_environments.#", "1"),
+					resource.TestCheckResourceAttr(fqrn, "project_environments.0", fmt.Sprintf("%s-%s", projectKey, environment)),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Adds a new optional `refresh_operation` attribute to the `artifactory_ldap_group_setting_v2` resource that controls how LDAP groups are synchronized with Artifactory after a create or update operation.

Previously, the resource only saved the LDAP group configuration via the API but never triggered the actual group synchronization. Users had to manually click **Synchronize** in the Artifactory UI or call the refresh API themselves after every `terraform apply`. This change automates that step.

## What changed

- **New attribute `refresh_operation`** — optional, computed, defaults to `UPDATE_AND_IMPORT`
  - `UPDATE` — re-syncs membership of already-imported groups
  - `IMPORT` — imports new groups from LDAP/AD into Artifactory
  - `UPDATE_AND_IMPORT` — does both (recommended default)

- **Create and Update** now call `POST /access/api/v1/ldap/groups/{name}/refresh?operation=<value>` automatically after saving the config

- **Read** preserves `refresh_operation` from prior state since the Artifactory API does not return this field in GET responses

- **ImportStateVerifyIgnore** added for `refresh_operation` in tests for the same reason — import cannot reconstruct this value from the API

## Files changed

| File | Change |
|---|---|
| `resource_artifactory_ldap_group_setting_v2.go` | New field, schema, Create/Read/Update logic |
| `resource_artifactory_ldap_group_setting_v2_test.go` | Updated template, checks, import ignore |
| `examples/resources/artifactory_ldap_group_setting_v2/resource.tf` | Added `refresh_operation` to example |
| `docs/resources/ldap_group_setting_v2.md` | Documented new attribute |

## Example usage

```hcl
resource "artifactory_ldap_group_setting_v2" "example" {
  name                   = "company-ad-groups"
  enabled_ldap           = "company-ad"
  group_base_dn          = "ou=Groups,dc=company,dc=com"
  group_name_attribute   = "cn"
  group_member_attribute = "member"
  filter                 = "(objectClass=group)"
  description_attribute  = "description"
  strategy               = "STATIC"
  refresh_operation      = "UPDATE_AND_IMPORT"
}
```

## API reference

- `POST /access/api/v1/ldap/groups/` — create group setting
- `POST /access/api/v1/ldap/groups/{name}/refresh?operation=UPDATE_AND_IMPORT` — trigger sync

## Testing

Verified manually via curl:
- Create returns `201 Created` with full config echoed back
- Refresh endpoint responds to the `operation` query param
- `refresh_operation` is correctly preserved in state across plan/apply cycles
