### PR TITLE
Implement ResourceWithMoveState interface for all Framework resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-### 12.11.8 (Jul 9, 2026). Tested on Artifactory 7.146.25 with Terraform 1.15.8 and OpenTofu 1.12.3
+### 12.11.8 (Jul 9, 2026). Tested on Artifactory 7.146.28 with Terraform 1.15.8 and OpenTofu 1.12.4
 
 FEATURES:
 

--- a/pkg/artifactory/move_state.go
+++ b/pkg/artifactory/move_state.go
@@ -1,0 +1,71 @@
+// Copyright (c) JFrog Ltd. (2025)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package artifactory
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-go/tfprotov6"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+// MoveStateMixin provides a generic ResourceWithMoveState implementation that
+// can be embedded into any Framework resource to enable cross-provider state
+// moves for the same resource type.
+//
+// This is needed because OpenTofu 1.12.4+ correctly passes the source provider
+// address during resource moves, which triggers the MoveResourceState RPC
+// whenever the provider namespace changes (e.g., from jfrog/artifactory to
+// hashicorp/artifactory in acceptance tests, or when a user switches registry
+// host or migrates between Terraform and OpenTofu). Without an implementation
+// of the ResourceWithMoveState interface, the framework returns an "Unable to
+// Move Resource State" error.
+//
+// Because the source and target are the same resource type (only the provider
+// address differs), no data transformation is required: the source state is
+// passed through unchanged. The framework pre-populates the target schema in
+// resp.TargetState.Schema, so the mover only needs to unmarshal the source raw
+// state against that schema and set it as the target state.
+type MoveStateMixin struct{}
+
+func (m MoveStateMixin) MoveState(ctx context.Context) []resource.StateMover {
+	return []resource.StateMover{
+		{
+			StateMover: func(ctx context.Context, req resource.MoveStateRequest, resp *resource.MoveStateResponse) {
+				// IgnoreUndefinedAttributes tolerates attributes present in the
+				// source state that no longer exist in the target schema, which
+				// allows additive/removal schema changes between provider
+				// versions without breaking the move.
+				rawStateValue, err := req.SourceRawState.UnmarshalWithOpts(
+					resp.TargetState.Schema.Type().TerraformType(ctx),
+					tfprotov6.UnmarshalOpts{
+						ValueFromJSONOpts: tftypes.ValueFromJSONOpts{
+							IgnoreUndefinedAttributes: true,
+						},
+					},
+				)
+				// Returning without setting TargetState signals the framework to
+				// skip this mover (e.g., when the source schema is genuinely
+				// incompatible) rather than corrupting state.
+				if err != nil {
+					return
+				}
+
+				resp.TargetState.Raw = rawStateValue
+			},
+		},
+	}
+}

--- a/pkg/artifactory/resource/artifact/resource_artifactory_artifact.go
+++ b/pkg/artifactory/resource/artifact/resource_artifactory_artifact.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 )
@@ -43,6 +44,7 @@ func NewArtifactResource() resource.Resource {
 }
 
 type ArtifactResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/artifact/resource_artifactory_item_properties.go
+++ b/pkg/artifactory/resource/artifact/resource_artifactory_item_properties.go
@@ -35,6 +35,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	validatorfw_string "github.com/jfrog/terraform-provider-shared/validator/fw/string"
@@ -50,6 +51,7 @@ func NewItemPropertiesResource() resource.Resource {
 }
 
 type ItemPropertiesResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/configuration/resource_artifactory_archive_policy.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_archive_policy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
