### PR TITLE
Fix the `CHANGELOG check` workflow fails for forked PRs

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,14 +1,17 @@
 name: "CHANGELOG check"
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, labeled, unlabeled]
 
 jobs:
   build:
     name: Check Actions
     runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      pull-requests: read
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Changelog check
         uses: Zomzog/changelog-checker@v1.2.0
         with:


### PR DESCRIPTION

### Root Cause

The workflow was using the `pull_request` trigger. For fork PRs, GitHub automatically
restricts the `GITHUB_TOKEN` to **read-only** as a security measure — it doesn't trust
code from outside the repository with write access.

The `Zomzog/changelog-checker` action with `checkNotification: Detailed` tries to create
a **GitHub Check Run** (the ✅/❌ status in the Checks tab), which requires `checks:write`.
Since the token is read-only for fork PRs → **403**.

---

## Fix

### 1. Change trigger from `pull_request` → `pull_request_target`

`pull_request_target` runs the workflow in the **base repository's context** (not the fork),
so the token has proper write access even for fork PRs.

**This is safe here because:**
- `actions/checkout` without an explicit `ref` checks out the **base branch** — not the fork's code
- `Zomzog/changelog-checker` uses the **GitHub API** to check file changes — no fork code is executed
- No scripts from the fork are run at any point

### 2. Add explicit `permissions` block

```yaml
permissions:
  checks: write       # to create the Check Run in the Checks tab
  pull-requests: read # to read which files changed in the PR