### PR TITLE
Fix docs for artifactory_saml_settings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Unreleased
+
+BUG FIXES:
+
+* resource/artifactory_saml_settings: Fix documentation incorrectly stating the resource supports `terraform import`. The resource has no import implementation.
+
 ### 12.11.5 (May 21, 2026). Tested on Artifactory 7.146.13 with Terraform 1.15.4 and OpenTofu 1.12.0
 
 BUG FIXES:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 12.11.16 (Sep 9, 2026).
+
+DOCUMENTATION:
+
+* resource/artifactory_saml_settings: Correct the documentation, which incorrectly stated that the resource can be imported using `saml_settings` as the ID. The importer was removed in PR [#1073](https://github.com/jfrog/terraform-provider-artifactory/pull/1073) and the resource has had no import implementation since. PR: [#1410](https://github.com/jfrog/terraform-provider-artifactory/pull/1410)
+
 ### 12.11.15 (Aug 31, 2026). Tested on Artifactory 7.161.20 with Terraform 1.16.0 and OpenTofu 1.12.3
 
 FEATURES:

--- a/docs/resources/saml_settings.md
+++ b/docs/resources/saml_settings.md
@@ -52,8 +52,4 @@ The following arguments are supported:
 
 ## Import
 
-Current SAML SSO settings can be imported using `saml_settings` as the `ID`, e.g.
-
-```
-$ terraform import artifactory_saml_settings.saml saml_settings
-```
+This resource **does not** support import.


### PR DESCRIPTION
The docs for `artifactory_saml_settings` say they can be imported using `saml_settings` as the ID.

However, this is not true, the `Importer` for `artifactory_saml_settings` was removed in:

https://github.com/jfrog/terraform-provider-artifactory/pull/1073

Here: https://github.com/jfrog/terraform-provider-artifactory/pull/1073/changes#diff-787510c6ee917786ac7b98df2385473e5375ced8b5da49f86922edb35e6ecf7aL46-L49

This PR updates the docs to be accurate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the SAML settings resource documentation to clarify that importing is not supported.
  - Removed the previously documented import command and instructions.
  - Added a changelog entry describing the documentation correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->