### PR TITLE
Add `enable_normalized_version` to NuGet repository resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 12.11.8 (Unreleased)
+
+FEATURES:
+
+* resource/artifactory_local_nuget_repository, resource/artifactory_remote_nuget_repository, resource/artifactory_virtual_nuget_repository, resource/artifactory_federated_nuget_repository: Add `enable_normalized_version` attribute to support NuGet Enforced Layout introduced in Artifactory 7.146.7. This attribute is immutable after repository creation — changing it forces resource replacement. Issue: [#1418](https://github.com/jfrog/terraform-provider-artifactory/issues/1418)
+
 ### 12.11.7 (Jun 16, 2026). Tested on Artifactory 7.146.17 with Terraform 1.15.6 and OpenTofu 1.12.2
 
 BUG FIXES:

--- a/pkg/artifactory/datasource/repository/remote/datasource_artifactory_remote_nuget_repository.go
+++ b/pkg/artifactory/datasource/repository/remote/datasource_artifactory_remote_nuget_repository.go
@@ -32,6 +32,7 @@ type NugetRemoteRepo struct {
 	V3FeedUrl                string `hcl:"v3_feed_url" json:"v3FeedUrl"` // Forced to specify hcl tag because predicate is not parsed by packer.Universal function.
 	ForceNugetAuthentication bool   `json:"forceNugetAuthentication"`
 	SymbolServerUrl          string `json:"symbolServerUrl"`
+	EnableNormalizedVersion  bool   `json:"enableNormalizedVersion"`
 }
 
 var NugetSchema = lo.Assign(
@@ -70,6 +71,12 @@ var NugetSchema = lo.Assign(
 			Default:          "https://symbols.nuget.org/download/symbols",
 			ValidateDiagFunc: validation.ToDiagFunc(validation.Any(validation.IsURLWithHTTPorHTTPS, validation.StringIsEmpty)),
 			Description:      `NuGet symbol server URL.`,
+		},
+		"enable_normalized_version": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: `Enables NuGet normalized versions enforced layout. Once set, this value cannot be changed without recreating the repository. Requires Artifactory 7.146.7+.`,
 		},
 	}, resource_repository.RepoLayoutRefSDKv2Schema(remote.Rclass, resource_repository.NugetPackageType),
 )

--- a/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_nuget_repository.go
+++ b/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_nuget_repository.go
@@ -36,6 +36,7 @@ func unpackLocalNugetRepository(data *schema.ResourceData, Rclass string) local.
 		RepositoryBaseParams:     local.UnpackBaseRepo(Rclass, data, repository.NugetPackageType),
 		MaxUniqueSnapshots:       d.GetInt("max_unique_snapshots", false),
 		ForceNugetAuthentication: d.GetBool("force_nuget_authentication", false),
+		EnableNormalizedVersion:  d.GetBool("enable_normalized_version", false),
 	}
 }
 

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_nuget_repository.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_nuget_repository.go
@@ -23,7 +23,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	sdkv2_schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -50,6 +52,7 @@ type LocalNugetResourceModel struct {
 	LocalResourceModel
 	MaxUniqueSnapshots       types.Int64 `tfsdk:"max_unique_snapshots"`
 	ForceNugetAuthentication types.Bool  `tfsdk:"force_nuget_authentication"`
+	EnableNormalizedVersion  types.Bool  `tfsdk:"enable_normalized_version"`
 }
 
 func (r *LocalNugetResourceModel) GetCreateResourcePlanData(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -102,6 +105,7 @@ func (r LocalNugetResourceModel) ToAPIModel(ctx context.Context, packageType str
 		LocalAPIModel:            localAPIModel,
 		MaxUniqueSnapshots:       r.MaxUniqueSnapshots.ValueInt64(),
 		ForceNugetAuthentication: r.ForceNugetAuthentication.ValueBool(),
+		EnableNormalizedVersion:  r.EnableNormalizedVersion.ValueBool(),
 	}, diags
 }
 
@@ -115,6 +119,7 @@ func (r *LocalNugetResourceModel) FromAPIModel(ctx context.Context, apiModel int
 	r.RepoLayoutRef = types.StringValue(model.RepoLayoutRef)
 	r.MaxUniqueSnapshots = types.Int64Value(model.MaxUniqueSnapshots)
 	r.ForceNugetAuthentication = types.BoolValue(model.ForceNugetAuthentication)
+	r.EnableNormalizedVersion = types.BoolValue(model.EnableNormalizedVersion)
 
 	return diags
 }
