### PR TITLE
chore: update CODEOWNERS with terraform provider maintainers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @srinivasgowda097
-* @vasukinjfrog
+* @vasukinjfrog @soumyas-dev @srinivasgowda097 @shahiinn @chukka @oumkale @vijayreddy1991


### PR DESCRIPTION
## Summary
- Update `CODEOWNERS` so all Terraform provider maintainers are requested on reviews
- Owners: `@vasukinjfrog` `@soumyas-dev` `@srinivasgowda097` `@shahiinn` `@chukka` `@oumkale` `@vijayreddy1991`
- Use a single `*` pattern with all owners listed (GitHub uses the last matching pattern, so one owner per line would keep only the last person)

## Test plan
- [ ] Confirm GitHub recognizes the file (`CODEOWNERS` at repo root)
- [ ] Confirm each listed user has write access so review requests succeed
- [ ] Open a small test PR (or check this PR) and verify all listed owners are requested

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository ownership assignments. No user-facing functionality or behavior has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->