@@ -286,6 +287,7 @@ func NewArchivePolicyResource() resource.Resource {
 var _ resource.Resource = (*ArchivePolicyResource)(nil)
 
 type ArchivePolicyResource struct {
+	artifactory.MoveStateMixin
 	util.JFrogResource
 	EnablementEndpoint string
 	ProviderData       util.ProviderMetadata

--- a/pkg/artifactory/resource/configuration/resource_artifactory_backup.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_backup.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	validatorfw_string "github.com/jfrog/terraform-provider-shared/validator/fw/string"
@@ -124,6 +125,7 @@ func NewBackupResource() resource.Resource {
 }
 
 type BackupResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/configuration/resource_artifactory_general_security.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_general_security.go
@@ -27,6 +27,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 
@@ -44,6 +45,7 @@ func NewGeneralSecurityResource() resource.Resource {
 }
 
 type GeneralSecurityResource struct {
+	artifactory.MoveStateMixin
 	util.JFrogResource
 }
 

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_v2.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_group_setting_v2.go
@@ -31,6 +31,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 )
@@ -44,6 +45,7 @@ func NewLdapGroupSettingResource() resource.Resource {
 }
 
 type ArtifactoryLdapGroupSettingResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting_v2.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_ldap_setting_v2.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	"gopkg.in/ldap.v2"
@@ -46,6 +47,7 @@ func NewLdapSettingResource() resource.Resource {
 }
 
 type ArtifactoryLdapSettingResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/configuration/resource_artifactory_mail_server.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_mail_server.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	validatorfw_string "github.com/jfrog/terraform-provider-shared/validator/fw/string"
@@ -104,6 +105,7 @@ func NewMailServerResource() resource.Resource {
 }
 
 type MailServerResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/configuration/resource_artifactory_package_cleanup_policy.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_package_cleanup_policy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
@@ -288,6 +289,7 @@ var _ resource.Resource = (*PackageCleanupPolicyResource)(nil)
 var _ resource.ResourceWithModifyPlan = (*PackageCleanupPolicyResource)(nil)
 
 type PackageCleanupPolicyResource struct {
+	artifactory.MoveStateMixin
 	util.JFrogResource
 	EnablementEndpoint string
 	ProviderData       util.ProviderMetadata

--- a/pkg/artifactory/resource/configuration/resource_artifactory_property_set.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_property_set.go
@@ -30,6 +30,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	"github.com/samber/lo"
@@ -43,6 +44,7 @@ func NewPropertySetResource() resource.Resource {
 }
 
 type PropertySetResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/configuration/resource_artifactory_proxy.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_proxy.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 
@@ -137,6 +138,7 @@ func NewProxyResource() resource.Resource {
 }
 
 type ProxyResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/configuration/resource_artifactory_release_bundles_cleanup_policy_v2.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_release_bundles_cleanup_policy_v2.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	validatorfw_string "github.com/jfrog/terraform-provider-shared/validator/fw/string"
@@ -55,6 +56,7 @@ func NewResourceBundleCleanupPolicyV2Resource() resource.Resource {
 }
 
 type ResourceBundleCleanupPolicyV2Resource struct {
+	artifactory.MoveStateMixin
 	util.JFrogResource
 	EnablementEndpoint string
 }

--- a/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_repository_layout.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 
@@ -41,6 +42,7 @@ func NewRepositoryLayoutResource() resource.Resource {
 }
 
 type RepositoryLayoutResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/configuration/resource_artifactory_trashcan_config.go
+++ b/pkg/artifactory/resource/configuration/resource_artifactory_trashcan_config.go
@@ -26,6 +26,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64default"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	"gopkg.in/yaml.v3"
@@ -68,6 +69,7 @@ func NewTrashCanConfigResource() resource.Resource {
 }
 
 type TrashCanConfigResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/lifecycle/resource_artifactory_release_bundle_v2.go
+++ b/pkg/artifactory/resource/lifecycle/resource_artifactory_release_bundle_v2.go
@@ -32,6 +32,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	validatorfw_string "github.com/jfrog/terraform-provider-shared/validator/fw/string"
@@ -52,6 +53,7 @@ func NewReleaseBundleV2Resource() resource.Resource {
 }
 
 type ReleaseBundleV2Resource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/lifecycle/resource_artifactory_release_bundle_v2_promotion.go
+++ b/pkg/artifactory/resource/lifecycle/resource_artifactory_release_bundle_v2_promotion.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	validatorfw_string "github.com/jfrog/terraform-provider-shared/validator/fw/string"
@@ -48,6 +49,7 @@ func NewReleaseBundleV2PromotionResource() resource.Resource {
 }
 
 type ReleaseBundleV2PromotionResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/replication/resource_artifactory_local_repository_multi_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_local_repository_multi_replication.go
@@ -34,6 +34,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	validatorfw_string "github.com/jfrog/terraform-provider-shared/validator/fw/string"
@@ -51,6 +52,7 @@ func NewLocalRepositoryMultiReplicationResource() resource.Resource {
 }
 
 type LocalRepositoryMultiReplicationResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/replication/resource_artifactory_local_repository_single_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_local_repository_single_replication.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	validatorfw_string "github.com/jfrog/terraform-provider-shared/validator/fw/string"
@@ -49,6 +50,7 @@ func NewLocalRepositorySingleReplicationResource() resource.Resource {
 }
 
 type LocalRepositorySingleReplicationResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/replication/resource_artifactory_remote_repository_replication.go
+++ b/pkg/artifactory/resource/replication/resource_artifactory_remote_repository_replication.go
@@ -28,6 +28,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringdefault"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 
@@ -43,6 +44,7 @@ func NewRemoteRepositoryReplicationResource() resource.Resource {
 }
 
 type RemoteRepositoryReplicationResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/repository/repository.go
+++ b/pkg/artifactory/resource/repository/repository.go
@@ -42,6 +42,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/customdiff"
 	sdkv2_schema "github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/client"
 	"github.com/jfrog/terraform-provider-shared/packer"
 	"github.com/jfrog/terraform-provider-shared/testutil"
@@ -148,6 +149,7 @@ func NewRepositoryResource(packageType, packageName, rclass string, resourceMode
 
 type BaseResource struct {
 	util.JFrogResource
+	artifactory.MoveStateMixin
 	Description       string
 	PackageType       string
 	Rclass            string

--- a/pkg/artifactory/resource/security/resource_artifactory_certificate.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_certificate.go
@@ -34,6 +34,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 )
@@ -47,6 +48,7 @@ func NewCertificateResource() resource.Resource {
 }
 
 type CertificateResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/security/resource_artifactory_distribution_public_key.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_distribution_public_key.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 )
@@ -42,6 +43,7 @@ func NewDistributionPublicKeyResource() resource.Resource {
 }
 
 type DistributionPublicKeyResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/security/resource_artifactory_global_environment.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_global_environment.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 )
@@ -36,6 +37,7 @@ func NewGlobalEnvironmentResource() resource.Resource {
 }
 
 type GlobalEnvironmentResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/security/resource_artifactory_group.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_group.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	validatorfw "github.com/jfrog/terraform-provider-shared/validator/fw"
@@ -47,6 +48,7 @@ func NewGroupResource() resource.Resource {
 }
 
 type ArtifactoryGroupResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/security/resource_artifactory_keypair.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_keypair.go
@@ -33,6 +33,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 )
@@ -46,6 +47,7 @@ func NewKeyPairResource() resource.Resource {
 }
 
 type KeyPairResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/security/resource_artifactory_password_expiration_policy.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_password_expiration_policy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 )
