### PR TITLE
fix: default missing webhook anyFederated field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ### 12.11.6 (Jun 9, 2026). Tested on Artifactory 7.146.15 with Terraform 1.15.5 and OpenTofu 1.12.1
 
+BUG FIXES:
+
+* resource/artifactory_artifact_webhook, resource/artifactory_artifact_property_webhook, resource/artifactory_docker_webhook, resource/artifactory_artifact_custom_webhook, resource/artifactory_artifact_property_custom_webhook, resource/artifactory_docker_custom_webhook: Treat missing `anyFederated` API fields as `false` during read to avoid panics when importing older webhooks. Issue: [#1412](https://github.com/jfrog/terraform-provider-artifactory/issues/1412)
+
 IMPROVEMENTS:
 
 * resource/artifactory_virtual_rpm_repository: Add `retrieval_cache_period_seconds` attribute. This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching. Default value is `7200`. PR: [#1413](https://github.com/jfrog/terraform-provider-artifactory/pull/1413)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,10 @@ IMPROVEMENTS:
 
 ### 12.11.6 (Jun 9, 2026). Tested on Artifactory 7.146.15 with Terraform 1.15.5 and OpenTofu 1.12.1
 
+BUG FIXES:
+
+* resource/artifactory_artifact_webhook, resource/artifactory_artifact_property_webhook, resource/artifactory_docker_webhook, resource/artifactory_artifact_custom_webhook, resource/artifactory_artifact_property_custom_webhook, resource/artifactory_docker_custom_webhook: Treat missing `anyFederated` API fields as `false` during read to avoid panics when importing older webhooks. Issue: [#1412](https://github.com/jfrog/terraform-provider-artifactory/issues/1412)
+
 IMPROVEMENTS:
 
 * resource/artifactory_virtual_rpm_repository: Add `retrieval_cache_period_seconds` attribute. This value refers to the number of seconds to cache metadata files before checking for newer versions on aggregated repositories. A value of 0 indicates no caching. Default value is `7200`. PR: [#1413](https://github.com/jfrog/terraform-provider-artifactory/pull/1413)

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook_repo.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook_repo.go
@@ -313,6 +313,11 @@ func fromRepoCriteriaAPIMode(ctx context.Context, criteriaAPIModel map[string]in
 		repoKeys = ks
 	}
 
+	anyFederated, ok := criteriaAPIModel["anyFederated"].(bool)
+	if !ok {
+		anyFederated = false
+	}
+
 	criteria, d := types.ObjectValue(
 		repoCriteriaSetResourceModelAttributeTypes,
 		lo.Assign(
@@ -320,7 +325,7 @@ func fromRepoCriteriaAPIMode(ctx context.Context, criteriaAPIModel map[string]in
 			map[string]attr.Value{
 				"any_local":     types.BoolValue(criteriaAPIModel["anyLocal"].(bool)),
 				"any_remote":    types.BoolValue(criteriaAPIModel["anyRemote"].(bool)),
-				"any_federated": types.BoolValue(criteriaAPIModel["anyFederated"].(bool)),
+				"any_federated": types.BoolValue(anyFederated),
 				"repo_keys":     repoKeys,
 			},
 		),

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook_repo_unit_test.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook_repo_unit_test.go
@@ -1,0 +1,47 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package webhook
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+func TestFromRepoCriteriaAPIModelDefaultsMissingAnyFederatedToFalse(t *testing.T) {
+	ctx := context.Background()
+	baseCriteriaAttrs := map[string]attr.Value{
+		"include_patterns": types.SetNull(types.StringType),
+		"exclude_patterns": types.SetNull(types.StringType),
+	}
+	criteriaAPIModel := map[string]interface{}{
+		"anyLocal":  false,
+		"anyRemote": false,
+		"repoKeys":  []interface{}{"my-local-repo"},
+	}
+
+	criteriaSet, diags := fromRepoCriteriaAPIMode(ctx, criteriaAPIModel, baseCriteriaAttrs)
+	if diags.HasError() {
+		t.Fatalf("unexpected diagnostics: %s", diags.Errors())
+	}
+
+	criteria := criteriaSet.Elements()[0].(types.Object)
+	anyFederated := criteria.Attributes()["any_federated"].(types.Bool)
+	if anyFederated.ValueBool() {
+		t.Fatal("expected missing anyFederated API field to default to false")
+	}
+}


### PR DESCRIPTION
## Summary

- default a missing webhook `anyFederated` API field to `false` while reading repo webhook criteria
- add a focused regression test for legacy API responses that omit `anyFederated`
- add a changelog entry for issue #1412

## Verification

- `go test ./pkg/artifactory/resource/webhook -run TestFromRepoCriteriaAPIModelDefaultsMissingAnyFederatedToFalse -count=1`
- `go test ./pkg/artifactory/resource/webhook -count=1`
- `git diff --check`

This was implemented with Codex assistance, with the final diff manually reviewed and kept focused on the missing-field panic.

Closes #1412.
