### PR TITLE
Change default value of `bypass_head_requests` for `artifactory_remote_ansible_repository`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
-### 12.11.7 (Jun 11, 2026). Tested on Artifactory 7.146.17 with Terraform 1.15.6 and OpenTofu 1.12.2
+### 12.11.7 (Jun 16, 2026). 
 
 BUG FIXES:
 
-* resource/artifactory_package_cleanup_policy: Preserve omitted `cron_expression` as null when Artifactory returns an empty string, avoiding an inconsistent result after apply. Issue: [#1406](https://github.com/jfrog/terraform-provider-artifactory/issues/1406)
+* resource/artifactory_package_cleanup_policy: Preserve omitted `cron_expression` as null when Artifactory returns an empty string, avoiding an inconsistent result after apply. Issue: [#1406](https://github.com/jfrog/terraform-provider-artifactory/issues/1406) PR: [#1414](https://github.com/jfrog/terraform-provider-artifactory/pull/1414)
+
+IMPROVEMENTS:
+
+* resource/artifactory_remote_ansible_repository: Change default value of `bypass_head_requests` from `false` to `true`. The `galaxy.ansible.com` registry rejects HEAD requests, so this attribute must be `true` for the remote repository to function correctly. This aligns the provider default with the Artifactory server behavior, which automatically sets this to `true` for Ansible repositories. PR: [#1422](https://github.com/jfrog/terraform-provider-artifactory/pull/1422)
 
 ### 12.11.6 (Jun 9, 2026). Tested on Artifactory 7.146.15 with Terraform 1.15.5 and OpenTofu 1.12.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 12.11.7 (Jun 16, 2026). 
+### 12.11.7 (Jun 16, 2026). Tested on Artifactory 7.146.17 with Terraform 1.15.6 and OpenTofu 1.12.2
 
 BUG FIXES:
 

--- a/docs/resources/remote_ansible_repository.md
+++ b/docs/resources/remote_ansible_repository.md
@@ -12,8 +12,9 @@ Official documentation can be found [here](https://jfrog.com/help/r/jfrog-artifa
 
 ```terraform
 resource "artifactory_remote_ansible_repository" "my-remote-ansible" {
-  key = "my-remote-ansible"
-  url = "https://galaxy.ansible.com"
+  key                  = "my-remote-ansible"
+  url                  = "https://galaxy.ansible.com"
+  bypass_head_requests = true
 }
 ```
 

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_ansible_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_ansible_repository.go
@@ -21,6 +21,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
@@ -120,6 +121,15 @@ func (r *remoteAnsibleResource) Schema(ctx context.Context, req resource.SchemaR
 				Computed:            true,
 				Default:             stringdefault.StaticString("https://galaxy.ansible.com"),
 				MarkdownDescription: "The remote repo URL. Default to 'https://galaxy.ansible.com'",
+			},
+			"bypass_head_requests": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(true),
+				MarkdownDescription: "Before caching an artifact, Artifactory first sends a HEAD request to the remote resource. " +
+					"In some remote resources, HEAD requests are disallowed and therefore rejected, even though downloading the " +
+					"artifact is allowed. When checked, Artifactory will bypass the HEAD request and cache the artifact directly using a GET request. " +
+					"Default to 'true' for Ansible repositories as 'https://galaxy.ansible.com' rejects HEAD requests.",
 			},
 		},
 	)

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_ansible_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_ansible_repository_test.go
@@ -43,6 +43,7 @@ func TestAccRemoteAnsibleRepository(t *testing.T) {
 				Check: resource.ComposeTestCheckFunc(
 					resource.TestCheckResourceAttr(fqrn, "key", name),
 					resource.TestCheckResourceAttr(fqrn, "url", "https://galaxy.ansible.com"),
+					resource.TestCheckResourceAttr(fqrn, "bypass_head_requests", "true"),
 				),
 			},
 			{
@@ -62,7 +63,8 @@ func TestAccRemoteAnsibleRepository_migrate_from_SDKv2(t *testing.T) {
 
 	const temp = `
 		resource "artifactory_remote_ansible_repository" "{{ .name }}" {
-			key = "{{ .name }}"
+			key                  = "{{ .name }}"
+			bypass_head_requests = true
 		}
 	`
 

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook_build.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook_build.go
@@ -66,7 +66,7 @@ var buildCriteriaBlock = schema.SetNestedBlock{
 				},
 				"selected_builds": schema.SetAttribute{
 					ElementType: types.StringType,
-					Optional: true,
+					Optional:    true,
 					Description: "Trigger on this list of build IDs",
 				},
 			},


### PR DESCRIPTION
## Summary

- Change default value of `bypass_head_requests` from `false` to `true` for `artifactory_remote_ansible_repository`
- `galaxy.ansible.com` rejects HEAD requests, making this attribute required for the remote repository to work.
- Artifactory server already defaults this to `true` for Ansible repos on creation, but the Terraform provider was explicitly sending `false` — overriding the server default. This fix aligns the provider with the server behavior.
- Updated example in documentation to include `bypass_head_requests = true`
- Updated migration test to explicitly set `bypass_head_requests = true` so old (12.8.3) and new provider produce the same state
- Added assertion in basic test to verify the default is `true`

## Files changed

- `pkg/artifactory/resource/repository/remote/resource_artifactory_remote_ansible_repository.go` — Override `bypass_head_requests` schema attribute to default to `true`
- `pkg/artifactory/resource/repository/remote/resource_artifactory_remote_ansible_repository_test.go` — Fix migration test, add default value assertion
- `docs/resources/remote_ansible_repository.md` — Add `bypass_head_requests = true` to example
- `CHANGELOG.md` — Add entry under IMPROVEMENTS with upgrade note

## Upgrade note

Existing Ansible remote repositories that did not explicitly set `bypass_head_requests` will see a plan diff (`false` -> `true`) on the next `terraform plan` after upgrading. This apply is safe and fixes the repository configuration. Users can explicitly set `bypass_head_requests = false` to override if needed.

## Test plan

- [x] `terraform apply` with `bypass_head_requests = true` — state confirms `true`
- [x] `terraform apply` without `bypass_head_requests` set (old provider) — state shows `false`, confirming the bug
- [x] Full remote repo acceptance tests pass (except pre-existing Hex PEM failures)
- [ ] `TestAccRemoteAnsible` tests pass with fix: `TF_ACC=1 go test ./pkg/artifactory/resource/repository/remote/ -run TestAccRemoteAnsible -v`
