### PR TITLE
Hide unauthorized resources flag support added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 12.11.15 (Aug 31, 2026). Tested on Artifactory 7.161.20 with Terraform 1.16.0 and OpenTofu 1.12.3
+
+FEATURES:
+
+* resource/artifactory_virtual_*_repository: Add `hide_unauthorized_resources` attribute mapping to Artifactory's `hideUnauthorizedResources` setting, so virtual repositories can return 404 instead of 403 for unauthorized resource access. Issue: [#1279](https://github.com/jfrog/terraform-provider-artifactory/issues/1279)
+
 ### 12.11.14 (Aug 25, 2026).
 
 FEATURES:
@@ -38,6 +44,12 @@ SECURITY:
 * provider: Address CVE-2026-56853 by upgrading Go to 1.27.0. CVSS 5.3 Medium.
 * provider: Address CVE-2026-27143 by upgrading Go to 1.27.0. CVSS 6.1 Critical.
 * provider: Address CVE-2026-27140 by upgrading Go to 1.27.0. CVSS 5.3 High.
+
+### 12.11.11 (Aug 18, 2026). Tested on Artifactory 7.161.16 with Terraform 1.15.8 and OpenTofu 1.12.3
+
+FEATURES:
+
+* resource/artifactory_virtual_*_repository: Add `hide_unauthorized_resources` attribute mapping to Artifactory's `hideUnauthorizedResources` setting, so virtual repositories can return 404 instead of 403 for unauthorized resource access. Issue: [#1279](https://github.com/jfrog/terraform-provider-artifactory/issues/1279)
 
 ### 12.11.10 (Aug 12, 2026).
 

--- a/docs/resources/virtual.md
+++ b/docs/resources/virtual.md
@@ -38,6 +38,7 @@ The following arguments are supported:
 * `repo_layout_ref` - (Optional) Repository layout key for the virtual repository.
 * `artifactory_requests_can_retrieve_remote_artifacts` - (Optional, Default: `false`) Whether the virtual repository should search through remote repositories when trying to resolve an artifact requested by another Artifactory instance.
 * `default_deployment_repo` - (Optional) Default repository to deploy artifacts.
