### PR TITLE
Add primary_keypair_ref to federated Terraform Provider repositories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 12.11.16 (Sep 02, 2026).
+
+FEATURES:
+
+* resource/artifactory_federated_terraform_provider_repository, data-source/artifactory_federated_terraform_provider_repository: Add `primary_keypair_ref` so a GPG signing key can be attached to federated Terraform Provider repositories. Issue: [#1391](https://github.com/jfrog/terraform-provider-artifactory/issues/1391)
+
 ### 12.11.15 (Aug 31, 2026). Tested on Artifactory 7.161.20 with Terraform 1.16.0 and OpenTofu 1.12.3
 
 FEATURES:

--- a/docs/data-sources/federated_terraform_provider_repository.md
+++ b/docs/data-sources/federated_terraform_provider_repository.md
@@ -3,13 +3,40 @@ subcategory: "Federated Repositories"
 ---
 # Artifactory Federated Terraform Provider Repository Data Source
 
-Retrieves a federated terraform provider repository.
+Retrieves a federated Terraform Provider repository.
 
 ## Example Usage
 
 ```hcl
+resource "artifactory_keypair" "terraform-signing-key" {
+  pair_name   = "terraform-signing-key"
+  pair_type   = "GPG"
+  alias       = "terraform-provider-signing"
+  private_key = file("samples/gpg.priv")
+  public_key  = file("samples/gpg.pub")
+
+  lifecycle {
+    ignore_changes = [
+      private_key,
+      passphrase,
+    ]
+  }
+}
+
+resource "artifactory_federated_terraform_provider_repository" "federated-test-terraform_provider-repo" {
+  key                 = "federated-test-terraform-provider-repo"
+  primary_keypair_ref = artifactory_keypair.terraform-signing-key.pair_name
+
+  member {
+    url     = "http://tempurl.org/artifactory/federated-test-terraform-provider-repo"
+    enabled = true
+  }
+
+  depends_on = [artifactory_keypair.terraform-signing-key]
+}
+
 data "artifactory_federated_terraform_provider_repository" "federated-test-terraform_provider-repo" {
-  key = "federated-test-terraform-provider-repo"
+  key = artifactory_federated_terraform_provider_repository.federated-test-terraform_provider-repo.key
 }
 ```
 
@@ -20,6 +47,7 @@ data "artifactory_federated_terraform_provider_repository" "federated-test-terra
 ## Attribute Reference
 The following attributes are supported, along with the [list of attributes from the local Terraform Provider repository](local_terraform_provider_repository.md):
 
+* `primary_keypair_ref` - The primary GPG key to be used to sign packages.
 * `member` - The list of Federated members and must contain this repository URL (configured base URL
   `/artifactory/` + repo `key`). Note that each of the federated members will need to have a base URL set.
   Please follow the [instruction](https://www.jfrog.com/confluence/display/JFROG/Working+with+Federated+Repositories#WorkingwithFederatedRepositories-SettingUpaFederatedRepository)

--- a/docs/resources/federated_terraform_provider_repository.md
+++ b/docs/resources/federated_terraform_provider_repository.md
@@ -3,13 +3,33 @@ subcategory: "Federated Repositories"
 ---
 # Artifactory Federated Terraform Provider Repository Resource
 
-Creates a federated Generic repository.
+Creates a federated Terraform Provider repository.
+Official documentation can be found [here](https://www.jfrog.com/confluence/display/JFROG/Terraform+Repositories).
+
+The Terraform Registry protocol requires a configured GPG key pair. Use `primary_keypair_ref` to attach a signing key.
 
 ## Example Usage
 
 ```hcl
+resource "artifactory_keypair" "terraform-signing-key" {
+  pair_name   = "terraform-signing-key"
+  pair_type   = "GPG"
+  alias       = "terraform-provider-signing"
+  private_key = file("samples/gpg.priv")
+  public_key  = file("samples/gpg.pub")
+
+  lifecycle {
+    ignore_changes = [
+      private_key,
+      passphrase,
+    ]
+  }
+}
+
 resource "artifactory_federated_terraform_provider_repository" "terraform-federated-test-terraform_provider-repo" {
-  key       = "terraform-federated-test-terraform-provider-repo"
+  key                 = "terraform-federated-test-terraform-provider-repo"
+  primary_keypair_ref = artifactory_keypair.terraform-signing-key.pair_name
+
   member {
     url     = "http://tempurl.org/artifactory/terraform-federated-test-terraform_provider-repo"
     enabled = true
@@ -19,6 +39,8 @@ resource "artifactory_federated_terraform_provider_repository" "terraform-federa
     url     = "http://tempurl2.org/artifactory/terraform-federated-test-terraform_provider-repo-2"
     enabled = true
   }
+
+  depends_on = [artifactory_keypair.terraform-signing-key]
 }
 ```
 
@@ -27,6 +49,7 @@ resource "artifactory_federated_terraform_provider_repository" "terraform-federa
 The following attributes are supported, along with the [list of attributes from the local Terraform Provider repository](local_terraform_provider_repository.md):
 
 * `key` - (Required) the identity key of the repo.
+* `primary_keypair_ref` - (Optional) The primary GPG key to be used to sign packages. Default is empty.
 * `member` - (Required) The list of Federated members and must contain this repository URL (configured base URL
   `/artifactory/` + repo `key`). Note that each of the federated members will need to have a base URL set.
   Please follow the [instruction](https://www.jfrog.com/confluence/display/JFROG/Working+with+Federated+Repositories#WorkingwithFederatedRepositories-SettingUpaFederatedRepository)
@@ -38,6 +61,10 @@ The following attributes are supported, along with the [list of attributes from 
 * `cleanup_on_delete` - (Optional) Delete all federated members on `terraform destroy` if set to `true`. Default is `false`. This attribute is added to match Terrform logic, so all the resources, created by the provider, must be removed on cleanup. Artifactory's behavior for the federated repositories is different, all the federated repositories stay after the user deletes the initial federated repository. **Caution**: if set to `true` all the repositories in the federation will be deleted, including repositories on other Artifactory instances in the "Circle of trust". This operation can not be reversed.
 * `proxy` - (Optional) Proxy key from Artifactory Proxies settings. Default is empty field. Can't be set if `disable_proxy = true`.
 * `disable_proxy` - (Optional, Default: `false`) When set to `true`, the proxy is disabled, and not returned in the API response body. If there is a default proxy set for the Artifactory instance, it will be ignored, too.
+
+Artifactory REST API call Get Key Pair doesn't return keys `private_key` and `passphrase`, but consumes these keys in the POST call.
+
+The meta-argument `lifecycle` used here to make Provider ignore the changes for these two keys in the Terraform state.
 
 ## Import
 

--- a/examples/data-sources/artifactory_federated_terraform_provider_repository/data-source.tf
+++ b/examples/data-sources/artifactory_federated_terraform_provider_repository/data-source.tf
@@ -1,0 +1,3 @@
+data "artifactory_federated_terraform_provider_repository" "federated-test-terraform_provider-repo" {
+  key = "federated-test-terraform-provider-repo"
+}

--- a/examples/resources/artifactory_federated_terraform_provider_repository/import.sh
+++ b/examples/resources/artifactory_federated_terraform_provider_repository/import.sh
@@ -1,0 +1,1 @@
+terraform import artifactory_federated_terraform_provider_repository.terraform-federated-test-terraform-provider-repo terraform-federated-test-terraform-provider-repo

--- a/examples/resources/artifactory_federated_terraform_provider_repository/resource.tf
+++ b/examples/resources/artifactory_federated_terraform_provider_repository/resource.tf
@@ -1,0 +1,31 @@
+resource "artifactory_keypair" "terraform-signing-key" {
+  pair_name   = "terraform-signing-key"
+  pair_type   = "GPG"
+  alias       = "terraform-provider-signing"
+  private_key = file("samples/gpg.priv")
+  public_key  = file("samples/gpg.pub")
+
+  lifecycle {
+    ignore_changes = [
+      private_key,
+      passphrase,
+    ]
+  }
+}
+
+resource "artifactory_federated_terraform_provider_repository" "terraform-federated-test-terraform-provider-repo" {
+  key                 = "terraform-federated-test-terraform-provider-repo"
+  primary_keypair_ref = artifactory_keypair.terraform-signing-key.pair_name
+
+  member {
+    url     = "http://tempurl.org/artifactory/terraform-federated-test-terraform-provider-repo"
+    enabled = true
+  }
+
+  member {
+    url     = "http://tempurl2.org/artifactory/terraform-federated-test-terraform-provider-repo-2"
+    enabled = true
+  }
+
+  depends_on = [artifactory_keypair.terraform-signing-key]
+}

--- a/pkg/artifactory/datasource/repository/federated/datasource_artifactory_federated_repository_test.go
+++ b/pkg/artifactory/datasource/repository/federated/datasource_artifactory_federated_repository_test.go
@@ -1216,6 +1216,79 @@ func TestAccDataSourceFederatedTerraformRepositories(t *testing.T) {
 	}
 }
 
+func TestAccDataSourceFederatedTerraformProviderRepository_primaryKeyPairRef(t *testing.T) {
+	_, tempFqrn, name := testutil.MkNames("terraform-provider-federated", "artifactory_federated_terraform_provider_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", acctest.GetArtifactoryUrl(t), name)
+
+	federatedRepositoryBasic := util.ExecuteTemplate("keypair", `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "GPG"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+			lifecycle {
+				ignore_changes = [
+					private_key,
+					passphrase,
+				]
+			}
+		}
+		resource "artifactory_federated_terraform_provider_repository" "{{ .repo_name }}" {
+			key                 = "{{ .repo_name }}"
+			primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+
+			member {
+				url     = "{{ .memberUrl }}"
+				enabled = true
+			}
+
+			depends_on = [artifactory_keypair.{{ .kp_name }}]
+		}
+		data "artifactory_federated_terraform_provider_repository" "{{ .repo_name }}" {
+			key = artifactory_federated_terraform_provider_repository.{{ .repo_name }}.id
+		}
+	`, map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"memberUrl":   federatedMemberUrl,
+		"private_key": os.Getenv("JFROG_TEST_PGP_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_PGP_PUBLIC_KEY"),
+	})
+
+	fqrn := "data." + tempFqrn
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: federatedRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "terraform"),
+					resource.TestCheckResourceAttr(fqrn, "primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("federated", "terraform_provider")
+						return r
+					}()),
+				),
+			},
+		},
+	})
+}
+
 func TestAccDataSourceFederatedMissingRepository(t *testing.T) {
 	_, fqrn, name := testutil.MkNames("terraform-local", "data.artifactory_federated_terraform_provider_repository")
 	params := map[string]interface{}{

--- a/pkg/artifactory/datasource/repository/federated/datasource_artifactory_federated_terraform_repository.go
+++ b/pkg/artifactory/datasource/repository/federated/datasource_artifactory_federated_terraform_repository.go
@@ -35,17 +35,28 @@ func DataSourceArtifactoryFederatedTerraformRepository(registryType string) *sch
 		federatedSchemaV4,
 		resource_repository.RepoLayoutRefSDKv2Schema(federated.Rclass, packageType),
 	)
+	if registryType == "provider" {
+		terraformFederatedSchema = lo.Assign(
+			terraformFederatedSchema,
+			resource_repository.PrimaryKeyPairRefSDKv2,
+		)
+	}
 
 	var packTerraformMembers = func(repo interface{}, d *schema.ResourceData) error {
 		members := repo.(*federated.TerraformFederatedRepositoryParams).Members
 		return federated.PackMembers(members, d)
 	}
 
+	ignoreFields := []string{"member", "terraform_type"}
+	if registryType != "provider" {
+		ignoreFields = append(ignoreFields, "primary_keypair_ref")
+	}
+
 	pkr := packer.Compose(
 		packer.Universal(
 			predicate.All(
 				predicate.NoClass,
-				predicate.Ignore("member", "terraform_type"),
+				predicate.Ignore(ignoreFields...),
 			),
 		),
 		packTerraformMembers,

--- a/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_repository_test.go
+++ b/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_repository_test.go
@@ -1564,6 +1564,82 @@ func TestAccFederatedTerraformRepositories(t *testing.T) {
 	}
 }
 
+func TestAccFederatedTerraformProviderRepository_primaryKeyPairRef(t *testing.T) {
+	_, fqrn, name := testutil.MkNames("terraform-provider-federated", "artifactory_federated_terraform_provider_repository")
+	kpId, kpFqrn, kpName := testutil.MkNames("some-keypair", "artifactory_keypair")
+
+	federatedMemberUrl := fmt.Sprintf("%s/artifactory/%s", acctest.GetArtifactoryUrl(t), name)
+
+	federatedRepositoryBasic := util.ExecuteTemplate("keypair", `
+		resource "artifactory_keypair" "{{ .kp_name }}" {
+			pair_name  = "{{ .kp_name }}"
+			pair_type = "GPG"
+			alias = "foo-alias{{ .kp_id }}"
+			private_key = <<EOF
+{{ .private_key }}
+EOF
+			public_key = <<EOF
+{{ .public_key }}
+EOF
+			lifecycle {
+				ignore_changes = [
+					private_key,
+					passphrase,
+				]
+			}
+		}
+
+		resource "artifactory_federated_terraform_provider_repository" "{{ .repo_name }}" {
+			key                 = "{{ .repo_name }}"
+			primary_keypair_ref = artifactory_keypair.{{ .kp_name }}.pair_name
+
+			member {
+				url     = "{{ .memberUrl }}"
+				enabled = true
+			}
+
+			depends_on = [artifactory_keypair.{{ .kp_name }}]
+		}
+	`, map[string]interface{}{
+		"kp_id":       kpId,
+		"kp_name":     kpName,
+		"repo_name":   name,
+		"memberUrl":   federatedMemberUrl,
+		"private_key": os.Getenv("JFROG_TEST_PGP_PRIVATE_KEY"),
+		"public_key":  os.Getenv("JFROG_TEST_PGP_PUBLIC_KEY"),
+	})
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { acctest.PreCheck(t) },
+		ProtoV6ProviderFactories: acctest.ProtoV6MuxProviderFactories,
+		CheckDestroy: acctest.CompositeCheckDestroy(
+			acctest.VerifyDeleted(t, fqrn, "key", acctest.CheckRepo),
+			acctest.VerifyDeleted(t, kpFqrn, "", security.VerifyKeyPair),
+		),
+		Steps: []resource.TestStep{
+			{
+				Config: federatedRepositoryBasic,
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttr(fqrn, "key", name),
+					resource.TestCheckResourceAttr(fqrn, "package_type", "terraform"),
+					resource.TestCheckResourceAttr(fqrn, "primary_keypair_ref", kpName),
+					resource.TestCheckResourceAttr(fqrn, "repo_layout_ref", func() string {
+						r, _ := repository.GetDefaultRepoLayoutRef("federated", "terraform_provider")
+						return r
+					}()),
+				),
+			},
+			{
+				ResourceName:            fqrn,
+				ImportState:             true,
+				ImportStateVerify:       true,
+				ImportStateCheck:        validator.CheckImportState(name, "key"),
+				ImportStateVerifyIgnore: []string{"cleanup_on_delete"},
+			},
+		},
+	})
+}
+
 func TestAccFederatedReleasebundlesRepository(t *testing.T) {
 	if skip, reason := skipFederatedRepo(); skip {
 		t.Skip(reason)

--- a/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_terraform_repository.go
+++ b/pkg/artifactory/resource/repository/federated/resource_artifactory_federated_terraform_repository.go
@@ -20,6 +20,7 @@ import (
 	"github.com/jfrog/terraform-provider-artifactory/v12/pkg/artifactory/resource/repository/local"
 	"github.com/jfrog/terraform-provider-shared/packer"
 	"github.com/jfrog/terraform-provider-shared/predicate"
+	utilsdk "github.com/jfrog/terraform-provider-shared/util/sdk"
 	"github.com/samber/lo"
 )
 
@@ -27,6 +28,7 @@ type TerraformFederatedRepositoryParams struct {
 	local.RepositoryBaseParams
 	Members []Member `hcl:"member" json:"members"`
 	RepoParams
+	repository.PrimaryKeyPairRefParam
 }
 
 func unpackLocalTerraformRepository(data *schema.ResourceData, Rclass string, registryType string) local.RepositoryBaseParams {
@@ -38,18 +40,31 @@ func unpackLocalTerraformRepository(data *schema.ResourceData, Rclass string, re
 
 func ResourceArtifactoryFederatedTerraformRepository(registryType string) *schema.Resource {
 	packageType := "terraform_" + registryType
+	isProvider := registryType == "provider"
 
 	terraformFederatedSchema := lo.Assign(
 		local.GetTerraformSchemas(registryType)[local.CurrentSchemaVersion],
 		federatedSchemaV4,
 		repository.RepoLayoutRefSDKv2Schema(Rclass, packageType),
 	)
+	if isProvider {
+		terraformFederatedSchema = lo.Assign(
+			terraformFederatedSchema,
+			repository.PrimaryKeyPairRefSDKv2,
+		)
+	}
 
 	var unpackFederatedTerraformRepository = func(data *schema.ResourceData) (interface{}, string, error) {
+		d := &utilsdk.ResourceData{ResourceData: data}
 		repo := TerraformFederatedRepositoryParams{
 			RepositoryBaseParams: unpackLocalTerraformRepository(data, Rclass, registryType),
 			Members:              unpackMembers(data),
 			RepoParams:           unpackRepoParams(data),
+		}
+		if isProvider {
+			repo.PrimaryKeyPairRefParam = repository.PrimaryKeyPairRefParam{
+				PrimaryKeyPairRefSDKv2: d.GetString("primary_keypair_ref", false),
+			}
 		}
 		return repo, repo.Id(), nil
 	}
@@ -59,11 +74,16 @@ func ResourceArtifactoryFederatedTerraformRepository(registryType string) *schem
 		return PackMembers(members, d)
 	}
 
+	ignoreFields := []string{"member", "terraform_type"}
+	if !isProvider {
+		ignoreFields = append(ignoreFields, "primary_keypair_ref")
+	}
+
 	pkr := packer.Compose(
 		packer.Universal(
 			predicate.All(
 				predicate.NoClass,
-				predicate.Ignore("member", "terraform_type"),
+				predicate.Ignore(ignoreFields...),
 			),
 		),
 		packTerraformMembers,

--- a/sample.tf
+++ b/sample.tf
@@ -846,6 +846,23 @@ resource "artifactory_federated_generic_repository" "generic-federated-1" {
   }
 }
 
+resource "artifactory_federated_terraform_provider_repository" "terraform-provider-federated" {
+  key                 = "terraform-provider-federated"
+  primary_keypair_ref = artifactory_keypair.some-keypairGPG1.pair_name
+  description         = "Repo created by Terraform Provider Artifactory"
+
+  member {
+    url     = "http://artifactory-2:8081/artifactory/terraform-provider-federated"
+    enabled = true
+  }
+
+  depends_on = [artifactory_keypair.some-keypairGPG1]
+}
+
+data "artifactory_federated_terraform_provider_repository" "terraform-provider-federated" {
+  key = artifactory_federated_terraform_provider_repository.terraform-provider-federated.key
+}
+
 resource "artifactory_remote_vcs_repository" "gitlab_vcs" {
   key         = "my-gitlab-vcs-remote"
   url         = "https://gitlab.com/your-group/your-repo"


### PR DESCRIPTION
## Summary
- Add optional `primary_keypair_ref` to `artifactory_federated_terraform_provider_repository` (and its data source) so a GPG signing key can be set via Terraform.
- Terraform Registry protocol requires a signing key; Artifactory already accepts `primaryKeyPairRef` on Terraform Provider repos. This was missing from the federated resource.
- `artifactory_local_terraform_provider_repository` is intentionally unchanged. Local remains the gap in [#1391](https://github.com/jfrog/terraform-provider-artifactory/issues/1391).

## Test plan
- [x] `TestAccFederatedTerraformProviderRepository_primaryKeyPairRef`
- [x] `TestAccDataSourceFederatedTerraformProviderRepository_primaryKeyPairRef`
- [ ] Confirm `artifactory_local_terraform_provider_repository` still rejects `primary_keypair_ref`
- [ ] `terraform apply` federated example, then GET `/artifactory/api/repositories/{key}` and verify `primaryKeyPairRef`


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `primary_keypair_ref` support for federated Terraform Provider repositories.
  * GPG signing keys can now be attached to these repositories and retrieved through the corresponding data source.

* **Documentation**
  * Updated resource and data source guides with signing-key configuration examples.
  * Added Terraform examples for creating, importing, and reading federated Terraform Provider repositories.

* **Bug Fixes**
  * Ensured the signing-key reference is handled correctly for Provider repositories while remaining unavailable for other registry types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->