@@ -123,6 +128,7 @@ type LocalNugetAPIModel struct {
 	LocalAPIModel
 	MaxUniqueSnapshots       int64 `json:"maxUniqueSnapshots"`
 	ForceNugetAuthentication bool  `json:"forceNugetAuthentication"`
+	EnableNormalizedVersion  bool  `json:"enableNormalizedVersion"`
 }
 
 func (r *localNugetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -144,6 +150,15 @@ func (r *localNugetResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Computed:            true,
 				Default:             booldefault.StaticBool(false),
 				MarkdownDescription: "Force basic authentication credentials in order to use this repository.",
+			},
+			"enable_normalized_version": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+				MarkdownDescription: "Enables NuGet normalized versions enforced layout. Once set, this value cannot be changed without recreating the repository. Requires Artifactory 7.146.7+.",
 			},
 		},
 	)
@@ -170,6 +185,13 @@ var nugetSchema = lo.Assign(
 			Default:     false,
 			Description: "Force basic authentication credentials in order to use this repository.",
 		},
+		"enable_normalized_version": {
+			Type:        sdkv2_schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			ForceNew:    true,
+			Description: "Enables NuGet normalized versions enforced layout. Once set, this value cannot be changed without recreating the repository. Requires Artifactory 7.146.7+.",
+		},
 	},
 	repository.RepoLayoutRefSDKv2Schema(Rclass, repository.NugetPackageType),
 )
@@ -180,6 +202,7 @@ type NugetLocalRepositoryParams struct {
 	RepositoryBaseParams
 	MaxUniqueSnapshots       int  `hcl:"max_unique_snapshots" json:"maxUniqueSnapshots"`
 	ForceNugetAuthentication bool `hcl:"force_nuget_authentication" json:"forceNugetAuthentication"`
+	EnableNormalizedVersion  bool `hcl:"enable_normalized_version" json:"enableNormalizedVersion"`
 }
 
 //

--- a/pkg/artifactory/resource/repository/local/resource_artifactory_local_nuget_repository_test.go
+++ b/pkg/artifactory/resource/repository/local/resource_artifactory_local_nuget_repository_test.go
@@ -65,6 +65,78 @@ func TestAccLocalNugetRepository(t *testing.T) {
 	})
 }
 
