### PR TITLE
Updating index compression format default values in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+
+### 12.11.10 (Jul 24, 2026). Tested on Artifactory 7.146.29 with Terraform 1.15.8 and OpenTofu 1.12.3
+
+DOCUMENTATION:
+
+* resource/artifactory_local_debian_repository: Update documentation for `index_compression_formats` to clarify that all three formats (`bz2`, `lzma`, `xz`) are supported and can be used in any combination, and that the default value is empty. Also update the example usage to reflect an empty default. PR: [1440](https://github.com/jfrog/terraform-provider-artifactory/pull/1440)
+
+
 ### 12.11.9 (Jul 21, 2026). Tested on Artifactory 7.146.28 with Terraform 1.15.8 and OpenTofu 1.12.3
 
 BUG FIXES:

--- a/docs/resources/local_debian_repository.md
+++ b/docs/resources/local_debian_repository.md
@@ -38,7 +38,7 @@ resource "artifactory_local_debian_repository" "my-debian-repo" {
   key                       = "my-debian-repo"
   primary_keypair_ref       = artifactory_keypair.some-keypairGPG1.pair_name
   secondary_keypair_ref     = artifactory_keypair.some-keypairGPG2.pair_name
-  index_compression_formats = ["bz2", "lzma", "xz"]
+  index_compression_formats = []
   trivial_layout            = true
   depends_on                = [artifactory_keypair.some-keypairGPG1, artifactory_keypair.some-keypairGPG2]
 }
@@ -52,8 +52,8 @@ The following arguments are supported, along with the [common list of arguments 
 * `key` - (Required) the identity key of the repo.
 * `primary_keypair_ref` - (Optional) The primary RSA key to be used to sign packages.
 * `secondary_keypair_ref` - (Optional) The secondary RSA key to be used to sign packages.
-* `index_compression_formats` - (Optional) The options are Bzip2 (.bz2 extension) (default), LZMA (.lzma extension)
-and XZ (.xz extension).
+* `index_compression_formats` - (Optional) The options are Bzip2 (.bz2 extension), LZMA (.lzma extension)
+and XZ (.xz extension). All three formats are supported, so you can use any combination of them, e.g. `index_compression_formats = ["bz2", "lzma", "xz"]`. Default is empty.
 * `trivial_layout` - (Optional) When set, the repository will use the deprecated trivial layout.
 
 Artifactory REST API call Get Key Pair doesn't return keys `private_key` and `passphrase`, but consumes these keys in the POST call.

--- a/sample.tf
+++ b/sample.tf
@@ -274,7 +274,7 @@ resource "artifactory_local_debian_repository" "my-debian-repo" {
   key                       = "my-debian-repo"
   primary_keypair_ref       = artifactory_keypair.some-keypairGPG1.pair_name
   secondary_keypair_ref     = artifactory_keypair.some-keypairGPG2.pair_name
-  index_compression_formats = ["bz2", "lzma", "xz"]
+  index_compression_formats = []
   depends_on                = [artifactory_keypair.some-keypairGPG1, artifactory_keypair.some-keypairGPG2]
 }
 
@@ -600,7 +600,7 @@ resource "artifactory_virtual_debian_repository" "foo-debian" {
   notes                              = "Internal description"
   includes_pattern                   = "com/jfrog/**,cloud/jfrog/**"
   excludes_pattern                   = "com/google/**"
-  optional_index_compression_formats = ["bz2", "xz"]
+  optional_index_compression_formats = []
   debian_default_architectures       = "amd64,i386"
 }
 


### PR DESCRIPTION
Example usage: Set `index_compression_formats = []` (empty) instead of listing all three formats.
Argument reference: Removed the (default) label from Bzip2, added a note that all three formats are supported with an example (`["bz2", "lzma", "xz"]`), and clarified that the default is empty.