### PR TITLE
Allow storage info scoped tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 BUG FIXES:
 
+* resource/artifactory_scoped_token: Allow the documented `system:info/storage:r` scope for storage summary read access. Issue: [#1401](https://github.com/jfrog/terraform-provider-artifactory/issues/1401)
 * resource/artifactory_\*\_repository: Use `types.String` to support "unknown" `project_environments` elements during `terraform plan`. This fixes a `Value Conversion Error` when `project_environments` contains values from other resources (e.g., `project_environment` resource IDs). Issue: [#1251](https://github.com/jfrog/terraform-provider-artifactory/issues/1251). PR: [#1252](https://github.com/jfrog/terraform-provider-artifactory/pull/1252)
 
 IMPROVEMENTS:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,7 @@ IMPROVEMENTS:
 
 BUG FIXES:
 
+* resource/artifactory_scoped_token: Allow the documented `system:info/storage:r` scope for storage summary read access. Issue: [#1401](https://github.com/jfrog/terraform-provider-artifactory/issues/1401)
 * resource/artifactory_\*\_repository: Use `types.String` to support "unknown" `project_environments` elements during `terraform plan`. This fixes a `Value Conversion Error` when `project_environments` contains values from other resources (e.g., `project_environment` resource IDs). Issue: [#1251](https://github.com/jfrog/terraform-provider-artifactory/issues/1251). PR: [#1252](https://github.com/jfrog/terraform-provider-artifactory/pull/1252)
 
 IMPROVEMENTS:

--- a/docs/resources/scoped_token.md
+++ b/docs/resources/scoped_token.md
@@ -87,6 +87,7 @@ resource "artifactory_scoped_token" "audience" {
   - `applied-permissions/groups` - this scope assigns permissions to groups using the following format: `applied-permissions/groups:<group-name>[,<group-name>...]`
   - `system:metrics:r` - for getting the service metrics
   - `system:livelogs:r` - for getting the service livelogs
+  - `system:info/storage:r` - for getting storage summary information
   - Resource Permissions: From Artifactory 7.38.x, resource permissions scoped tokens are also supported in the REST API. A permission can be represented as a scope token string in the following format: `<resource-type>:<target>[/<sub-resource>]:<actions>`
     - Where:
       - `<resource-type>` - one of the permission resource types, from a predefined closed list. Currently, the only resource type that is supported is the artifact resource type.

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
@@ -208,6 +208,7 @@ var schemaAttributesV0 = map[string]schema.Attribute{
 			"      - `metrics|livelogs|identities|permissions` - one of these options can be chosen" +
 			"      - `<actions>` - comma-separated list of action acronyms. " +
 			"The actions allowed are `r`, `w`, `d`, `a`, `m`, `x`, `s`, or any combination of these actions. To allow all actions - use `*`\n" +
+			"      - `system:info/storage:r` - grants read access to storage summary information.\n" +
 			"    - Examples:\n" +
 			"      - `[\"system:livelogs:r\", \"system:metrics:r,w,d\"]`\n" +
 			"->The scope to assign to the token should be provided as a list of scope tokens, limited to 500 characters in total.\n" +
@@ -229,7 +230,7 @@ var schemaAttributesV0 = map[string]schema.Attribute{
 					stringvalidator.RegexMatches(regexp.MustCompile(`^applied-permissions\/groups:.+$`), "must be 'applied-permissions/groups:<group-name>[,<group-name>...]'"),
 					stringvalidator.RegexMatches(regexp.MustCompile(`^applied-permissions\/roles:.+:.+$`), "must be 'applied-permissions/roles:<project-key>:<role-name>[,<role-name>...]'"),
 					stringvalidator.RegexMatches(regexp.MustCompile(`^artifact:(?:.+):(?:(?:[rwdamxs*]+)|(?:[rwdamxs]+)(?:,[rwdamxs]+)+)$`), "must be '<resource-type>:<target>[/<sub-resource>]:<actions>'"),
-					stringvalidator.RegexMatches(regexp.MustCompile(`^system:(?:metrics|livelogs|identities|permissions):(?:(?:[rwdamxs*]+)|(?:[rwdamxs]+)(?:,[rwdamxs]+)+)$`), "must be 'system:(metrics|livelogs|identities|permissions):<actions>'"),
+					stringvalidator.RegexMatches(regexp.MustCompile(`^(?:system:(?:metrics|livelogs|identities|permissions):(?:(?:[rwdamxs*]+)|(?:[rwdamxs]+)(?:,[rwdamxs]+)+)|system:info\/storage:r)$`), "must be 'system:(metrics|livelogs|identities|permissions):<actions>' or 'system:info/storage:r'"),
 				),
 			),
 		},

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token_schema_test.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token_schema_test.go
@@ -1,0 +1,70 @@
+// Copyright (c) JFrog Ltd. (2026)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestScopedTokenScopesValidatorAllowsSystemStorageInfo(t *testing.T) {
+	validateScopedTokenScopes(t, "system:info/storage:r", false)
+}
+
+func TestScopedTokenScopesValidatorRejectsUnsupportedSystemStorageInfoAction(t *testing.T) {
+	validateScopedTokenScopes(t, "system:info/storage:w", true)
+}
+
+func validateScopedTokenScopes(t *testing.T, scope string, expectError bool) {
+	t.Helper()
+
+	scopesAttribute, ok := schemaAttributesV1["scopes"].(schema.SetAttribute)
+	if !ok {
+		t.Fatal("expected scopes attribute to be a schema.SetAttribute")
+	}
+
+	scopesValue, diags := types.SetValue(types.StringType, []attr.Value{
+		types.StringValue(scope),
+	})
+	if diags.HasError() {
+		t.Fatalf("failed to build scopes value: %s", diags.Errors())
+	}
+
+	for _, setValidator := range scopesAttribute.Validators {
+		var response validator.SetResponse
+		setValidator.ValidateSet(context.Background(), validator.SetRequest{
+			Path:        path.Root("scopes"),
+			ConfigValue: scopesValue,
+		}, &response)
+
+		if expectError && response.Diagnostics.HasError() {
+			return
+		}
+
+		if !expectError && response.Diagnostics.HasError() {
+			t.Fatalf("expected %q to pass validation, got: %s", scope, response.Diagnostics.Errors())
+		}
+	}
+
+	if expectError {
+		t.Fatalf("expected %q to fail validation", scope)
+	}
+}


### PR DESCRIPTION
## Summary

- Allow `artifactory_scoped_token.scopes` to accept the documented `system:info/storage:r` scope.
- Keep storage-info scope validation narrow to the read-only form, and add focused validator coverage.
- Update the resource docs and changelog for the accepted scope.

Fixes #1401.

## Source refs

- JFrog Storage Summary Info docs list `system:info/storage:r` as the scoped-token permission for storage summary read access: https://docs.jfrog.com/artifactory/reference/getStorageSummaryInfo

## Verification

- `go test ./pkg/artifactory/resource/security -run 'TestScopedTokenScopesValidator' -count=1`
- `go test ./pkg/artifactory/resource/security -run '^$' -count=1`
- `go test ./pkg/artifactory/provider -run TestProviderSDKV2 -count=1`
- `git diff --check`

Implemented with Codex assistance; I kept the patch focused and manually reviewed the final diff.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Scoped tokens now accept the documented `system:info/storage:r` permission for read-only storage summary access.
  * Unsupported write access, such as `system:info/storage:w`, continues to be rejected.

* **Documentation**
  * Updated scoped-token documentation and changelog entries to include the storage information read permission.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->