+func TestAccLocalNugetRepository_EnableNormalizedVersion(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("nuget-local", "artifactory_local_nuget_repository")
+	params := map[string]interface{}{"name": name}
+
+	config := util.ExecuteTemplate("TestAccLocalNugetRepository_EnableNormalizedVersion", `
+		resource "artifactory_local_nuget_repository" "{{ .name }}" {
+		  key                      = "{{ .name }}"
+		  enable_normalized_version = true
+		}
+	`, params)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "enable_normalized_version", "true"),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+			},
+		},
+	})
+}
+
+func TestAccLocalNugetRepository_EnableNormalizedVersion_RequiresReplace(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("nuget-local", "artifactory_local_nuget_repository")
+	params := map[string]interface{}{"name": name}
+
+	configFalse := util.ExecuteTemplate("TestAccLocalNugetRepository_EnableNormalizedVersion_false", `
+		resource "artifactory_local_nuget_repository" "{{ .name }}" {
+		  key                      = "{{ .name }}"
+		  enable_normalized_version = false
+		}
+	`, params)
+
+	configTrue := util.ExecuteTemplate("TestAccLocalNugetRepository_EnableNormalizedVersion_true", `
+		resource "artifactory_local_nuget_repository" "{{ .name }}" {
+		  key                      = "{{ .name }}"
+		  enable_normalized_version = true
+		}
+	`, params)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: configFalse,
+				Check:  resource.TestCheckResourceAttr(fqrn, "enable_normalized_version", "false"),
+			},
+			{
+				Config: configTrue,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(fqrn, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: resource.TestCheckResourceAttr(fqrn, "enable_normalized_version", "true"),
+			},
+		},
+	})
+}
+
 func TestAccLocalNugetRepository_UpgradeFromSDKv2(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("nuget-local", "artifactory_local_nuget_repository")
 	params := map[string]interface{}{

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository.go
@@ -23,6 +23,8 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/boolplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -54,6 +56,7 @@ type remoteNugetResourceModel struct {
 	V3FeedURL                types.String `tfsdk:"v3_feed_url"`
 	ForceNugetAuthentication types.Bool   `tfsdk:"force_nuget_authentication"`
 	SymbolServerURL          types.String `tfsdk:"symbol_server_url"`
+	EnableNormalizedVersion  types.Bool   `tfsdk:"enable_normalized_version"`
 }
 
 func (r *remoteNugetResourceModel) GetCreateResourcePlanData(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -110,6 +113,7 @@ func (r remoteNugetResourceModel) ToAPIModel(ctx context.Context, packageType st
 		V3FeedURL:                r.V3FeedURL.ValueString(),
 		ForceNugetAuthentication: r.ForceNugetAuthentication.ValueBool(),
 		SymbolServerURL:          r.SymbolServerURL.ValueString(),
+		EnableNormalizedVersion:  r.EnableNormalizedVersion.ValueBool(),
 	}, diags
 }
 
@@ -132,6 +136,7 @@ func (r *remoteNugetResourceModel) FromAPIModel(ctx context.Context, apiModel in
 	if model.SymbolServerURL != "" {
 		r.SymbolServerURL = types.StringValue(model.SymbolServerURL)
 	}
+	r.EnableNormalizedVersion = types.BoolValue(model.EnableNormalizedVersion)
 	return diags
 }
 
@@ -143,6 +148,7 @@ type RemoteNugetAPIModel struct {
 	V3FeedURL                string `json:"v3FeedUrl"`
 	ForceNugetAuthentication bool   `json:"forceNugetAuthentication"`
 	SymbolServerURL          string `json:"symbolServerUrl"`
+	EnableNormalizedVersion  bool   `json:"enableNormalizedVersion"`
 }
 
 func (r *remoteNugetResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
@@ -195,6 +201,15 @@ func (r *remoteNugetResource) Schema(ctx context.Context, req resource.SchemaReq
 					),
 				},
 				MarkdownDescription: "NuGet symbol server URL.",
+			},
+			"enable_normalized_version": schema.BoolAttribute{
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
+				PlanModifiers: []planmodifier.Bool{
+					boolplanmodifier.RequiresReplace(),
+				},
+				MarkdownDescription: "Enables NuGet normalized versions enforced layout. Once set, this value cannot be changed without recreating the repository. Requires Artifactory 7.146.7+.",
 			},
 		},
 	)

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_nuget_repository_test.go
@@ -37,6 +37,50 @@ func TestAccRemoteNugetRepository(t *testing.T) {
 	}))
 }
 
+func TestAccRemoteNugetRepository_EnableNormalizedVersion(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("test-nuget-remote", "artifactory_remote_nuget_repository")
+	params := map[string]interface{}{"name": name}
+
+	configFalse := util.ExecuteTemplate("TestAccRemoteNugetRepository_EnableNormalizedVersion_false", `
+		resource "artifactory_remote_nuget_repository" "{{ .name }}" {
+			key                      = "{{ .name }}"
+			url                      = "https://www.nuget.org/"
+			enable_normalized_version = false
+		}
+	`, params)
+
+	configTrue := util.ExecuteTemplate("TestAccRemoteNugetRepository_EnableNormalizedVersion_true", `
+		resource "artifactory_remote_nuget_repository" "{{ .name }}" {
+			key                      = "{{ .name }}"
+			url                      = "https://www.nuget.org/"
+			enable_normalized_version = true
+		}
+	`, params)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: configFalse,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "enable_normalized_version", "false"),
+				),
+			},
+			{
+				Config: configTrue,
+				ConfigPlanChecks: resource.ConfigPlanChecks{
+					PreApply: []plancheck.PlanCheck{
+						plancheck.ExpectResourceAction(fqrn, plancheck.ResourceActionDestroyBeforeCreate),
+					},
+				},
+				Check: resource.TestCheckResourceAttr(fqrn, "enable_normalized_version", "true"),
+			},
+		},
+	})
+}
+
 func TestAccRemoteNugetRepository_url_fields(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("test-nuget-remote", "artifactory_remote_nuget_repository")
 

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_nuget_repository.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_nuget_repository.go
@@ -30,6 +30,13 @@ var nugetSchema = lo.Assign(
 			Default:     false,
 			Description: "If set, user authentication is required when accessing the repository. An anonymous request will display an HTTP 401 error. This is also enforced when aggregated repositories support anonymous requests.",
 		},
+		"enable_normalized_version": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			ForceNew:    true,
+			Description: "Enables NuGet normalized versions enforced layout. Once set, this value cannot be changed without recreating the repository. Requires Artifactory 7.146.7+.",
+		},
 	},
 	repository.RepoLayoutRefSDKv2Schema(Rclass, repository.NugetPackageType),
 )
