### PR TITLE
Add enable_token_authentication to remote generic repositories

### DIFF
--- a/docs/resources/remote_generic_repository.md
+++ b/docs/resources/remote_generic_repository.md
@@ -14,6 +14,19 @@ resource "artifactory_remote_generic_repository" "my-remote-generic" {
 }
 ```
 
+### Access token (Bearer) authentication
+
+When the remote requires an Artifactory / identity access token, set `enable_token_authentication = true` and put the token in `password` (username may be empty). This matches the UI “Enable Token Authentication” checkbox and avoids putting credentials in `custom_http_headers`.
+
+```hcl
+resource "artifactory_remote_generic_repository" "token-auth" {
+  key                           = "token-auth-generic"
+  url                           = "https://remote.example.com/artifactory/generic-local/"
+  password                      = var.remote_access_token
+  enable_token_authentication   = true
+}
+```
+
 ### Custom HTTP headers
 
 Use `custom_http_headers` to send up to 5 static headers on every outbound request to the remote URL. A common use case is authenticating to Azure Blob Storage or packagecloud.io.
@@ -44,6 +57,7 @@ The following arguments are supported, along with the [common list of arguments 
 * `url` - (Required) The remote repo URL.
 * `propagate_query_params` - (Optional, Default: `false`) When set, if query params are included in the request to Artifactory, they will be passed on to the remote repository.
 * `retrieve_sha256_from_server` - (Optional, Default: `false`) When set to `true`, Artifactory retrieves the SHA256 from the remote server if it is not cached in the remote repo.
+* `enable_token_authentication` - (Optional, Default: `false`) Enable token (Bearer) based authentication. When set, use an access token as `password` (username may be empty) so Artifactory authenticates to the remote with a Bearer token instead of Basic auth.
 * `custom_http_headers` - (Optional) List of up to 5 custom HTTP headers sent on every outbound request to the remote URL. Each entry supports:
   * `name` - (Required) Header name.
   * `value` - (Required) Header value. Masked in Terraform plan output. Stored in state as configured; never read back from Artifactory.

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_generic_repository.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_generic_repository.go
@@ -69,7 +69,8 @@ type CustomHttpHeaderModel struct {
 
 type RemoteGenericResourceModelV5 struct {
 	RemoteGenericResourceModelV4
-	CustomHttpHeaders []CustomHttpHeaderModel `tfsdk:"custom_http_headers"`
+	CustomHttpHeaders         []CustomHttpHeaderModel `tfsdk:"custom_http_headers"`
+	EnableTokenAuthentication types.Bool              `tfsdk:"enable_token_authentication"`
 }
 
 func (r RemoteGenericResourceModelV4) ToAPIModel(ctx context.Context, packageType string) (interface{}, diag.Diagnostics) {
@@ -145,6 +146,7 @@ func (r *RemoteGenericResourceModelV5) ToAPIModel(ctx context.Context, packageTy
 	}
 
 	m := base.(RemoteGenericAPIModel)
+	m.EnableTokenAuthentication = r.EnableTokenAuthentication.ValueBool()
 	if len(r.CustomHttpHeaders) > 0 {
 		headers := make([]httpHeaderAPIModel, 0, len(r.CustomHttpHeaders))
 		for _, h := range r.CustomHttpHeaders {
@@ -166,7 +168,9 @@ func (r *RemoteGenericResourceModelV5) ToAPIModel(ctx context.Context, packageTy
 // r already holds the plan/state value before this method is called, so it is preserved as-is.
 func (r *RemoteGenericResourceModelV5) FromAPIModel(ctx context.Context, apiModel interface{}) diag.Diagnostics {
 	model := apiModel.(*RemoteGenericAPIModel)
-	return r.RemoteGenericResourceModelV4.FromAPIModel(ctx, model)
+	diags := r.RemoteGenericResourceModelV4.FromAPIModel(ctx, model)
+	r.EnableTokenAuthentication = types.BoolValue(model.EnableTokenAuthentication)
+	return diags
 }
 
 type httpHeaderAPIModel struct {
@@ -216,9 +220,10 @@ func (v customHttpHeadersVersionValidator) ValidateList(_ context.Context, req v
 
 type RemoteGenericAPIModel struct {
 	RemoteAPIModel
-	PropagateQueryParams     bool                  `json:"propagateQueryParams"`
-	RetrieveSha256FromServer bool                  `json:"retrieveSha256FromServer"`
-	CustomHttpHeaders        *[]httpHeaderAPIModel `json:"customHttpHeaders,omitempty"`
+	PropagateQueryParams      bool                  `json:"propagateQueryParams"`
+	RetrieveSha256FromServer  bool                  `json:"retrieveSha256FromServer"`
+	EnableTokenAuthentication bool                  `json:"enableTokenAuthentication"`
+	CustomHttpHeaders         *[]httpHeaderAPIModel `json:"customHttpHeaders,omitempty"`
 }
 
 var remoteGenericAttributesV2 = lo.Assign(
@@ -254,6 +259,12 @@ func (r *remoteGenericResource) Schema(ctx context.Context, req resource.SchemaR
 	resp.Schema = schema.Schema{
 		Version: currentGenericSchemaVersion,
 		Attributes: lo.Assign(remoteGenericAttributesV4, map[string]schema.Attribute{
+			"enable_token_authentication": schema.BoolAttribute{
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+				MarkdownDescription: "Enable token (Bearer) based authentication. When set, use an access token as `password` (username may be empty) so Artifactory authenticates to the remote with a Bearer token instead of Basic auth.",
+			},
 			"custom_http_headers": schema.ListNestedAttribute{
 				Optional:            true,
 				MarkdownDescription: fmt.Sprintf("Up to 5 custom HTTP headers sent on every outbound request to the remote URL. Header values are write-only and masked in plan output. To remove all headers, remove this attribute. When `sensitive` is `true`, Artifactory encrypts the value server-side. Requires Artifactory %s or later.", customHttpHeadersSupportedVersion),
@@ -310,6 +321,7 @@ func (r *remoteGenericResource) UpgradeState(ctx context.Context) map[int64]reso
 						},
 						RetrieveSha256FromServer: types.BoolValue(false),
 					},
+					EnableTokenAuthentication: types.BoolValue(false),
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateData)...)
@@ -333,6 +345,7 @@ func (r *remoteGenericResource) UpgradeState(ctx context.Context) map[int64]reso
 						RemoteGenericResourceModelV3: priorStateData,
 						RetrieveSha256FromServer:     types.BoolValue(false),
 					},
+					EnableTokenAuthentication: types.BoolValue(false),
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateData)...)
@@ -353,6 +366,7 @@ func (r *remoteGenericResource) UpgradeState(ctx context.Context) map[int64]reso
 
 				upgradedStateData := RemoteGenericResourceModelV5{
 					RemoteGenericResourceModelV4: priorStateData,
+					EnableTokenAuthentication:   types.BoolValue(false),
 				}
 
 				resp.Diagnostics.Append(resp.State.Set(ctx, upgradedStateData)...)
@@ -364,9 +378,10 @@ func (r *remoteGenericResource) UpgradeState(ctx context.Context) map[int64]reso
 // SDKv2
 type GenericRemoteRepo struct {
 	RepositoryRemoteBaseParams
-	PropagateQueryParams     bool                 `json:"propagateQueryParams"`
-	RetrieveSha256FromServer bool                 `hcl:"retrieve_sha256_from_server" json:"retrieveSha256FromServer"`
-	CustomHttpHeaders        []httpHeaderAPIModel `json:"customHttpHeaders,omitempty"`
+	PropagateQueryParams      bool                 `json:"propagateQueryParams"`
+	RetrieveSha256FromServer  bool                 `hcl:"retrieve_sha256_from_server" json:"retrieveSha256FromServer"`
+	EnableTokenAuthentication bool                 `json:"enableTokenAuthentication"`
+	CustomHttpHeaders         []httpHeaderAPIModel `json:"customHttpHeaders,omitempty"`
 }
 
 var genericSchemaV3 = lo.Assign(
@@ -396,6 +411,12 @@ var GenericSchemaV4 = lo.Assign(
 var GenericSchemaV5 = lo.Assign(
 	GenericSchemaV4,
 	map[string]*sdkv2_schema.Schema{
+		"enable_token_authentication": {
+			Type:        sdkv2_schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Enable token (Bearer) based authentication. When set, use an access token as password (username may be empty) so Artifactory authenticates to the remote with a Bearer token instead of Basic auth.",
+		},
 		"custom_http_headers": {
 			Type:      sdkv2_schema.TypeList,
 			Optional:  true,

--- a/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_generic_repository_test.go
+++ b/pkg/artifactory/resource/repository/remote/resource_artifactory_remote_generic_repository_test.go
@@ -118,6 +118,44 @@ func TestAccRemoteGenericRepository_migrate_to_schema_v4(t *testing.T) {
 	})
 }
 
+func TestAccRemoteGenericRepository_with_enable_token_authentication(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("test-generic-remote", "artifactory_remote_generic_repository")
+
+	const tmpl = `
+		resource "artifactory_remote_generic_repository" "{{ .name }}" {
+			key                         = "{{ .name }}"
+			url                         = "https://registry.npmjs.org/"
+			password                    = "test-access-token"
+			enable_token_authentication = true
+		}
+	`
+
+	params := map[string]interface{}{"name": name}
+	config := util.ExecuteTemplate("TestAccRemoteGenericRepository_with_enable_token_authentication", tmpl, params)
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6ProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+		Steps: []resource.TestStep{
+			{
+				Config: config,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "enable_token_authentication", "true"),
+				),
+			},
+			{
+				ResourceName:                         fqrn,
+				ImportState:                          true,
+				ImportStateId:                        name,
+				ImportStateVerify:                    true,
+				ImportStateVerifyIdentifierAttribute: "key",
+				ImportStateVerifyIgnore:              []string{"password"},
+			},
+		},
+	})
+}
+
 func TestAccRemoteGenericRepository_with_custom_http_headers(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("test-generic-remote", "artifactory_remote_generic_repository")
 


### PR DESCRIPTION
## Summary

- Expose Artifactory's `enableTokenAuthentication` on `artifactory_remote_generic_repository` (UI: **Enable Token Authentication**).
- Allows using an access token via `password` with Bearer auth, matching the existing Docker/OCI remote attribute.
- Avoids workarounds that put credentials in `custom_http_headers`.

This is the **minimal / focused** variant. A broader alternative that adds the attribute to all remote package types is available as a separate PR from branch `fix/remote-enable-token-authentication-common`.

## Motivation

Generic remotes that proxy another Artifactory (or any Bearer-token endpoint) need the UI "Enable Token Authentication" checkbox. Without it, putting a JWT/access token in `password` still uses Basic auth and Test Connection fails until the box is checked manually.

Docker, OCI, and Helm OCI already expose `enable_token_authentication`. Generic did not.

## Usage

```hcl
resource "artifactory_remote_generic_repository" "example" {
  key                         = "example"
  url                         = "https://remote.example.com/artifactory/generic-local/"
  password                    = var.remote_access_token
  enable_token_authentication = true
}
```

## Test plan

- [ ] Acceptance: `TestAccRemoteGenericRepository_with_enable_token_authentication`
- [ ] Manual: create generic remote with token + flag; Test Connection succeeds without toggling the UI checkbox
- [ ] Confirm existing generic remotes without the attribute default to `false` (computed default only)

## Related

- Alternative (broader) PR branch: `fix/remote-enable-token-authentication-common`
- Related enhancement request for Go remotes: https://github.com/jfrog/terraform-provider-artifactory/issues/1389