+* `hide_unauthorized_resources` - (Optional, Default: `false`) When `true`, returns **404 Not Found** instead of revealing that an unauthorized resource exists. When `false` (default), Artifactory keeps its normal behavior: anonymous requests get **401**, and unauthorized authenticated users get **403**. See [Hide Existence of Unauthorized Resources](https://jfrog.com/help/r/jfrog-platform-administration-documentation/hide-existence-of-unauthorized-resources).
 * `allow_delete` - (Optional) When unset or set to `true`, provider will delete the repository even if it contains artifacts. Must be set to `false` for the provider to return error when destroying the resource.
 
 ~>To maintain backward compatibility with provider version 12.0.0 and earlier, the state value for `allow_delete` is automatically set to `true` for existing resources.

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_hex_repository_test.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_hex_repository_test.go
@@ -32,7 +32,7 @@ import (
 func TestAccVirtualHexRepository_full(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("hex-virtual-test-repo", "artifactory_virtual_hex_repository")
 	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
-	localRepoName := testutil.RandSelect("local-repo-1", "local-repo-2", "local-repo-3").(string)
+	_, _, localRepoName := testutil.MkNames("hex-local-repo", "artifactory_local_hex_repository")
 
 	temp := `
 		resource "artifactory_keypair" "{{ .kp_name }}" {
@@ -355,8 +355,8 @@ EOF
 func TestAccVirtualHexRepository_withRepositories(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("hex-virtual", "artifactory_virtual_hex_repository")
 	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
-	localRepoName1 := testutil.RandSelect("local-repo-1", "local-repo-2", "local-repo-3").(string)
-	localRepoName2 := testutil.RandSelect("local-repo-4", "local-repo-5", "local-repo-6").(string)
+	_, _, localRepoName1 := testutil.MkNames("hex-local-repo1", "artifactory_local_hex_repository")
+	_, _, localRepoName2 := testutil.MkNames("hex-local-repo2", "artifactory_local_hex_repository")
 
 	temp := `
 		resource "artifactory_keypair" "{{ .kp_name }}" {
@@ -563,7 +563,7 @@ EOF
 func TestAccVirtualHexRepository_allFields(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("hex-virtual", "artifactory_virtual_hex_repository")
 	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
-	localRepoName := testutil.RandSelect("local-repo-1", "local-repo-2", "local-repo-3").(string)
+	_, _, localRepoName := testutil.MkNames("hex-local-repo", "artifactory_local_hex_repository")
 
 	temp := `
 		resource "artifactory_keypair" "{{ .kp_name }}" {
@@ -692,8 +692,8 @@ EOF
 func TestAccVirtualHexRepository_updateRepositories(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("hex-virtual", "artifactory_virtual_hex_repository")
 	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
-	localRepoName1 := testutil.RandSelect("local-repo-1", "local-repo-2", "local-repo-3").(string)
-	localRepoName2 := testutil.RandSelect("local-repo-4", "local-repo-5", "local-repo-6").(string)
+	_, _, localRepoName1 := testutil.MkNames("hex-local-repo1", "artifactory_local_hex_repository")
+	_, _, localRepoName2 := testutil.MkNames("hex-local-repo2", "artifactory_local_hex_repository")
 
 	temp := `
 		resource "artifactory_keypair" "{{ .kp_name }}" {

--- a/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
+++ b/pkg/artifactory/resource/repository/virtual/resource_artifactory_virtual_repository_test.go
@@ -514,6 +514,56 @@ func TestAccVirtualRepository_update(t *testing.T) {
 	})
 }
 
+func TestAccVirtualRepository_hideUnauthorizedResources(t *testing.T) {
+	id := testutil.RandomInt()
+	name := fmt.Sprintf("foo%d", id)
+	fqrn := fmt.Sprintf("artifactory_virtual_maven_repository.%s", name)
+	const virtualRepositoryHideUnauthorizedEnabled = `
+		resource "artifactory_virtual_maven_repository" "%s" {
+			key          = "%s"
+			repositories = []
+			hide_unauthorized_resources = true
+		}
+	`
+	const virtualRepositoryHideUnauthorizedDisabled = `
+		resource "artifactory_virtual_maven_repository" "%s" {
+			key          = "%s"
+			repositories = []
+			hide_unauthorized_resources = false
+		}
+	`
+
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy:             acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(virtualRepositoryHideUnauthorizedEnabled, name, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "maven"),
+					resource.TestCheckResourceAttr(fqrn, "hide_unauthorized_resources", "true"),
+				),
+			},
+			{
+				Config: fmt.Sprintf(virtualRepositoryHideUnauthorizedDisabled, name, name),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "maven"),
+					resource.TestCheckResourceAttr(fqrn, "hide_unauthorized_resources", "false"),
+				),
+			},
+			{
+				ResourceName:      fqrn,
+				ImportState:       true,
+				ImportStateVerify: true,
+				ImportStateCheck:  validator.CheckImportState(name, "key"),
+			},
+		},
+	})
+}
+
 func TestAccVirtualNugetRepository_PackageCreationFull(t *testing.T) {
 	id := testutil.RandomInt()
 	name := fmt.Sprintf("foo%d", id)

--- a/pkg/artifactory/resource/repository/virtual/virtual.go
+++ b/pkg/artifactory/resource/repository/virtual/virtual.go
@@ -56,6 +56,7 @@ type VirtualResourceModel struct {
 	ArtifactoryRequestsCanRetrieveRemoteArtifacts types.Bool   `tfsdk:"artifactory_requests_can_retrieve_remote_artifacts"`
 	DefaultDeploymentRepo                         types.String `tfsdk:"default_deployment_repo"`
 	RepoLayoutRef                                 types.String `tfsdk:"repo_layout_ref"`
+	HideUnauthorizedResources                     types.Bool   `tfsdk:"hide_unauthorized_resources"`
 }
 
 func (r *VirtualResourceModel) GetCreateResourcePlanData(ctx context.Context, req resource.CreateRequest, resp *resource.CreateResponse) {
@@ -128,6 +129,7 @@ func (r VirtualResourceModel) ToAPIModel(ctx context.Context, packageType string
 		ArtifactoryRequestsCanRetrieveRemoteArtifacts: r.ArtifactoryRequestsCanRetrieveRemoteArtifacts.ValueBool(),
 		DefaultDeploymentRepo:                         r.DefaultDeploymentRepo.ValueString(),
 		RepoLayoutRef:                                 repoLayoutRef,
+		HideUnauthorizedResources:                     r.HideUnauthorizedResources.ValueBool(),
 	}, diags
 }
 
@@ -143,6 +145,7 @@ func (r *VirtualResourceModel) FromAPIModel(ctx context.Context, apiModel interf
 	r.ArtifactoryRequestsCanRetrieveRemoteArtifacts = types.BoolValue(model.ArtifactoryRequestsCanRetrieveRemoteArtifacts)
 	r.DefaultDeploymentRepo = types.StringValue(model.DefaultDeploymentRepo)
 	r.RepoLayoutRef = types.StringValue(model.RepoLayoutRef)
+	r.HideUnauthorizedResources = types.BoolValue(model.HideUnauthorizedResources)
 
 	repositories, ds := types.ListValueFrom(ctx, types.StringType, model.Repositories)
 	if ds.HasError() {
@@ -160,6 +163,7 @@ type VirtualAPIModel struct {
 	ArtifactoryRequestsCanRetrieveRemoteArtifacts bool     `json:"artifactoryRequestsCanRetrieveRemoteArtifacts"`
 	DefaultDeploymentRepo                         string   `json:"defaultDeploymentRepo,omitempty"`
 	RepoLayoutRef                                 string   `json:"repoLayoutRef,omitempty"`
+	HideUnauthorizedResources                     bool     `json:"hideUnauthorizedResources"`
 }
 
 var VirtualAttributes = lo.Assign(
@@ -184,6 +188,12 @@ var VirtualAttributes = lo.Assign(
 			Default:             stringdefault.StaticString(""),
 			MarkdownDescription: "Default repository to deploy artifacts.",
 		},
+		"hide_unauthorized_resources": schema.BoolAttribute{
+			Optional:            true,
+			Computed:            true,
+			Default:             booldefault.StaticBool(false),
+			MarkdownDescription: "When set to `true`, returns a 404 Not Found response instead of revealing that an unauthorized resource exists. When `false` (default), Artifactory keeps its normal behavior: anonymous requests get 401 and unauthorized authenticated users get 403.",
+		},
 	},
 )
 
@@ -201,6 +211,7 @@ type RepositoryBaseParams struct {
 	Repositories                                  []string `hcl:"repositories" json:"repositories,omitempty"`
 	ArtifactoryRequestsCanRetrieveRemoteArtifacts bool     `hcl:"artifactory_requests_can_retrieve_remote_artifacts" json:"artifactoryRequestsCanRetrieveRemoteArtifacts"`
 	DefaultDeploymentRepo                         string   `hcl:"default_deployment_repo" json:"defaultDeploymentRepo,omitempty"`
+	HideUnauthorizedResources                     bool     `hcl:"hide_unauthorized_resources" json:"hideUnauthorizedResources"`
 }
 
 type RepositoryBaseParamsWithRetrievalCachePeriodSecs struct {
@@ -251,6 +262,12 @@ var baseSchema = map[string]*sdkv2_schema.Schema{
 		Optional:    true,
 		Description: "Default repository to deploy artifacts.",
 	},
+	"hide_unauthorized_resources": {
+		Type:        sdkv2_schema.TypeBool,
+		Optional:    true,
+		Default:     false,
+		Description: "When set to true, returns a 404 Not Found response instead of revealing that an unauthorized resource exists. When false (default), Artifactory keeps its normal behavior: anonymous requests get 401 and unauthorized authenticated users get 403.",
+	},
 }
 
 var BaseSchemaV1 = lo.Assign(
@@ -284,10 +301,11 @@ func UnpackBaseVirtRepo(s *sdkv2_schema.ResourceData, packageType string) Reposi
 		ExcludesPattern:     d.GetString("excludes_pattern", false),
 		RepoLayoutRef:       d.GetString("repo_layout_ref", false),
 		ArtifactoryRequestsCanRetrieveRemoteArtifacts: d.GetBool("artifactory_requests_can_retrieve_remote_artifacts", false),
-		Repositories:          d.GetList("repositories"),
-		Description:           d.GetString("description", false),
-		Notes:                 d.GetString("notes", false),
-		DefaultDeploymentRepo: repository.HandleResetWithNonExistentValue(d, "default_deployment_repo"),
+		Repositories:              d.GetList("repositories"),
+		Description:               d.GetString("description", false),
+		Notes:                     d.GetString("notes", false),
+		DefaultDeploymentRepo:     repository.HandleResetWithNonExistentValue(d, "default_deployment_repo"),
+		HideUnauthorizedResources: d.GetBool("hide_unauthorized_resources", false),
 	}
 }
 

--- a/pkg/artifactory/resource/repository/virtual/virtual_hide_unauthorized_resources_test.go
+++ b/pkg/artifactory/resource/repository/virtual/virtual_hide_unauthorized_resources_test.go
@@ -1,0 +1,105 @@
+// Copyright (c) JFrog Ltd. (2026)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package virtual_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository"
+	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/virtual"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVirtualSchema_HideUnauthorizedResources(t *testing.T) {
+	t.Parallel()
+
+	_, ok := virtual.BaseSchemaV1["hide_unauthorized_resources"]
+	assert.True(t, ok, "SDKv2 base schema must expose hide_unauthorized_resources")
+
+	_, ok = virtual.VirtualAttributes["hide_unauthorized_resources"]
+	assert.True(t, ok, "Framework virtual attributes must expose hide_unauthorized_resources")
+
+	mavenResource := virtual.ResourceArtifactoryVirtualJavaRepository("maven")
+	_, ok = mavenResource.Schema["hide_unauthorized_resources"]
+	assert.True(t, ok, "virtual maven repository schema must expose hide_unauthorized_resources")
+}
+
+func TestRepositoryBaseParams_HideUnauthorizedResourcesJSON(t *testing.T) {
+	t.Parallel()
+
+	params := virtual.RepositoryBaseParams{
+		Key:                       "maven-virt",
+		Rclass:                    virtual.Rclass,
+		PackageType:               "maven",
+		HideUnauthorizedResources: true,
+	}
+
+	raw, err := json.Marshal(params)
+	require.NoError(t, err)
+
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	assert.Equal(t, true, decoded["hideUnauthorizedResources"])
+
+	var roundTrip virtual.RepositoryBaseParams
+	require.NoError(t, json.Unmarshal(raw, &roundTrip))
+	assert.True(t, roundTrip.HideUnauthorizedResources)
+}
+
+func TestVirtualResourceModel_HideUnauthorizedResourcesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	model := virtual.VirtualResourceModel{
+		BaseResourceModel: repository.BaseResourceModel{
+			Key:                 types.StringValue("maven-virt"),
+			ProjectKey:          types.StringValue(""),
+			ProjectEnvironments: types.SetValueMust(types.StringType, []attr.Value{}),
+			Description:         types.StringValue(""),
+			Notes:               types.StringValue(""),
+			IncludesPattern:     types.StringValue("**/*"),
+			ExcludesPattern:     types.StringValue(""),
+		},
+		Repositories: types.ListValueMust(types.StringType, []attr.Value{}),
+		ArtifactoryRequestsCanRetrieveRemoteArtifacts: types.BoolValue(false),
+		DefaultDeploymentRepo:                         types.StringValue(""),
+		RepoLayoutRef:                                 types.StringValue("maven-2-default"),
+		HideUnauthorizedResources:                     types.BoolValue(true),
+	}
+
+	apiModel, diags := model.ToAPIModel(ctx, "maven")
+	require.False(t, diags.HasError(), diags.Errors())
+
+	virtualAPI, ok := apiModel.(virtual.VirtualAPIModel)
+	require.True(t, ok)
+	assert.True(t, virtualAPI.HideUnauthorizedResources)
+
+	raw, err := json.Marshal(virtualAPI)
+	require.NoError(t, err)
+	var decoded map[string]interface{}
+	require.NoError(t, json.Unmarshal(raw, &decoded))
+	assert.Equal(t, true, decoded["hideUnauthorizedResources"])
+
+	var fromAPI virtual.VirtualResourceModel
+	fromAPI.Repositories = types.ListNull(types.StringType)
+	diags = fromAPI.FromAPIModel(ctx, virtualAPI)
+	require.False(t, diags.HasError(), diags.Errors())
+	assert.True(t, fromAPI.HideUnauthorizedResources.ValueBool())
+}

--- a/sample.tf
+++ b/sample.tf
@@ -704,6 +704,7 @@ resource "artifactory_virtual_maven_repository" "foo" {
   excludes_pattern                         = "com/google/**"
   force_maven_authentication               = true
   pom_repository_references_cleanup_policy = "discard_active_reference"
+  hide_unauthorized_resources              = false
 }
 
 resource "artifactory_virtual_npm_repository" "foo-npm" {


### PR DESCRIPTION
resource/artifactory_virtual_*_repository: Add `hide_unauthorized_resources` attribute mapping to Artifactory's `hideUnauthorizedResources` setting, so virtual repositories can return 404 instead of 403 for unauthorized resource access. Issue: [#1279](https://github.com/jfrog/terraform-provider-artifactory/issues/1279)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `hide_unauthorized_resources` option to virtual repositories.
  - When enabled, unauthorized requests return **404 Not Found** instead of revealing resource existence with **403 Forbidden**.
  - Anonymous requests continue to return **401 Unauthorized**.
  - The option is disabled by default and supported across virtual repository types.
  - Configuration changes are preserved during updates and imports.

- **Documentation**
  - Added guidance describing configuration and authorization response behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->