@@ -41,6 +48,7 @@ func ResourceArtifactoryVirtualNugetRepository() *schema.Resource {
 	type NugetVirtualRepositoryParams struct {
 		RepositoryBaseParams
 		ForceNugetAuthentication bool `json:"forceNugetAuthentication"`
+		EnableNormalizedVersion  bool `json:"enableNormalizedVersion"`
 	}
 
 	var unpackNugetVirtualRepository = func(s *schema.ResourceData) (interface{}, string, error) {
@@ -49,6 +57,7 @@ func ResourceArtifactoryVirtualNugetRepository() *schema.Resource {
 		repo := NugetVirtualRepositoryParams{
 			RepositoryBaseParams:     UnpackBaseVirtRepo(s, repository.NugetPackageType),
 			ForceNugetAuthentication: d.GetBool("force_nuget_authentication", false),
+			EnableNormalizedVersion:  d.GetBool("enable_normalized_version", false),
 		}
 		repo.PackageType = repository.NugetPackageType
 		return &repo, repo.Key, nil

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
@@ -529,6 +529,7 @@ func TestAccVirtualNugetRepository_PackageCreationFull(t *testing.T) {
 			excludes_pattern = "com/google/**"
 			artifactory_requests_can_retrieve_remote_artifacts = true
 			force_nuget_authentication	= true
+			enable_normalized_version   = true
 		}
 	`
 
@@ -544,6 +545,7 @@ func TestAccVirtualNugetRepository_PackageCreationFull(t *testing.T) {
 					resource.TestCheckResourceAttr(fqrn, "package_type", "nuget"),
 					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", "nuget-default"),
 					resource.TestCheckResourceAttr(fqrn, "force_nuget_authentication", "true"),
+					resource.TestCheckResourceAttr(fqrn, "enable_normalized_version", "true"),
 				),
 			},
 			{


### PR DESCRIPTION
## Summary

Artifactory 7.146.7 introduced a "NuGet Enforced Layout" feature via the `enableNormalizedVersion` field on NuGet repositories. This field was not surfaced in the Terraform provider, forcing teams to manage the setting outside Terraform (e.g. via `null_resource` + `curl`), losing drift detection and plan visibility.

Closes #1418

## Changes

- **`artifactory_local_nuget_repository`** — Framework resource; field added to model, API model, `ToAPIModel`, `FromAPIModel`, and schema with `RequiresReplace`
- **`artifactory_remote_nuget_repository`** — Same Framework-based pattern
- **`artifactory_virtual_nuget_repository`** — SDKv2 resource; field added to schema (`ForceNew: true`) and inline struct
- **`artifactory_federated_nuget_repository`** — Inherits schema/struct from local; `unpackLocalNugetRepository` updated to read the field
- **`data.artifactory_remote_nuget_repository`** — Field added to `NugetRemoteRepo` struct and `NugetSchema`

## Immutability

The Artifactory API does not allow updating `enableNormalizedVersion` after repository creation. Accordingly:

- Framework resources use `boolplanmodifier.RequiresReplace()`
- SDKv2 resources use `ForceNew: true`

> [!WARNING]
> Changing this attribute on an existing repository triggers a **destroy-and-recreate**. Destroying a local repository deletes all of its artifacts.

## Usage

```hcl
resource "artifactory_local_nuget_repository" "example" {
  key                       = "my-nuget-local"
  enable_normalized_version = true
}


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `enable_normalized_version` option for NuGet local, remote, virtual, and federated repositories.
  - Enables NuGet Enforced Layout support in Artifactory 7.146.7 and later.
  - Defaults to disabled for new repositories.

- **Important Notes**
  - This setting cannot be changed after repository creation. Changing it requires replacing the repository.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->