### PR TITLE
Add `retrieval_cache_period_seconds` attribute to RPM virtual repository types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 12.11.6 (Jun 9, 2026).
+### 12.11.6 (Jun 9, 2026). Tested on Artifactory 7.146.15 with Terraform 1.15.5 and OpenTofu 1.12.1
 
 IMPROVEMENTS:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 12.11.6 (Jun 9, 2026).
+
+IMPROVEMENTS:
+
+* resource/artifactory_virtual_rpm_repository: Add `retrieval_cache_period_seconds` attribute. This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching. Default value is `7200`. PR: [#1413](https://github.com/jfrog/terraform-provider-artifactory/pull/1413)
+
 ### 12.11.5 (May 21, 2026). Tested on Artifactory 7.146.13 with Terraform 1.15.4 and OpenTofu 1.12.0
 
 BUG FIXES:

--- a/docs/resources/virtual_rpm_repository.md
+++ b/docs/resources/virtual_rpm_repository.md
@@ -61,6 +61,7 @@ The following arguments are supported, along with the [common list of arguments 
   contain spaces or special characters.
 * `primary_keypair_ref` - (Optional) The primary GPG key to be used to sign packages.
 * `secondary_keypair_ref` - (Optional) The secondary GPG key to be used to sign packages.
+* `retrieval_cache_period_seconds` - (Optional, Default: `7200`) This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching.
 
 Artifactory REST API call Get Key Pair doesn't return keys `private_key` and `passphrase`, but consumes these keys in the POST call.
 

--- a/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_rpm_repository.go
+++ b/pkg/artifactory/datasource/repository/virtual/datasource_artifactory_virtual_rpm_repository.go
@@ -31,10 +31,12 @@ func DatasourceArtifactoryVirtualRpmRepository() *schema.Resource {
 			return nil, err
 		}
 
-		return &virtual.RepositoryBaseParams{
-			PackageType:   resource_repository.RPMPackageType,
-			Rclass:        virtual.Rclass,
-			RepoLayoutRef: repoLayout,
+		return &virtual.RepositoryBaseParamsWithRetrievalCachePeriodSecs{
+			RepositoryBaseParams: virtual.RepositoryBaseParams{
+				PackageType:   resource_repository.RPMPackageType,
+				Rclass:        virtual.Rclass,
+				RepoLayoutRef: repoLayout,
+			},
 		}, nil
 	}
 

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
@@ -405,9 +405,10 @@ EOF
 		}
 
 		resource "artifactory_virtual_rpm_repository" "{{ .repo_name }}" {
-			key 	              = "{{ .repo_name }}"
-			primary_keypair_ref   = artifactory_keypair.{{ .kp_name }}.pair_name
-			secondary_keypair_ref = artifactory_keypair.{{ .kp_name2 }}.pair_name
+			key 	                       = "{{ .repo_name }}"
+			primary_keypair_ref            = artifactory_keypair.{{ .kp_name }}.pair_name
+			secondary_keypair_ref          = artifactory_keypair.{{ .kp_name2 }}.pair_name
+			retrieval_cache_period_seconds = 650
 
 			depends_on = [
 				artifactory_keypair.{{ .kp_name }},
@@ -440,6 +441,7 @@ EOF
 					resource.TestCheckResourceAttr(fqrn, "package_type", packageType),
 					resource.TestCheckResourceAttr(fqrn, "primary_keypair_ref", kpName),
 					resource.TestCheckResourceAttr(fqrn, "secondary_keypair_ref", kpName2),
+					resource.TestCheckResourceAttr(fqrn, "retrieval_cache_period_seconds", "650"),
 					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
 						r, _ := repository.GetDefaultRepoLayoutRef(virtual.Rclass, packageType)
 						return r

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_rpm_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_rpm_repository.go
@@ -25,6 +25,7 @@ import (
 var rpmSchema = lo.Assign(
 	repository.PrimaryKeyPairRefSDKv2,
 	repository.SecondaryKeyPairRefSDKv2,
+	RetrievalCachePeriodSecondsSchema,
 	repository.RepoLayoutRefSDKv2Schema(Rclass, repository.RPMPackageType),
 )
 
@@ -37,7 +38,7 @@ func ResourceArtifactoryVirtualRpmRepository() *schema.Resource {
 	}
 
 	type RpmVirtualRepositoryParams struct {
-		RepositoryBaseParams
+		RepositoryBaseParamsWithRetrievalCachePeriodSecs
 		CommonRpmDebianVirtualRepositoryParams
 	}
 
@@ -45,7 +46,7 @@ func ResourceArtifactoryVirtualRpmRepository() *schema.Resource {
 		d := &utilsdk.ResourceData{ResourceData: s}
 
 		repo := RpmVirtualRepositoryParams{
-			RepositoryBaseParams: UnpackBaseVirtRepo(s, "rpm"),
+			RepositoryBaseParamsWithRetrievalCachePeriodSecs: UnpackBaseVirtRepoWithRetrievalCachePeriodSecs(s, "rpm"),
 			CommonRpmDebianVirtualRepositoryParams: CommonRpmDebianVirtualRepositoryParams{
 				PrimaryKeyPairRefParam: repository.PrimaryKeyPairRefParam{
 					PrimaryKeyPairRefSDKv2: d.GetString("primary_keypair_ref", false),
@@ -62,9 +63,11 @@ func ResourceArtifactoryVirtualRpmRepository() *schema.Resource {
 
 	constructor := func() (interface{}, error) {
 		return &RpmVirtualRepositoryParams{
-			RepositoryBaseParams: RepositoryBaseParams{
-				Rclass:      Rclass,
-				PackageType: repository.RPMPackageType,
+			RepositoryBaseParamsWithRetrievalCachePeriodSecs: RepositoryBaseParamsWithRetrievalCachePeriodSecs{
+				RepositoryBaseParams: RepositoryBaseParams{
+					Rclass:      Rclass,
+					PackageType: repository.RPMPackageType,
+				},
 			},
 		}, nil
 	}

--- a/sample.tf
+++ b/sample.tf
@@ -744,8 +744,9 @@ resource "artifactory_virtual_pypi_repository" "foo-pypi" {
 resource "artifactory_virtual_rpm_repository" "foo-rpm-virtual" {
   key = "foo-rpm-virtual"
 
-  primary_keypair_ref   = artifactory_keypair.some-keypairGPG1.pair_name
-  secondary_keypair_ref = artifactory_keypair.some-keypairGPG2.pair_name
+  primary_keypair_ref            = artifactory_keypair.some-keypairGPG1.pair_name
+  secondary_keypair_ref          = artifactory_keypair.some-keypairGPG2.pair_name
+  retrieval_cache_period_seconds = 650
 
   depends_on = [
     artifactory_keypair.some-keypairGPG1,


### PR DESCRIPTION
## Summary

- Add `retrieval_cache_period_seconds` attribute to `artifactory_virtual_rpm_repository` resource and data source
- This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching. Default: `7200`
- The API field is `virtualRetrievalCachePeriodSecs` and defaults to `600` server-side when not set; the provider sets a static default of `7200` to maintain consistency with other virtual repository types (alpine, conan, debian, helm, npm) that already support this attribute

## Changes

| File | Change |
|------|--------|
| `resource_artifactory_virtual_rpm_repository.go` | Added `RetrievalCachePeriodSecondsSchema` to schema, changed struct to `RepositoryBaseParamsWithRetrievalCachePeriodSecs`, uses `UnpackBaseVirtRepoWithRetrievalCachePeriodSecs` for unpacking |
| `datasource_artifactory_virtual_rpm_repository.go` | Updated constructor to return `RepositoryBaseParamsWithRetrievalCachePeriodSecs` so the packer populates the field on read |
| `resource_artifactory_virtual_repository_test.go` | Added `retrieval_cache_period_seconds = 650` to `TestAccVirtualRpmRepository` config and check |
| `docs/resources/virtual_rpm_repository.md` | Documented the new attribute |
| `CHANGELOG.md` | Added 12.11.6 entry |
| `sample.tf` | Added `retrieval_cache_period_seconds = 650` to RPM virtual repo example |

## Test plan

- [ ] `TestAccVirtualRpmRepository` — verifies `retrieval_cache_period_seconds = 650` is set and persisted through create, import, and import-state-verify
- [ ] Verify `terraform plan` shows no drift after `terraform apply` for RPM virtual repos with and without the attribute set
- [ ] Verify existing virtual repository types (alpine, conan, debian, helm, npm) are unaffected