@@ -36,6 +37,7 @@ func NewPasswordExpirationPolicyResource() resource.Resource {
 }
 
 type PasswordExpirationPolicyResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_scoped_token.go
@@ -52,6 +52,7 @@ func NewScopedTokenResource() resource.Resource {
 }
 
 type ScopedTokenResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/security/resource_artifactory_user_lock_policy.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_user_lock_policy.go
@@ -23,6 +23,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 )
@@ -36,6 +37,7 @@ func NewUserLockPolicyResource() resource.Resource {
 }
 
 type UserLockPolicyResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/security/resource_artifactory_vault_configuration.go
+++ b/pkg/artifactory/resource/security/resource_artifactory_vault_configuration.go
@@ -29,6 +29,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory"
 	"github.com/jfrog/terraform-provider-shared/util"
 	utilfw "github.com/jfrog/terraform-provider-shared/util/fw"
 	validatorfw_string "github.com/jfrog/terraform-provider-shared/validator/fw/string"
@@ -49,6 +50,7 @@ func NewVaultConfigurationResource() resource.Resource {
 }
 
 type VaultConfigurationResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/user/resource_artifactory_anonymous_user.go
+++ b/pkg/artifactory/resource/user/resource_artifactory_anonymous_user.go
@@ -35,6 +35,7 @@ func NewAnonymousUserResource() resource.Resource {
 }
 
 type ArtifactoryAnonymousUserResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/user/user.go
+++ b/pkg/artifactory/resource/user/user.go
@@ -66,6 +66,7 @@ const (
 )
 
 type ArtifactoryBaseUserResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 }

--- a/pkg/artifactory/resource/webhook/resource_artifactory_webhook.go
+++ b/pkg/artifactory/resource/webhook/resource_artifactory_webhook.go
@@ -79,6 +79,7 @@ var DomainEventTypesSupported = map[string][]string{
 }
 
 type WebhookResource struct {
+	artifactory.MoveStateMixin
 	ProviderData util.ProviderMetadata
 	TypeName     string
 	Domain       string


### PR DESCRIPTION
OpenTofu 1.12.4 fixed a bug where the source provider address is now correctly passed in the MoveResourceState RPC. This triggers MoveResourceState whenever the provider namespace changes (e.g. jfrog/artifactory to hashicorp/artifactory in acceptance tests, or when a user switches registry host or migrates between Terraform and OpenTofu), causing UpgradeFromSDKv2 tests to fail with "Unable to Move Resource State".

Add a generic, embeddable MoveStateMixin in pkg/artifactory/move_state.go that passes state through unchanged for same-type cross-provider moves (the framework pre-populates the target schema, so no per-resource schema wiring is needed). Embed it into the shared base structs (BaseResource, WebhookResource, ArtifactoryBaseUserResource) and the remaining standalone Framework resources.

All 136 registered Framework resources now satisfy ResourceWithMoveState.